### PR TITLE
Use system colors (dark/light mode compatible)

### DIFF
--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -18,37 +18,31 @@ class CaretView: NSView {
     {
         super.init(frame: frame)
         wantsLayer = true
+        setupView()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public var caretColor: NSColor! {
-        didSet (newValue) {
-            if let val = newValue {
-                layer?.borderColor = val.cgColor
-                if focused {
-                    layer?.backgroundColor = val.cgColor
-                    layer?.borderWidth = 0
-                } else {
-                    layer?.borderWidth = 1
-                }
-            }
+    public var caretColor: NSColor = NSColor.selectedControlColor {
+        didSet {
+          setupView()
         }
     }
     
     public var focused: Bool = false {
-        didSet (newValue) {
-            if focused {
-                layer?.backgroundColor = caretColor.cgColor
-                layer?.borderWidth = 0
-            } else {
-                layer?.backgroundColor = NSColor.clear.cgColor
-                layer?.borderWidth = 2
-            }
+        didSet {
+          setupView()
         }
     }
+
+  private func setupView() {
+      guard let layer = layer else { return }
+      layer.borderWidth = focused ? 0 : 2
+      layer.borderColor = caretColor.cgColor
+      layer.backgroundColor = focused ? caretColor.cgColor : NSColor.clear.cgColor
+  }
     
     override func hitTest(_ point: NSPoint) -> NSView? {
         // we do not want to steal hits, let the terminal view take them

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacSelectionView.swift
@@ -31,7 +31,7 @@ class SelectionView: NSView {
         
         maskLayer = CAShapeLayer ()
         layer?.mask = maskLayer
-        layer?.backgroundColor = NSColor (calibratedRed: 0.4, green: 0.2, blue: 0.9, alpha: 0.8).cgColor
+        layer?.backgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.8).cgColor
     }
     
     public required init? (coder: NSCoder)

--- a/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -106,7 +106,6 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
         
         addSubview(caretView)
         
-        caretView.caretColor = NSColor (colorSpace: NSColor.blue.colorSpace, hue: 0.4, saturation: 0.2, brightness: 0.9, alpha: 0.5)
         selectionView = SelectionView (terminalView: self, frame: CGRect (x: 0, y: 0, width: 0, height: 0))
 
         search = SearchService (terminal: terminal)
@@ -320,15 +319,15 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
         // The default color
         if color == Terminal.defaultColor {
             if isFg {
-                return NSColor.black
+                return NSColor.textColor
             } else {
-                return NSColor.clear
+                return NSColor.textBackgroundColor
             }
         } else if color == Terminal.defaultInvertedColor {
             if isFg {
-                return NSColor.white
+                return NSColor.textColor.inverseColor()
             } else {
-                return NSColor.black
+                return NSColor.textBackgroundColor.inverseColor()
             }
         }
 
@@ -498,11 +497,11 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
     
     // TODO: Clip here
     override public func draw(_ dirtyRect: NSRect) {
-        NSColor.white.set ()
+        mapColor(color: Int(Terminal.defaultColor), isFg: false).set()
         bounds.fill()
     
         //print ("Dirty rect is: \(dirtyRect)")
-        NSColor.black.set ()
+        mapColor(color: Int(Terminal.defaultColor), isFg: true).set()
         guard let context = NSGraphicsContext.current?.cgContext else {
             return
         }
@@ -513,7 +512,7 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
         let baseLine = frame.height - cellDim.delta
         for row in 0..<maxRow {
             context.textPosition = CGPoint (x: 0, y: baseLine - (cellDim.height + CGFloat (row) * cellDim.height))
-            let attrLine = attrStrBuffer [row + yDisp]
+            let attrLine = attrStrBuffer[row + yDisp]
             // var dbg = NSAttributedString (string: "\(row)", attributes: getAttributes(CharData.defaultAttr))
             let ctline = CTLineCreateWithAttributedString(attrLine)
             CTLineDraw(ctline, context)
@@ -1202,3 +1201,15 @@ public class TerminalView: NSView, TerminalDelegate, NSTextInputClient, NSUserIn
 }
 
 #endif
+
+private extension NSColor {
+  func inverseColor() -> NSColor {
+    guard let color = self.usingColorSpace(.deviceRGB) else {
+      return self
+    }
+
+    var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    return NSColor(calibratedRed: 1.0 - red, green: 1.0 - green, blue: 1.0 - blue, alpha: alpha)
+  }
+}


### PR DESCRIPTION
Use system-defined colors for text/background/caret - this makes it work nicely in light/dark mode