### PR TITLE
Better background processing

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -816,42 +816,20 @@ extension TerminalView {
         scrollTo (row: newPosition)
     }
       
-    func queueDisplayAtFrameRate ()
-    {
-        queuePendingDisplay()
-        let fps60 = 16670000
-        // let fps30 = 16670000*2
-        let fpsDelay = fps60
-
-        if !pending {
-            return
-        }
-        DispatchQueue.main.asyncAfter(
-            deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay)),
-            execute: queueDisplayAtFrameRate)
-    }
-    
     // Sends data to the terminal emulator for interpretation
     public func feed (byteArray: ArraySlice<UInt8>)
     {
         search.invalidate ()
-        pending = true
-        queueDisplayAtFrameRate()
+        
         terminal.feed (buffer: byteArray)
-        pending = false
-        queuePendingDisplay ()
     }
     
     // Sends data to the terminal emulator for interpretation
     public func feed (text: String)
     {
         search.invalidate ()
-        pending = true
-        queueDisplayAtFrameRate()
-        terminal.feed (text: text)
-        pending = false
-        queuePendingDisplay ()
         
+        terminal.feed (text: text)
     }
          
     /**

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -816,11 +816,29 @@ extension TerminalView {
         scrollTo (row: newPosition)
     }
       
+    func queueDisplayAtFrameRate ()
+    {
+        queuePendingDisplay()
+        let fps60 = 16670000
+        // let fps30 = 16670000*2
+        let fpsDelay = fps60
+
+        if !pending {
+            return
+        }
+        DispatchQueue.main.asyncAfter(
+            deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay)),
+            execute: queueDisplayAtFrameRate)
+    }
+    
     // Sends data to the terminal emulator for interpretation
     public func feed (byteArray: ArraySlice<UInt8>)
     {
         search.invalidate ()
+        pending = true
+        queueDisplayAtFrameRate()
         terminal.feed (buffer: byteArray)
+        pending = false
         queuePendingDisplay ()
     }
     
@@ -828,8 +846,12 @@ extension TerminalView {
     public func feed (text: String)
     {
         search.invalidate ()
+        pending = true
+        queueDisplayAtFrameRate()
         terminal.feed (text: text)
+        pending = false
         queuePendingDisplay ()
+        
     }
          
     /**

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -635,10 +635,8 @@ extension TerminalView {
     // Does not use a default argument and merge, because it is called back
     func updateDisplay ()
     {
-        terminal.terminalLock()
         updateDisplay (notifyAccessibility: true)
         updateDebugDisplay()
-        terminal.terminalUnlock()
         pendingDisplay = false
     }
     

--- a/Sources/SwiftTerm/BufferLine.swift
+++ b/Sources/SwiftTerm/BufferLine.swift
@@ -156,12 +156,7 @@ class BufferLine: CustomDebugStringConvertible{
     
     public func copyFrom (line: BufferLine)
     {
-        if data.count != line.count {
-            data = Array.init (repeating: CharData.Null, count: line.count)
-        }
-        for i in 0..<line.count {
-            data [i] = line [i]
-        }
+        data = line.data
         isWrapped = line.isWrapped
     }
     

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -93,6 +93,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations {
     var attributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     var urlAttributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     
+    
     // Cache for the colors in the 0..255 range
     var colors: [NSColor?] = Array(repeating: nil, count: 256)
     var trueColors: [Attribute.Color:NSColor] = [:]
@@ -135,9 +136,18 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations {
     private func setup()
     {
         wantsLayer = true
-        
         setupScroller()
         setupOptions()
+    }
+    
+    func startDisplayUpdates ()
+    {
+        // Not used on Mac
+    }
+    
+    func suspendDisplayUpdates()
+    {
+        // Not used on Mac
     }
     
     func setupOptions ()

--- a/Sources/SwiftTerm/SixelDcsHandler.swift
+++ b/Sources/SwiftTerm/SixelDcsHandler.swift
@@ -24,6 +24,7 @@ class SixelDcsHandler : DcsHandler {
     }
     
     func put (data : ArraySlice<UInt8>) {
+        print ("Sixel data for \(data.count)")
         for x in data {
             self.data.append(x)
         }

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -376,6 +376,16 @@ open class Terminal {
     
     var conformance: TerminalConformance = .vt500
     
+    public func terminalLock ()
+    {
+        parser.parseLock.lock ()
+    }
+    
+    public func terminalUnlock ()
+    {
+        parser.parseLock.unlock()
+    }
+    
     /**
      * Returns true if we should respect the left/right margins, which is based on the originMode and marginMode setting
      */

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -376,16 +376,6 @@ open class Terminal {
     
     var conformance: TerminalConformance = .vt500
     
-    public func terminalLock ()
-    {
-        parser.parseLock.lock ()
-    }
-    
-    public func terminalUnlock ()
-    {
-        parser.parseLock.unlock()
-    }
-    
     /**
      * Returns true if we should respect the left/right margins, which is based on the originMode and marginMode setting
      */
@@ -3757,15 +3747,9 @@ open class Terminal {
         parse (buffer: ([UInt8] (text.utf8))[...])
     }
 
-    var count = 0
     public func feed (buffer: ArraySlice<UInt8>)
     {
-        count += 1
         parse (buffer: buffer)
-        count -= 1
-        if count != 0 {
-            print ("Too many")
-        }
     }
 
     public func parse (buffer: ArraySlice<UInt8>)

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -3756,9 +3756,15 @@ open class Terminal {
         parse (buffer: ([UInt8] (text.utf8))[...])
     }
 
+    var count = 0
     public func feed (buffer: ArraySlice<UInt8>)
     {
+        count += 1
         parse (buffer: buffer)
+        count -= 1
+        if count != 0 {
+            print ("Too many")
+        }
     }
 
     public func parse (buffer: ArraySlice<UInt8>)

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -989,6 +989,7 @@ open class Terminal {
     // the rules for wrapping around, scrolling and overflow expected in the terminal.
     func insertCharacter (_ charData: CharData)
     {
+        let buffer = self.buffer
         var chWidth = Int (charData.width)
         var bufferRow = buffer.lines [buffer.y + buffer.yBase]
 

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -1453,7 +1453,7 @@ open class Terminal {
         }
         let newX = buffer.x - max (1, count)
         if newX < left {
-                buffer.x = left
+            buffer.x = left
         } else {
             buffer.x = newX
         }

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -121,13 +121,26 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         setup()
     }
           
+    var link: CADisplayLink!
     func setup()
     {
+        let link = CADisplayLink(target: self, selector: #selector(step))
+            
+        link.add(to: .current, forMode: .default)
+        
         setupOptions ()
         setupGestures ()
         setupAccessoryView ()
     }
-    
+
+    @objc
+    func step(displaylink: CADisplayLink) {
+        terminal.terminalLock()
+        updateDisplay()
+        terminal.terminalUnlock()
+    }
+
+
     @objc func pasteCmd(_ sender: Any?) {
         if let s = UIPasteboard.general.string {
             send(txt: s)
@@ -403,8 +416,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     
     open func scrolled(source terminal: Terminal, yDisp: Int) {
         //XselectionView.notifyScrolled(source: terminal)
-        updateScroller()
-        terminalDelegate?.scrolled(source: self, position: scrollPosition)
+        //updateScroller()
+        //terminalDelegate?.scrolled(source: self, position: scrollPosition)
     }
     
     open func linefeed(source: Terminal) {

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -430,8 +430,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     
     open func scrolled(source terminal: Terminal, yDisp: Int) {
         //XselectionView.notifyScrolled(source: terminal)
-        //updateScroller()
-        //terminalDelegate?.scrolled(source: self, position: scrollPosition)
+        updateScroller()
+        terminalDelegate?.scrolled(source: self, position: scrollPosition)
     }
     
     open func linefeed(source: Terminal) {
@@ -471,14 +471,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         // drawTerminalContents and CoreText expect the AppKit coordinate system
         context.scaleBy (x: 1, y: -1)
         context.translateBy(x: 0, y: -frame.height)
-        terminal.terminalLock()
         drawTerminalContents (dirtyRect: dirtyRect, context: context)
-        terminal.terminalUnlock()
     }
     
-    var pending = false
-    
-
     open override var frame: CGRect {
         get {
             return super.frame

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -444,9 +444,14 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         // drawTerminalContents and CoreText expect the AppKit coordinate system
         context.scaleBy (x: 1, y: -1)
         context.translateBy(x: 0, y: -frame.height)
+        terminal.terminalLock()
         drawTerminalContents (dirtyRect: dirtyRect, context: context)
+        terminal.terminalUnlock()
     }
     
+    var pending = false
+    
+
     open override var frame: CGRect {
         get {
             return super.frame

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -83,7 +83,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     // of attributes for an NSAttributedString
     var attributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     var urlAttributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
-    
+
+    // Timer to display the terminal buffer
+    var link: CADisplayLink!
+
     // Cache for the colors in the 0..255 range
     var colors: [UIColor?] = Array(repeating: nil, count: 256)
     var trueColors: [Attribute.Color:UIColor] = [:]
@@ -121,26 +124,37 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         setup()
     }
           
-    var link: CADisplayLink!
     func setup()
     {
-        let link = CADisplayLink(target: self, selector: #selector(step))
-            
-        link.add(to: .current, forMode: .default)
-        
+        setupDisplayUpdates ();
         setupOptions ()
         setupGestures ()
         setupAccessoryView ()
     }
 
+    func setupDisplayUpdates ()
+    {
+        link = CADisplayLink(target: self, selector: #selector(step))
+            
+        link.add(to: .current, forMode: .default)
+        suspendDisplayUpdates()
+    }
+    
     @objc
     func step(displaylink: CADisplayLink) {
-        terminal.terminalLock()
         updateDisplay()
-        terminal.terminalUnlock()
     }
 
-
+    func startDisplayUpdates()
+    {
+        link.isPaused = false
+    }
+    
+    func suspendDisplayUpdates()
+    {
+        link.isPaused = true
+    }
+    
     @objc func pasteCmd(_ sender: Any?) {
         if let s = UIPasteboard.general.string {
             send(txt: s)

--- a/TerminalApp/iOSTerminal.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TerminalApp/iOSTerminal.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:SwiftTerm.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
+++ b/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
@@ -19,7 +19,8 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
     
     public override init (frame: CGRect)
     {
-        sshQueue = DispatchQueue.global(qos: .background)
+        sshQueue = DispatchQueue (label: "SSH Queue")
+        
         super.init (frame: frame)
         terminalDelegate = self
         do {
@@ -46,7 +47,6 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
             s.withCallback { [unowned self] (data: Data?, error: Data?) in
                 if let d = data {
                     let sliced = Array(d) [0...]
-     
                     self.feed(byteArray: sliced)
                 }
             }

--- a/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
+++ b/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
@@ -26,7 +26,7 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
             
             authenticationChallenge = .byPassword(username: "miguel", password: try String (contentsOfFile: "/Users/miguel/password"))
             shell = try? SSHShell(sshLibrary: Libssh2.self,
-                                  host: "192.168.86.78",
+                                  host: "192.168.86.77",
                                   port: 22,
                                   environment: [Environment(name: "LANG", variable: "en_US.UTF-8")],
                                   terminal: "xterm-256color")
@@ -47,35 +47,7 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
                 if let d = data {
                     let sliced = Array(d) [0...]
      
-                    // The first code causes problems, because the SSH library
-                    // accumulates data, rather that sending it as it comes,
-                    // so it can deliver blocks of 300k to 2megs of data
-                    // which as far as the user is concerned, nothing happens
-                    // while the terminal parsers proceses this.
-                    //
-                    // The solution was below, and it fed the data in chunks
-                    // to the UI, but this caused the UI to not update chunks
-                    // of the screen, for reasons that I do not understand yet.
-                    #if true
-                    DispatchQueue.main.sync {
-                        self.feed(byteArray: sliced)
-                    }
-                    #else
-                    let blocksize = 1024
-                    var next = 0
-                    let last = sliced.endIndex
-                    
-                    while next < last {
-                        
-                        let end = min (next+blocksize, last)
-                        let chunk = sliced [next..<end]
-                    
-                        DispatchQueue.main.sync {
-                            self.feed(byteArray: chunk)
-                        }
-                        next = end
-                    }
-                    #endif
+                    self.feed(byteArray: sliced)
                 }
             }
             .connect()

--- a/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
+++ b/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
@@ -47,20 +47,11 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
             s.withCallback { [unowned self] (data: Data?, error: Data?) in
                 if let d = data {
                     let sliced = Array(d) [0...]
-                    // The first code causes problems, because the SSH library
-                    // accumulates data, rather that sending it as it comes,
-                    // so it can deliver blocks of 300k to 2megs of data
-                    // which as far as the user is concerned, nothing happens
-                    // while the terminal parsers proceses this.
-                    //
-                    // The solution was below, and it fed the data in chunks
-                    // to the UI, but this caused the UI to not update chunks
-                    // of the screen, for reasons that I do not understand yet.
-                    #if false
-                    DispatchQueue.main.sync {
-                        self.feed(byteArray: sliced)
-                    }
-                    #else
+                    
+                    // We chunk the processing of data, as the SSH library might have
+                    // received a lot of data, and we do not want the terminal to
+                    // parse it all, and then render, we want to parse in chunks to
+                    // give the terminal the chance to update the display as it goes.
                     let blocksize = 1024
                     var next = 0
                     let last = sliced.endIndex
@@ -75,7 +66,6 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
                         }
                         next = end
                     }
-                    #endif
                 }
             }
             .connect()

--- a/TerminalApp/iOSTerminal/ViewController.swift
+++ b/TerminalApp/iOSTerminal/ViewController.swift
@@ -73,7 +73,7 @@ class ViewController: UIViewController {
         
         view.addSubview(tv)
         tv.becomeFirstResponder()
-        //self.tv.feed(text: "Welcome to SwiftTerm - connecting to my localhost\n\n")
+        self.tv.feed(text: "Welcome to SwiftTerm - connecting to my localhost\n\n")
     }
     
     override func viewWillLayoutSubviews() {

--- a/TerminalApp/iOSTerminal/ViewController.swift
+++ b/TerminalApp/iOSTerminal/ViewController.swift
@@ -73,7 +73,7 @@ class ViewController: UIViewController {
         
         view.addSubview(tv)
         tv.becomeFirstResponder()
-        tv.feed(text: "Welcome to SwiftTerm - connecting to my localhost\n\n")
+        //self.tv.feed(text: "Welcome to SwiftTerm - connecting to my localhost\n\n")
     }
     
     override func viewWillLayoutSubviews() {


### PR DESCRIPTION
This implements a more responsive terminal in particular in scenarios where
a lot of data might be delivered by a remote end-point, or where the remote data
has been queued.

This work was first proposed and documented here:

https://github.com/migueldeicaza/SwiftTerm/issues/137

I originally thought that what I should do was to make the parsing take place in
a background thread, and keep the UI updating using a `CADisplayLink` to ensure
smooth updates.   While did this work, it made the code more complicated in places
where it did not have to be - in particular, events were being raised on a background 
thread.   There was also an additional problem, which I documented like this
on the issue:

```
Observation on multi-threading: while this works fabulously, the current system will 
just take as much input from the remote server, without putting a stop to data that 
can be consumed, which has the unfortunate side-effect that when you press C-c, 
the sequence is sent, but there is too much data already buffered.

So it might be useful to throttle just how much data can be posted by the background 
thread for flow control. I could swear in the past there was some sort of flow control.
```

During the process of implementing the background operations, I found a handful of
bugs in the sequence parser, which were the reason why previous attempts at feeding
data in chunks failed.   So when I fixed those bugs, it turned out that there was no need
to multi-thread, and a dispatching system in chunks was working - without the
any additional complexity.

It also means that the contract for users remains simple.

It might be possible to remove the `CADisplayLink` entirely, if we can call `updateDisplay()`
when the state is dirty just after feeding the console.