### PR TITLE
Mac: Improve fonts metrics and line drawing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+DerivedData

--- a/SwiftTerm.xcodeproj/project.pbxproj
+++ b/SwiftTerm.xcodeproj/project.pbxproj
@@ -98,7 +98,9 @@
 				49BD1A5B224207B5005A2252 /* Products */,
 				49AE019F2410AB0A0051E902 /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		49BD1A5B224207B5005A2252 /* Products */ = {
 			isa = PBXGroup;

--- a/SwiftTerm/Sources/SwiftTerm/Buffer.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Buffer.swift
@@ -131,7 +131,7 @@ class Buffer {
         cols = terminal.cols
         rows = terminal.rows
         
-        let len = hasScrollback ? (terminal.options.scrollback ?? 0) + rows : rows
+        let len = hasScrollback ? (terminal.options.scrollback) + rows : rows
         _lines = CircularList<BufferLine> (maxLength: len)
         _lines.makeEmpty = makeEmptyLine
         setupTabStops ()
@@ -140,7 +140,7 @@ class Buffer {
     public func getCorrectBufferLength (_ rows: Int) -> Int
     {
         if hasScrollback {
-            let correct = rows + (terminal.options.scrollback ?? 0)
+            let correct = rows + (terminal.options.scrollback)
             return correct > Int32.max ? Int (Int32.max) : correct
         } else {
             return rows

--- a/SwiftTerm/Sources/SwiftTerm/CircularList.swift
+++ b/SwiftTerm/Sources/SwiftTerm/CircularList.swift
@@ -26,7 +26,7 @@ class CircularList<T> {
             if newValue > array.count {
                 let start = array.count
                 for _ in start..<newValue {
-                    array.append(nil)
+                    array.append (nil)
                 }
             }
             _count = newValue

--- a/SwiftTerm/Sources/SwiftTerm/CircularList.swift
+++ b/SwiftTerm/Sources/SwiftTerm/CircularList.swift
@@ -26,14 +26,14 @@ class CircularList<T> {
             if newValue > array.count {
                 let start = array.count
                 for _ in start..<newValue {
-                    array.append (nil)
+                    array.append(nil)
                 }
             }
             _count = newValue
         }
     }
     
-    var _count: Int
+    private var _count: Int
     var maxLength: Int {
         didSet {
             if maxLength != oldValue {
@@ -82,7 +82,7 @@ class CircularList<T> {
         }
         set (newValue){
             array [getCyclicIndex(index)] = newValue
-        }
+      }
     }
     
     func push (_ value: T)

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
@@ -42,29 +42,29 @@ class SelectionView: NSView {
         abort()
     }
 
-    func notifyScrolled(source terminal: Terminal)
+    func notifyScrolled (source terminal: Terminal)
     {
         update(with: terminal)
     }
     
-    func update(with terminal: Terminal)
+    func update (with terminal: Terminal)
     {
         updateMask(with: terminal)
     }
     
-    func updateMask(with terminal: Terminal)
+    func updateMask (with terminal: Terminal)
     {
         // remove the prior mask
         maskLayer.path = nil
         
         maskLayer.frame = bounds
-        let path = CGMutablePath()
+        let path = CGMutablePath ()
         guard let terminal = terminalView.terminal else {
           return
         }
         var start, end: Position
         
-        if Position.compare(selection.start, selection.end) == .after {
+        if Position.compare (selection.start, selection.end) == .after {
             start = selection.end
             end = selection.start
         } else {
@@ -85,7 +85,7 @@ class SelectionView: NSView {
             col = 0
         }
         
-        maskPartialRow(path: path, row: screenRowStart, colStart: start.col, colEnd: col, terminal: terminal)
+        maskPartialRow (path: path, row: screenRowStart, colStart: start.col, colEnd: col, terminal: terminal)
 
         if screenRowStart == screenRowEnd {
             // we're done, only one row to mask
@@ -101,16 +101,16 @@ class SelectionView: NSView {
                 col = terminal.cols
             }
         }
-        maskPartialRow(path: path, row: screenRowEnd, colStart: col, colEnd: end.col, terminal: terminal)
+        maskPartialRow (path: path, row: screenRowEnd, colStart: col, colEnd: end.col, terminal: terminal)
         
         // now mask any full rows in between
         let fullRowCount = screenRowEnd - screenRowStart
         if fullRowCount > 1 {
             // Mask full rows up to the last row
-            maskFullRows(path: path, rowStart: screenRowStart + 1, rowCount: fullRowCount-1)
+            maskFullRows (path: path, rowStart: screenRowStart + 1, rowCount: fullRowCount-1)
         } else if fullRowCount < -1 {
             // Mask full rows up to the last row
-            maskFullRows(path: path, rowStart: screenRowStart - 0, rowCount: fullRowCount+1)
+            maskFullRows (path: path, rowStart: screenRowStart - 0, rowCount: fullRowCount+1)
         }
         
         maskLayer.path = path
@@ -118,18 +118,18 @@ class SelectionView: NSView {
     
     func maskFullRows(path: CGMutablePath, rowStart: Int, rowCount: Int)
     {
-        let startY = frame.height  - (CGFloat(rowStart + rowCount) * defaultLineHeight)
+        let startY = frame.height  - (CGFloat (rowStart + rowCount) * defaultLineHeight)
         let pathRect = CGRect (x: 0, y: startY, width: frame.width, height: defaultLineHeight * CGFloat (rowCount))
 
-        path.addRect(pathRect)
+        path.addRect (pathRect)
     }
     
-  func maskPartialRow(path: CGMutablePath, row: Int, colStart: Int, colEnd: Int, terminal: Terminal)
+    func maskPartialRow(path: CGMutablePath, row: Int, colStart: Int, colEnd: Int, terminal: Terminal)
     {
         let startY = frame.height - (CGFloat(row + 1) * defaultLineHeight)
         var pathRect: CGRect
-        let startOffset = self.terminalView.characterOffset(atRow: row + terminal.buffer.yDisp, col: colStart)
-        let endOffset = self.terminalView.characterOffset(atRow: row + terminal.buffer.yDisp, col: colEnd)
+        let startOffset = self.terminalView.characterOffset (atRow: row + terminal.buffer.yDisp, col: colStart)
+        let endOffset = self.terminalView.characterOffset (atRow: row + terminal.buffer.yDisp, col: colEnd)
 
         let width: CGFloat
         if colEnd == terminal.cols {
@@ -140,16 +140,17 @@ class SelectionView: NSView {
 
         if (colStart < colEnd) {
             // start before the beginning of the start column and end just before the start of the next column
-            pathRect = CGRect(x: startOffset, y: startY, width: width, height: defaultLineHeight)
+            pathRect = CGRect (x: startOffset, y: startY, width: width, height: defaultLineHeight)
         } else {
             // start before the beginning of the _end_ column and end just before the start of the _start_ column
             // note this creates a rect with negative width
-            pathRect = CGRect(x: startOffset, y: startY, width: width, height: defaultLineHeight)
+            pathRect = CGRect (x: startOffset, y: startY, width: width, height: defaultLineHeight)
         }
         path.addRect(pathRect)
     }
     
-    override func hitTest(_ point: NSPoint) -> NSView? {
+    override func hitTest (_ point: NSPoint) -> NSView? 
+    {
         // we do not want to steal hits, let the terminal view take them
         return nil
     }

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
@@ -25,7 +25,7 @@ class SelectionView: NSView {
       terminalView.lineHeight
     }
     
-    public init (terminalView: TerminalView, frame: CGRect)
+    public init(terminalView: TerminalView, frame: CGRect)
     {
         self.terminalView = terminalView
         self.maskLayer = CAShapeLayer()
@@ -42,17 +42,17 @@ class SelectionView: NSView {
         abort()
     }
 
-    func notifyScrolled ()
+    func notifyScrolled(source terminal: Terminal)
     {
-        update()
+        update(with: terminal)
     }
     
-    func update()
+    func update(with terminal: Terminal)
     {
-        updateMask()
+        updateMask(with: terminal)
     }
     
-    func updateMask()
+    func updateMask(with terminal: Terminal)
     {
         // remove the prior mask
         maskLayer.path = nil

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
@@ -21,8 +21,8 @@ class SelectionView: NSView {
     private var selection: SelectionService {
       terminalView.selection
     }
-    private var lineHeight: CGFloat {
-      terminalView.lineHeight
+    private var defaultLineHeight: CGFloat {
+      terminalView.defaultLineHeight
     }
     
     public init(terminalView: TerminalView, frame: CGRect)
@@ -42,7 +42,7 @@ class SelectionView: NSView {
         abort()
     }
 
-  func notifyScrolled(source terminal: Terminal)
+    func notifyScrolled(source terminal: Terminal)
     {
         update(with: terminal)
     }
@@ -118,15 +118,15 @@ class SelectionView: NSView {
     
     func maskFullRows(path: CGMutablePath, rowStart: Int, rowCount: Int)
     {
-        let startY = frame.height  - (CGFloat(rowStart + rowCount) * lineHeight)
-        let pathRect = CGRect (x: 0, y: startY, width: frame.width, height: lineHeight * CGFloat (rowCount))
+        let startY = frame.height  - (CGFloat(rowStart + rowCount) * defaultLineHeight)
+        let pathRect = CGRect (x: 0, y: startY, width: frame.width, height: defaultLineHeight * CGFloat (rowCount))
 
         path.addRect(pathRect)
     }
     
   func maskPartialRow(path: CGMutablePath, row: Int, colStart: Int, colEnd: Int, terminal: Terminal)
     {
-        let startY = frame.height - (CGFloat(row + 1) * lineHeight)
+        let startY = frame.height - (CGFloat(row + 1) * defaultLineHeight)
         var pathRect: CGRect
         let startOffset = self.terminalView.characterOffset(atRow: row + terminal.buffer.yDisp, col: colStart)
         let endOffset = self.terminalView.characterOffset(atRow: row + terminal.buffer.yDisp, col: colEnd)
@@ -140,11 +140,11 @@ class SelectionView: NSView {
 
         if (colStart < colEnd) {
             // start before the beginning of the start column and end just before the start of the next column
-            pathRect = CGRect(x: startOffset, y: startY, width: width, height: lineHeight)
+            pathRect = CGRect(x: startOffset, y: startY, width: width, height: defaultLineHeight)
         } else {
             // start before the beginning of the _end_ column and end just before the start of the _start_ column
             // note this creates a rect with negative width
-            pathRect = CGRect(x: startOffset, y: startY, width: width, height: lineHeight)
+            pathRect = CGRect(x: startOffset, y: startY, width: width, height: defaultLineHeight)
         }
         path.addRect(pathRect)
     }

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
@@ -42,7 +42,7 @@ class SelectionView: NSView {
         abort()
     }
 
-    func notifyScrolled(source terminal: Terminal)
+  func notifyScrolled(source terminal: Terminal)
     {
         update(with: terminal)
     }

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
@@ -113,8 +113,7 @@ class SelectionView: NSView {
     
     func maskFullRows (path: CGMutablePath, rowStart: Int, rowCount: Int)
     {
-        let cursorYOffset: CGFloat = 4
-        let startY = frame.height  - (CGFloat (rowStart + rowCount) * cellDim.height - cellDim.delta - cursorYOffset)
+        let startY = frame.height  - (CGFloat (rowStart + rowCount) * cellDim.height)
         let pathRect = CGRect (x: 0, y: startY, width: frame.width, height: cellDim.height * CGFloat (rowCount))
 
         path.addRect (pathRect)
@@ -125,9 +124,8 @@ class SelectionView: NSView {
         // -2 to get the top of the selection to fit over the top of the text properly
         // and to align with the cursor
         let cursorXPadding: CGFloat = 1
-        let cursorYOffset: CGFloat = 4
-        let startY = frame.height - cellDim.height - (CGFloat (row) * cellDim.height - cellDim.delta - cursorYOffset)
-        let startX = CGFloat (colStart) * cellDim.width
+        let startY = frame.height - (CGFloat(row + 1) * cellDim.height)
+        let startX = CGFloat(colStart) * cellDim.width
         var pathRect: CGRect
         
         if colStart == colEnd {

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -82,7 +82,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
       
         // Calculation assume that all glyphs in the font have the same advancement.
         // Get the ascent + descent + leading from the font, already scaled for the font's size
-        self.defaultLineHeight = CTFontGetAscent(font.normal) + CTFontGetDescent(font.normal) + CTFontGetLeading(font.normal);
+        self.defaultLineHeight = CTFontGetAscent (font.normal) + CTFontGetDescent (font.normal) + CTFontGetLeading (font.normal)
         let options = TerminalOptions(cols: Int(rect.width / font.normal.maximumAdvancement.width),
                                       rows: Int(rect.height / defaultLineHeight))
 
@@ -172,7 +172,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
      */
     public func getOptimalFrameSize () -> NSRect
     {
-      return NSRect (x: 0, y: 0, width: font.normal.maximumAdvancement.width * CGFloat(terminal.cols), height: defaultLineHeight * CGFloat(terminal.rows))
+        return NSRect (x: 0, y: 0, width: font.normal.maximumAdvancement.width * CGFloat(terminal.cols), height: defaultLineHeight * CGFloat(terminal.rows))
     }
     
     public func scrolled(source terminal: Terminal, yDisp: Int) {
@@ -337,8 +337,8 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         var bg = attribute.bg
         var fg = attribute.fg
         
-        if flags.contains(.inverse) {
-            swap(&bg, &fg)
+        if flags.contains (.inverse) {
+            swap (&bg, &fg)
             
             if fg == .defaultColor {
                 fg = .defaultInvertedColor
@@ -348,39 +348,39 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
             }
         }
         
-        if let result = attributes[attribute] {
+        if let result = attributes [attribute] {
             return result
         }
         
         var font: NSFont
-        if flags.contains(.bold){
+        if flags.contains (.bold){
             if flags.contains (.italic) {
                 font = self.font.boldItalic
             } else {
                 font = self.font.bold
             }
-        } else if flags.contains(.italic) {
+        } else if flags.contains (.italic) {
             font = self.font.italic
         } else {
             font = self.font.normal
         }
         
-        let fgColor = mapColor(color: fg, isFg: true)
+        let fgColor = mapColor (color: fg, isFg: true)
         var nsattr: [NSAttributedString.Key:Any] = [
             .font: font,
             .foregroundColor: fgColor,
             .fullBackgroundColor: mapColor(color: bg, isFg: false)
         ]
         if flags.contains (.underline) {
-            nsattr[.underlineColor] = fgColor
-            nsattr[.underlineStyle] = NSUnderlineStyle.single.rawValue
+            nsattr [.underlineColor] = fgColor
+            nsattr [.underlineStyle] = NSUnderlineStyle.single.rawValue
         }
         if flags.contains (.crossedOut) {
-            nsattr[.strikethroughColor] = fgColor
-            nsattr[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+            nsattr [.strikethroughColor] = fgColor
+            nsattr [.strikethroughStyle] = NSUnderlineStyle.single.rawValue
         }
 
-        attributes[attribute] = nsattr
+        attributes [attribute] = nsattr
         return nsattr
     }
     
@@ -402,14 +402,14 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
                 attr = ch.attribute
             } else {
                 if attr != ch.attribute {
-                    res.append(NSAttributedString(string: str, attributes: getAttributes(attr)))
+                    res.append (NSAttributedString (string: str, attributes: getAttributes(attr)))
                     str = ""
                     attr = ch.attribute
                 }
             }
-            str.append(ch.code == 0 ? " " : ch.getCharacter())
+            str.append(ch.code == 0 ? " " : ch.getCharacter ())
         }
-        res.append(NSAttributedString(string: str, attributes: getAttributes(attr)))
+        res.append (NSAttributedString (string: str, attributes: getAttributes (attr)))
         return res
     }
     
@@ -430,7 +430,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         
         let cols = terminal.cols
         for row in 0..<rows {
-            attrStrBuffer[row] = buildAttributedString(line: terminal.buffer.lines [row], cols: cols, prefix: "")
+            attrStrBuffer [row] = buildAttributedString (line: terminal.buffer.lines [row], cols: cols, prefix: "")
         }
         attrStrBuffer.count = rows
     }
@@ -438,14 +438,14 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
     func makeEmptyLine (_ index: Int) -> NSAttributedString
     {
         let line = terminal.buffer.lines [index]
-        return buildAttributedString(line: line, cols: terminal.cols, prefix: "")
+        return buildAttributedString (line: line, cols: terminal.cols, prefix: "")
     }
     
     func updateDisplay (notifyAccessibility: Bool)
     {
         updateCursorPosition ()
 
-         guard let (rowStart, rowEnd) = terminal.getUpdateRange() else {
+         guard let (rowStart, rowEnd) = terminal.getUpdateRange () else {
             return
         }
         
@@ -457,16 +457,16 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         for row in rowStart...rowEnd {
             let line = terminal.buffer.lines [row + tb.yDisp]
             
-            attrStrBuffer[row + tb.yDisp] = buildAttributedString(line: line, cols: cols, prefix: "")
+            attrStrBuffer [row + tb.yDisp] = buildAttributedString (line: line, cols: cols, prefix: "")
         }
         
         //print ("Dirty is \(rowStart) to \(rowEnd)")
         // BROKEN:
         let baseLine = frame.height
-        let region = CGRect(x: 0,
-                            y: baseLine - (defaultLineHeight + CGFloat(rowEnd) * defaultLineHeight),
-                            width: frame.width,
-                            height: CGFloat(rowEnd-rowStart + 1) * defaultLineHeight)
+        let region = CGRect (x: 0,
+                             y: baseLine - (defaultLineHeight + CGFloat(rowEnd) * defaultLineHeight),
+                             width: frame.width,
+                             height: CGFloat(rowEnd-rowStart + 1) * defaultLineHeight)
         
         //print ("Region: \(region)")
         setNeedsDisplay(region)
@@ -475,29 +475,29 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         
         if (notifyAccessibility) {
             accessibility.invalidate ()
-            NSAccessibility.post(element: self, notification: .valueChanged)
-            NSAccessibility.post(element: self, notification: .selectedTextChanged)
+            NSAccessibility.post (element: self, notification: .valueChanged)
+            NSAccessibility.post (element: self, notification: .selectedTextChanged)
         }
     }
 
     private func ctline(forRow row: Int) -> CTLine {
-      let attributedStringLine = attrStrBuffer[row]
-      let ctline = CTLineCreateWithAttributedString(attributedStringLine)
+      let attributedStringLine = attrStrBuffer [row]
+      let ctline = CTLineCreateWithAttributedString (attributedStringLine)
       return ctline
     }
 
-    func characterOffset(atRow row: Int, col: Int) -> CGFloat {
-      let ctline = self.ctline(forRow: row)
-      return CTLineGetOffsetForStringIndex(ctline, col, nil)
+    func characterOffset (atRow row: Int, col: Int) -> CGFloat {
+      let ctline = self.ctline (forRow: row)
+      return CTLineGetOffsetForStringIndex (ctline, col, nil)
     }
     
     // TODO: Clip here
-    override public func draw(_ dirtyRect: NSRect) {
+    override public func draw (_ dirtyRect: NSRect) {
         // it doesn't matter. Our attributed string has color set anyway
         defFgColor.set()
 
         guard let context = NSGraphicsContext.current?.cgContext else {
-          return
+            return
         }
 
         // draw background
@@ -511,122 +511,121 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         // lines to draw
         // TODO: for the performance reasons, it's better to create CTLine when attrStrBuffer is updated
         let lines: [CTLine] = attrStrBuffer.array[terminal.buffer.yDisp...].compactMap({
-          guard let value = $0 else {
-            return nil
-          }
-          return CTLineCreateWithAttributedString(value)
+            guard let value = $0 else {
+                return nil
+            }
+            return CTLineCreateWithAttributedString(value)
         })
 
         // draw lines
         var prevY: CGFloat = 0
         for line in lines {
-          var lineAscent: CGFloat = 0
-          var lineDescent: CGFloat = 0
-          var lineLeading: CGFloat = 0
-          _ = CTLineGetTypographicBounds(line, &lineAscent, &lineDescent, &lineLeading)
-          let currentLineHeight = lineAscent + lineDescent + lineLeading
-          let lineOrigin = CGPoint(x: 0, y: frame.height - (currentLineHeight + prevY))
+            var lineAscent: CGFloat = 0
+            var lineDescent: CGFloat = 0
+            var lineLeading: CGFloat = 0
+            _ = CTLineGetTypographicBounds (line, &lineAscent, &lineDescent, &lineLeading)
+            let currentLineHeight = lineAscent + lineDescent + lineLeading
+            let lineOrigin = CGPoint (x: 0, y: frame.height - (currentLineHeight + prevY))
 
-          // Draw line manually, so we can run custom routine for background color
-          for glyphRun in CTLineGetGlyphRuns(line) as? [CTRun] ?? [] {
-            let runAttributes = CTRunGetAttributes(glyphRun) as? [NSAttributedString.Key: Any] ?? [:]
+            // Draw line manually, so we can run custom routine for background color
+            for glyphRun in CTLineGetGlyphRuns (line) as? [CTRun] ?? [] {
+                let runAttributes = CTRunGetAttributes(glyphRun) as? [NSAttributedString.Key: Any] ?? [:]
 
-            var runAscent: CGFloat = 0
-            var runDescent: CGFloat = 0
-            var runLeading: CGFloat = 0
-            let runWidth = CTRunGetTypographicBounds(glyphRun, CFRange(), &runAscent, &runDescent, &runLeading)
+                var runAscent: CGFloat = 0
+                var runDescent: CGFloat = 0
+                var runLeading: CGFloat = 0
+                let runWidth = CTRunGetTypographicBounds (glyphRun, CFRange (), &runAscent, &runDescent, &runLeading)
 
-            // Default to font.normal
-            var runFont = font.normal
-            if runAttributes.keys.contains(.font) {
-              runFont = runAttributes[.font] as! NSFont
-            }
-
-            // Get glyphs positions
-            var glyphsPositions = [CGPoint](repeating: .zero, count: CTRunGetGlyphCount(glyphRun))
-            CTRunGetPositions(glyphRun, CFRange(), &glyphsPositions)
-
-            // Draw background.
-            // Background color fill the entire height of the line.
-            if runAttributes.keys.contains(.fullBackgroundColor) {
-              let backgroundColor = runAttributes[.fullBackgroundColor] as! NSColor
-
-              var transform = CGAffineTransform(translationX: glyphsPositions[0].x, y: 0)
-              let path = CGPath(rect: CGRect(origin: lineOrigin, size: CGSize(width: CGFloat(runWidth), height: currentLineHeight)), transform: &transform)
-
-              context.saveGState()
-
-              context.setShouldAntialias(false)
-              context.setLineCap(.square)
-              context.setLineWidth(0)
-              context.setFillColor(backgroundColor.cgColor)
-              context.setStrokeColor(backgroundColor.cgColor)
-              context.addPath(path)
-              context.drawPath(using: .fill)
-
-              context.restoreGState()
-            }
-
-            // Draw glyphs
-            // Not really needed, use CTLineDraw instead
-            #if false
-              // Adjust positions for text
-              let baseLineAdj = runFont.descender + runFont.leading
-              glyphsPositions = glyphsPositions.map({ CGPoint(x: $0.x, y: lineOrigin.y + baseLineAdj) })
-
-              // Set foreground color
-              if runAttributes.keys.contains(.foregroundColor) {
-                let color = runAttributes[.foregroundColor] as! NSColor
-                context.setFillColor(color.cgColor)
-              }
-
-              if runAttributes.keys.contains(.underlineColor) {
-                let color = runAttributes[.underlineColor] as! NSColor
-                context.setFillColor(color.cgColor)
-              }
-
-              if runAttributes.keys.contains(.strikethroughColor) {
-                let color = runAttributes[.strikethroughColor] as! NSColor
-                context.setFillColor(color.cgColor)
-              }
-
-              var glyphs = [CGGlyph](repeating: .zero, count: CTRunGetGlyphCount(glyphRun))
-              CTRunGetGlyphs(glyphRun, CFRange(), &glyphs)
-
-              // TODO: disable antialiasing for non-letters
-              //
-              for (i, glyph) in glyphs.enumerated() {
-                var transform = CGAffineTransform(translationX: glyphsPositions[i].x, y: lineOrigin.y - baseLineAdj)
-                if let path = CTFontCreatePathForGlyph(runFont, glyph, &transform) {
-                  context.addPath(path)
-                  context.drawPath(using: .fill)
+                // Default to font.normal
+                var runFont = font.normal
+                if runAttributes.keys.contains(.font) {
+                    runFont = runAttributes[.font] as! NSFont
                 }
-              }
-            #endif
-          }
 
+                // Get glyphs positions
+                var glyphsPositions = [CGPoint](repeating: .zero, count: CTRunGetGlyphCount (glyphRun))
+                CTRunGetPositions(glyphRun, CFRange(), &glyphsPositions)
 
-          // The code above is CTLineDraw() in disguise
-          let baseLineAdj = font.normal.descender + font.normal.leading
-          context.textPosition = CGPoint(x: 0, y: lineOrigin.y - baseLineAdj)
-          CTLineDraw(line, context)
+                // Draw background.
+                // Background color fill the entire height of the line.
+                if runAttributes.keys.contains(.fullBackgroundColor) {
+                    let backgroundColor = runAttributes[.fullBackgroundColor] as! NSColor
 
-          prevY += currentLineHeight
+                    var transform = CGAffineTransform (translationX: glyphsPositions[0].x, y: 0)
+                    let path = CGPath (rect: CGRect (origin: lineOrigin, size: CGSize (width: CGFloat (runWidth), height: currentLineHeight)), transform: &transform)
+
+                    context.saveGState ()
+
+                    context.setShouldAntialias (false)
+                    context.setLineCap (.square)
+                    context.setLineWidth(0)
+                    context.setFillColor(backgroundColor.cgColor)
+                    context.setStrokeColor(backgroundColor.cgColor)
+                    context.addPath(path)
+                    context.drawPath(using: .fill)
+
+                    context.restoreGState()
+                }
+
+                // Draw glyphs
+                // Not really needed, use CTLineDraw instead
+                #if false
+                // Adjust positions for text
+                let baseLineAdj = runFont.descender + runFont.leading
+                glyphsPositions = glyphsPositions.map({ CGPoint(x: $0.x, y: lineOrigin.y + baseLineAdj) })
+
+                // Set foreground color
+                if runAttributes.keys.contains(.foregroundColor) {
+                    let color = runAttributes[.foregroundColor] as! NSColor
+                    context.setFillColor(color.cgColor)
+                }
+
+                if runAttributes.keys.contains(.underlineColor) {
+                    let color = runAttributes[.underlineColor] as! NSColor
+                    context.setFillColor(color.cgColor)
+                }
+
+                if runAttributes.keys.contains(.strikethroughColor) {
+                    let color = runAttributes[.strikethroughColor] as! NSColor
+                    context.setFillColor(color.cgColor)
+                }
+
+                var glyphs = [CGGlyph](repeating: .zero, count: CTRunGetGlyphCount(glyphRun))
+                CTRunGetGlyphs(glyphRun, CFRange(), &glyphs)
+
+                // TODO: disable antialiasing for non-letters
+                //
+                for (i, glyph) in glyphs.enumerated() {
+                    var transform = CGAffineTransform(translationX: glyphsPositions[i].x, y: lineOrigin.y - baseLineAdj)
+                    if let path = CTFontCreatePathForGlyph(runFont, glyph, &transform) {
+                        context.addPath(path)
+                        context.drawPath(using: .fill)
+                    }
+                }
+                #endif
+            }
+
+            // The code above is CTLineDraw() in disguise
+            let baseLineAdj = font.normal.descender + font.normal.leading
+            context.textPosition = CGPoint (x: 0, y: lineOrigin.y - baseLineAdj)
+            CTLineDraw (line, context)
+
+            prevY += currentLineHeight
         }
 
-        context.restoreGState()
+        context.restoreGState ()
     }
     
     func updateCursorPosition ()
     {
-        caretView.frame.origin = getCaretPos(terminal.buffer.x, terminal.buffer.y)
+        caretView.frame.origin = getCaretPos (terminal.buffer.x, terminal.buffer.y)
     }
 
     func getCaretPos(_ col: Int, _ row: Int) -> CGPoint
     {
-        let x = self.characterOffset(atRow: row, col: col)
-        let y = frame.height - (defaultLineHeight + (CGFloat(row) * defaultLineHeight))
-        return CGPoint(x: x, y: y)
+        let x = self.characterOffset (atRow: row, col: col)
+        let y = frame.height - (defaultLineHeight + (CGFloat (row) * defaultLineHeight))
+        return CGPoint (x: x, y: y)
     }
 
     // Does not use a default argument and merge, because it is called back
@@ -689,8 +688,8 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         set(newValue) {
             super.frame = newValue
 
-            let newRows = Int(newValue.height / defaultLineHeight)
-            let newCols = Int(newValue.width / font.normal.maximumAdvancement.width)
+            let newRows = Int (newValue.height / defaultLineHeight)
+            let newCols = Int (newValue.width / font.normal.maximumAdvancement.width)
 
             if newCols != terminal.cols || newRows != terminal.rows {
                 terminal.resize (cols: newCols, rows: newRows)
@@ -700,13 +699,13 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
             // make the selection view the entire visible portion of the view
             // we will mask the selected text that is visible to the user
             selectionView.frame = bounds
-            scroller.frame = getScrollerFrame(frame)
+            scroller.frame = getScrollerFrame (frame)
             updateCursorPosition ()
             
             accessibility.invalidate ()
             search.invalidate ()
 
-            delegate?.sizeChanged(source: self, newCols: newCols, newRows: newRows)
+            delegate?.sizeChanged (source: self, newCols: newCols, newRows: newRows)
             
         }
     }
@@ -717,7 +716,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
     public func resize (cols: Int, rows: Int)
     {
         terminal.resize (cols: cols, rows: rows)
-        sizeChanged(source: terminal)
+        sizeChanged (source: terminal)
         terminal.reset()
     }
     
@@ -725,9 +724,10 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
      * Sends the specified slice of byte arrays to the program running under the terminal emulator
      * - Parameter data: the slice of an array to send to the client
      */
-    public func send(data: ArraySlice<UInt8>) {
+    public func send(data: ArraySlice<UInt8>) 
+    {
         ensureCaretIsVisible ()
-        delegate?.send(source: self, data: data)
+        delegate?.send (source: self, data: data)
     }
     
     /**
@@ -1030,7 +1030,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
             return r
         }
         
-      return .zero
+        return .zero
     }
     
     // NSTextInputClient protocol implementation
@@ -1069,7 +1069,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
     }
     
     public func selectionChanged(source: Terminal) {
-      selectionView.update(with: source)
+        selectionView.update(with: source)
     }
 
     func cut (sender: Any?) {}
@@ -1118,7 +1118,7 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
         let point = convert(event.locationInWindow, from: nil)
         let row = Int((frame.height - point.y) / defaultLineHeight)
         if row < 0 {
-          return Position(col: 0, row: 0)
+            return Position(col: 0, row: 0)
         }
         let col = CTLineGetStringIndexForPosition(self.ctline(forRow: row), point)
         return Position(col: col, row: row)
@@ -1271,21 +1271,21 @@ extension TerminalView: TerminalDelegate {
   }
 
   public func setTerminalTitle(source: Terminal, title: String) {
-    delegate?.setTerminalTitle(source: self, title: title)
+      delegate?.setTerminalTitle(source: self, title: title)
   }
 
   public func sizeChanged(source: Terminal) {
-    delegate?.sizeChanged(source: self, newCols: source.cols, newRows: source.rows)
-    updateScroller ()
+      delegate?.sizeChanged(source: self, newCols: source.cols, newRows: source.rows)
+      updateScroller ()
   }
 
   public func setTerminalIconTitle(source: Terminal, title: String) {
-    //
+      //
   }
 
   // Terminal.Delegate method implementation
   public func windowCommand(source: Terminal, command: Terminal.WindowManipulationCommand) -> [UInt8]? {
-    return nil
+      return nil
   }
 
 }
@@ -1306,5 +1306,5 @@ private extension NSColor {
 
 
 extension NSAttributedString.Key {
-  static let fullBackgroundColor: NSAttributedString.Key = .init("SwiftTerm_fullBackgroundColor") // NSColor, default nil: no background
+    static let fullBackgroundColor: NSAttributedString.Key = .init("SwiftTerm_fullBackgroundColor") // NSColor, default nil: no background
 }

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1117,6 +1117,9 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
     {
         let point = convert(event.locationInWindow, from: nil)
         let row = Int((frame.height - point.y) / defaultLineHeight)
+        if row < 0 {
+          return Position(col: 0, row: 0)
+        }
         let col = CTLineGetStringIndexForPosition(self.ctline(forRow: row), point)
         return Position(col: col, row: row)
     }

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -545,10 +545,6 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
             var glyphsPositions = [CGPoint](repeating: .zero, count: CTRunGetGlyphCount(glyphRun))
             CTRunGetPositions(glyphRun, CFRange(), &glyphsPositions)
 
-            // Set y in position
-            let baseLineAdj = runFont.descender + runFont.leading
-            glyphsPositions = glyphsPositions.map({ CGPoint(x: $0.x, y: lineOrigin.y - baseLineAdj) })
-
             // Draw background.
             // Background color fill the entire height of the line.
             if runAttributes.keys.contains(.fullBackgroundColor) {
@@ -573,6 +569,10 @@ public class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations
             // Draw glyphs
             // Not really needed, use CTLineDraw instead
             #if false
+              // Adjust positions for text
+              let baseLineAdj = runFont.descender + runFont.leading
+              glyphsPositions = glyphsPositions.map({ CGPoint(x: $0.x, y: lineOrigin.y + baseLineAdj) })
+
               // Set foreground color
               if runAttributes.keys.contains(.foregroundColor) {
                 let color = runAttributes[.foregroundColor] as! NSColor

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -104,7 +104,7 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
 
         let options = TerminalOptions(cols: Int(rect.width / font.normal.boundingRectForFont.width),
                                       rows: Int(rect.height / lineHeight))
-      
+
         terminal = Terminal(delegate: self, options: options)
         fullBufferUpdate()
         
@@ -509,16 +509,13 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
     
     // TODO: Clip here
     override public func draw(_ dirtyRect: NSRect) {
-        mapColor(color: Int(Terminal.defaultColor), isFg: false).set()
-        bounds.fill()
-    
-        //print ("Dirty rect is: \(dirtyRect)")
-        mapColor(color: Int(Terminal.defaultColor), isFg: true).set()
         guard let context = NSGraphicsContext.current?.cgContext else {
             return
         }
-
         context.saveGState()
+
+        context.setFillColor(mapColor(color: Int(Terminal.defaultColor), isFg: false).cgColor)
+        context.fill(dirtyRect)
 
         for row in 0..<terminal.rows {
           // CGContextSetTextPosition is coicident with text baseline

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -179,9 +179,9 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
     func computeCellDimensions () -> CGRect
     {
         // Get the ascent + descent + leading from the font, already scaled for the font's size
-        let lineHeight: CGFloat = CTFontGetAscent(fontNormal!) + CTFontGetDescent(fontNormal!) + CTFontGetLeading(fontNormal!);
+        let lineHeight: CGFloat = CTFontGetAscent(font.normal) + CTFontGetDescent(font.normal) + CTFontGetLeading(font.normal);
 
-        let attributedString = NSAttributedString(string: "W", attributes: [NSAttributedString.Key.font: fontNormal!])
+        let attributedString = NSAttributedString(string: "W", attributes: [NSAttributedString.Key.font: font.normal])
         let line = CTLineCreateWithAttributedString(attributedString)
         let bounds = CTLineGetBoundsWithOptions(line, .useOpticalBounds)
         cellDim = CellDimensions(width: bounds.width, height: lineHeight, delta: bounds.minY)

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -473,6 +473,7 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
         for row in 0..<rows {
             attrStrBuffer[row] = buildAttributedString(line: terminal.buffer.lines [row], cols: cols, prefix: "")
         }
+        attrStrBuffer.count = rows
     }
     
     func makeEmptyLine (_ index: Int) -> NSAttributedString

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -612,43 +612,44 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
             }
 
             // Draw glyphs
-
-            // Set foreground color
-            if runAttributes.keys.contains(.foregroundColor) {
-              let color = runAttributes[.foregroundColor] as! NSColor
-              context.setFillColor(color.cgColor)
-            }
-
-            if runAttributes.keys.contains(.underlineColor) {
-              let color = runAttributes[.underlineColor] as! NSColor
-              context.setFillColor(color.cgColor)
-            }
-
-            if runAttributes.keys.contains(.strikethroughColor) {
-              let color = runAttributes[.strikethroughColor] as! NSColor
-              context.setFillColor(color.cgColor)
-            }
-
-            var glyphs = [CGGlyph](repeating: .zero, count: CTRunGetGlyphCount(glyphRun))
-            CTRunGetGlyphs(glyphRun, CFRange(), &glyphs)
-
-            // TODO: disable antialiasing for non-letters
-            for (i, glyph) in glyphs.enumerated() {
-              var transform = CGAffineTransform(translationX: glyphsPositions[i].x, y: lineOrigin.y - baseLineAdj)
-              if let path = CTFontCreatePathForGlyph(runFont, glyph, &transform) {
-                context.addPath(path)
-                context.drawPath(using: .fill)
+            // Not really needed, use CTLineDraw instead
+            #if false
+              // Set foreground color
+              if runAttributes.keys.contains(.foregroundColor) {
+                let color = runAttributes[.foregroundColor] as! NSColor
+                context.setFillColor(color.cgColor)
               }
-            }
+
+              if runAttributes.keys.contains(.underlineColor) {
+                let color = runAttributes[.underlineColor] as! NSColor
+                context.setFillColor(color.cgColor)
+              }
+
+              if runAttributes.keys.contains(.strikethroughColor) {
+                let color = runAttributes[.strikethroughColor] as! NSColor
+                context.setFillColor(color.cgColor)
+              }
+
+              var glyphs = [CGGlyph](repeating: .zero, count: CTRunGetGlyphCount(glyphRun))
+              CTRunGetGlyphs(glyphRun, CFRange(), &glyphs)
+
+              // TODO: disable antialiasing for non-letters
+              //
+              for (i, glyph) in glyphs.enumerated() {
+                var transform = CGAffineTransform(translationX: glyphsPositions[i].x, y: lineOrigin.y - baseLineAdj)
+                if let path = CTFontCreatePathForGlyph(runFont, glyph, &transform) {
+                  context.addPath(path)
+                  context.drawPath(using: .fill)
+                }
+              }
+            #endif
           }
 
 
-          #if DEBUG
           // The code above is CTLineDraw() in disguise
-          // let baseLineAdj = font.normal.descender + font.normal.leading
-          // context.textPosition = CGPoint(x: 0, y: lineOrigin.y - baseLineAdj)
-          // CTLineDraw(line, context)
-          #endif
+          let baseLineAdj = font.normal.descender + font.normal.leading
+          context.textPosition = CGPoint(x: 0, y: lineOrigin.y - baseLineAdj)
+          CTLineDraw(line, context)
 
           prevY += currentLineHeight
         }

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -102,9 +102,9 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
         // Get the ascent + descent + leading from the font, already scaled for the font's size
         self.lineHeight = CTFontGetAscent(font.normal) + CTFontGetDescent(font.normal) + CTFontGetLeading(font.normal);
 
-        let options = TerminalOptions()
-        options.cols = Int (rect.width / font.normal.boundingRectForFont.width)
-        options.rows = Int (rect.height / lineHeight)
+        let options = TerminalOptions(cols: Int(rect.width / font.normal.boundingRectForFont.width),
+                                      rows: Int(rect.height / lineHeight))
+      
         terminal = Terminal(delegate: self, options: options)
         fullBufferUpdate()
         

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -205,8 +205,8 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
       return NSRect (x: 0, y: 0, width: font.normal.boundingRectForFont.width * CGFloat(terminal.cols), height: lineHeight * CGFloat(terminal.rows))
     }
     
-    public func scrolled(source: Terminal, yDisp: Int) {
-        selectionView.notifyScrolled ()
+    public func scrolled(source terminal: Terminal, yDisp: Int) {
+        selectionView.notifyScrolled(source: terminal)
         updateScroller()
         delegate?.scrolled(source: self, position: scrollPosition)
     }
@@ -682,7 +682,7 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
             // do the display update
             updateDisplay (notifyAccessibility: notifyAccessibility)
             
-            selectionView.notifyScrolled ()
+            selectionView.notifyScrolled(source: terminal)
             delegate?.scrolled (source: self, position: scrollPosition)
             updateScroller()
         }
@@ -983,7 +983,7 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
     }
     
     public func selectionChanged(source: Terminal) {
-        selectionView.update()
+      selectionView.update(with: source)
     }
 
     func cut (sender: Any?) {}

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -166,11 +166,14 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
     
     func computeCellDimensions () -> CGRect
     {
-        let line = CTLineCreateWithAttributedString (NSAttributedString (string: "W", attributes: [NSAttributedString.Key.font: fontNormal!]))
-        
+        // Get the ascent + descent + leading from the font, already scaled for the font's size
+        let lineHeight: CGFloat = CTFontGetAscent(fontNormal!) + CTFontGetDescent(fontNormal!) + CTFontGetLeading(fontNormal!);
+
+        let attributedString = NSAttributedString(string: "W", attributes: [NSAttributedString.Key.font: fontNormal!])
+        let line = CTLineCreateWithAttributedString(attributedString)
+
         let bounds = CTLineGetBoundsWithOptions(line, .useOpticalBounds)
-        cellDim = CellDimensions(width: bounds.width, height: round (bounds.height), delta: bounds.minY)
-        
+        cellDim = CellDimensions(width: bounds.width, height: lineHeight, delta: bounds.minY)
         return bounds
     }
     

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -101,25 +101,26 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
         // Get the ascent + descent + leading from the font, already scaled for the font's size
         self.lineHeight = CTFontGetAscent(font.normal) + CTFontGetDescent(font.normal) + CTFontGetLeading(font.normal);
 
-        let options = TerminalOptions ()
+        let options = TerminalOptions()
         options.cols = Int (rect.width / font.normal.boundingRectForFont.width)
         options.rows = Int (rect.height / lineHeight)
         terminal = Terminal(delegate: self, options: options)
-        fullBufferUpdate ()
+        fullBufferUpdate()
         
-        selection = SelectionService (terminal: terminal)
+        selection = SelectionService(terminal: terminal)
 
-        caretView = CaretView(frame: CGRect(origin: .zero, size: CGSize(width: font.normal.maximumAdvancement.width, height: lineHeight)))
-        caretView.focused = false
-        
-        addSubview(caretView)
-        
+        // Install selection vew
         selectionView = SelectionView(terminalView: self, frame: .zero)
+        addSubview(selectionView)
+
+        // Install carret view
+        caretView = CaretView(frame: CGRect(origin: .zero, size: CGSize(width: font.normal.maximumAdvancement.width, height: lineHeight)))
+        addSubview(caretView)
 
         search = SearchService (terminal: terminal)
         setupScroller(rect)
     }
-        
+
     /**
      * The delegate that the TerminalView uses to interact with its hosting
      */
@@ -982,13 +983,6 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
     }
     
     public func selectionChanged(source: Terminal) {
-        if selection.active {
-            if selectionView.superview == nil {
-                addSubview(selectionView)
-            }
-        } else {
-            selectionView.removeFromSuperview()
-        }
         selectionView.update()
     }
 

--- a/SwiftTerm/Sources/SwiftTerm/Mac/TerminalViewDelegate.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/TerminalViewDelegate.swift
@@ -1,0 +1,33 @@
+//
+//  File.swift
+//  
+//
+//  Created by Marcin Krzyzanowski on 11/04/2020.
+//
+
+public protocol TerminalViewDelegate: class {
+  /**
+   * The client code sending commands to the terminal has requested a new size for the terminal
+   * Applications that support this should call the `TerminalView.getOptimalFrameSize`
+   * to get the ideal frame size.
+   *
+   * This is needed for the rare cases where the remote client request 80 or 132 column displays,
+   * it is a rare feature and you most likely can ignore this request.
+   */
+  func sizeChanged (source: TerminalView, newCols: Int, newRows: Int)
+
+  /**
+   * Request to change the title of the terminal.
+   */
+  func setTerminalTitle(source: TerminalView, title: String)
+
+  /**
+   * The provided `data` needs to be sent to the application running inside the terminal
+   */
+  func send (source: TerminalView, data: ArraySlice<UInt8>)
+
+  /**
+   * Invoked when the terminal has been scrolled and the new position is provided
+   */
+  func scrolled (source: TerminalView, position: Double)
+}

--- a/SwiftTerm/Sources/SwiftTerm/Mac/TerminalViewDelegate.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/TerminalViewDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  TerminalViewDelegate.swift
 //  
 //
 //  Created by Marcin Krzyzanowski on 11/04/2020.

--- a/SwiftTerm/Sources/SwiftTerm/TerminalOptions.swift
+++ b/SwiftTerm/Sources/SwiftTerm/TerminalOptions.swift
@@ -17,14 +17,26 @@ public enum CursorStyle {
     case steadyBar
 }
 
-public class TerminalOptions {
-    public var cols: Int = 80
-    public var rows: Int = 25
-    public var convertEol: Bool = true
-    public var cursorBlink: Bool = false
-    public var termName: String = "xterm"
-    public var cursorStyle = CursorStyle.blinkBlock
-    public var screenReaderMode: Bool = false
-    public var scrollback: Int? = 500
-    public var tabStopWidth: Int? = 8
+public struct TerminalOptions {
+    public var cols: Int
+    public var rows: Int
+    public var convertEol: Bool
+    public var cursorBlink: Bool
+    public var termName: String
+    public var cursorStyle: CursorStyle
+    public var screenReaderMode: Bool
+    public var scrollback: Int
+    public var tabStopWidth: Int
+
+    public init(cols: Int = 80, rows: Int = 25, convertEol: Bool = true, cursorBlink: Bool = false, termName: String = "xterm", cursorStyle: CursorStyle = CursorStyle.blinkBlock, screenReaderMode: Bool = false, scrollback: Int = 500, tabStopWidth: Int = 8) {
+      self.cols = cols
+      self.rows = rows
+      self.convertEol = convertEol
+      self.cursorBlink = cursorBlink
+      self.termName = termName
+      self.cursorStyle = cursorStyle
+      self.screenReaderMode = screenReaderMode
+      self.scrollback = scrollback
+      self.tabStopWidth = tabStopWidth
+    }
 }

--- a/SwiftTerm/Sources/SwiftTerm/TerminalOptions.swift
+++ b/SwiftTerm/Sources/SwiftTerm/TerminalOptions.swift
@@ -29,14 +29,14 @@ public struct TerminalOptions {
     public var tabStopWidth: Int
 
     public init(cols: Int = 80, rows: Int = 25, convertEol: Bool = true, cursorBlink: Bool = false, termName: String = "xterm", cursorStyle: CursorStyle = CursorStyle.blinkBlock, screenReaderMode: Bool = false, scrollback: Int = 500, tabStopWidth: Int = 8) {
-      self.cols = cols
-      self.rows = rows
-      self.convertEol = convertEol
-      self.cursorBlink = cursorBlink
-      self.termName = termName
-      self.cursorStyle = cursorStyle
-      self.screenReaderMode = screenReaderMode
-      self.scrollback = scrollback
-      self.tabStopWidth = tabStopWidth
+        self.cols = cols
+        self.rows = rows
+        self.convertEol = convertEol
+        self.cursorBlink = cursorBlink
+        self.termName = termName
+        self.cursorStyle = cursorStyle
+        self.screenReaderMode = screenReaderMode
+        self.scrollback = scrollback
+        self.tabStopWidth = tabStopWidth
     }
 }


### PR DESCRIPTION
Fixes #54 

In this PR:
- Selection highlight in pair with displayed glyphs

    - before
        <img width="324" alt="Screenshot 2020-04-09 at 00 58 04" src="https://user-images.githubusercontent.com/758033/78844040-dd54c700-7a04-11ea-934a-5b258851f8e0.png">

    - after
        <img width="270" alt="Screenshot 2020-04-09 at 02 07 06" src="https://user-images.githubusercontent.com/758033/78844704-d16a0480-7a06-11ea-94f1-1cf93e781a89.png">

- dynamic line-height support

    - before
        <img width="679" alt="Screenshot 2020-04-10 at 12 53 52" src="https://user-images.githubusercontent.com/758033/79053186-9997d280-7c3b-11ea-9dca-30071d5a0b22.png">

    - after
        <img width="591" alt="Screenshot 2020-04-11 at 21 19 04" src="https://user-images.githubusercontent.com/758033/79053190-9e5c8680-7c3b-11ea-839b-799810f2aa6d.png">

- Improved support for font metrics. Calculate lines positions based on used font (no more magic offset values)
- Sharp background frame - `fullBackgroundColor` attribute
    - before
![1](https://user-images.githubusercontent.com/758033/79053253-3eb2ab00-7c3c-11ea-99d4-052103261a22.png)
    - after
![2](https://user-images.githubusercontent.com/758033/79053259-512ce480-7c3c-11ea-868e-b0d6423a8121.png)



