### PR TITLE
Expose Terminal information outside module

### DIFF
--- a/SwiftTerm/Sources/SwiftTerm/CharData.swift
+++ b/SwiftTerm/Sources/SwiftTerm/CharData.swift
@@ -243,7 +243,7 @@ public struct CharData {
     var unused: UInt8 // Purely here to align to 16 bytes
     
     /// The color and character attributes for the cell
-    var attribute: Attribute
+    public var attribute: Attribute
     
     /// Initializes a new instance of the CharData structure with the provided attribute, character and the dimension
     /// - Parameter attribute: an attribute containing the color and style attributes for the cell

--- a/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -160,7 +160,7 @@ open class Terminal {
     // Whether the terminal is operating in application keypad mode
     var applicationKeypad : Bool = false
     // Whether the terminal is operating in application cursor mode
-    var applicationCursor : Bool = false
+    public var applicationCursor : Bool = false
     
     // You can ignore most of the defaults set here, the function
     // reset() will do that again
@@ -343,7 +343,7 @@ open class Terminal {
             buffers!.active
         }
     }
-    
+
     /// Returns the character at the specified column and row, these are zero-based
     /// - Parameter col: column to retrieve, starts at 0
     /// - Parameter row: row to retrieve, starts at 0
@@ -3609,6 +3609,19 @@ open class Terminal {
         refreshEnd = -1
     }
     
+    /**
+     * Zero-based (row, column) of cursor location relative to visible part of display.
+     */
+    public func getCursorLocation() -> (Int, Int) {
+        return (buffer.x, buffer.y)
+    }
+    
+    /**
+     * Uppermost visible row.
+     */
+    public func getTopVisibleRow() -> Int {
+        return buffer.yDisp
+    }
     
     // ESC c Full Reset (RIS)
     /// This performs a full reset of the terminal, like a soft reset, but additionally resets the buffer conents and scroll area.

--- a/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -344,12 +344,12 @@ open class Terminal {
         }
     }
 
-    /// Returns the character at the specified column and row, these are zero-based
+    /// Returns the CharData at the specified column and row, these are zero-based
     /// - Parameter col: column to retrieve, starts at 0
     /// - Parameter row: row to retrieve, starts at 0
-    /// - Returns: nil if the col or row are out of bounds, or the Character contained in that cell otherwise
+    /// - Returns: nil if the col or row are out of bounds, or the CharData contained in that cell otherwise
     
-    public func getCharacter (col: Int, row: Int) -> Character?
+    public func getCharData (col: Int, row: Int) -> CharData?
     {
         if row < 0 || row >= rows {
             return nil
@@ -357,7 +357,17 @@ open class Terminal {
         if col < 0 || col >= cols {
             return nil
         }
-        return buffer.lines [row + buffer.yDisp][col].getCharacter()
+        return buffer.lines [row + buffer.yDisp][col]
+    }
+
+    /// Returns the character at the specified column and row, these are zero-based
+    /// - Parameter col: column to retrieve, starts at 0
+    /// - Parameter row: row to retrieve, starts at 0
+    /// - Returns: nil if the col or row are out of bounds, or the Character contained in that cell otherwise
+    
+    public func getCharacter (col: Int, row: Int) -> Character?
+    {
+        return getCharData(col: col, row: row)?.getCharacter()
     }
     
     func setup (isReset: Bool = false)


### PR DESCRIPTION
A few changes to allow using the Terminal object from outside the SwiftTerm module.

You can read the following:
* CharData for a given row and column
* whether terminal is in application cursor mode or not
* cursor location relative to visible screen
* top visible row to help handle scrolling