### PR TITLE
add terminator to byte array that is read a null terminated c string

### DIFF
--- a/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -807,6 +807,7 @@ open class Terminal {
                 for _ in 1..<n {
                     x.append (readingBuffer.getNext())
                 }
+                x.append(0)
                 x.withUnsafeBytes { ptr in
                     let unsafeBound = ptr.bindMemory(to: UInt8.self)
                     let unsafePointer = unsafeBound.baseAddress!


### PR DESCRIPTION
I was running with memory bounds checks and found this