### PR TITLE
avoid buffer overflow in selectCharset

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -1848,6 +1848,7 @@ open class Terminal {
         
         if (p.count != 2) {
             cmdSelectDefaultCharset ()
+            return
         }
         var ch: UInt8
         var charset: [UInt8:String]?


### PR DESCRIPTION
`selectCharset()` could overflow when called with incorrect parameters.

`if CharSets.all.keys.contains(p [1]){` a few lines down fails if `count < 2` and by returning early this can no longer happen. 