### PR TITLE
Issue with `updateCursorPostion` in drawDirtyRect

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -554,10 +554,10 @@ extension TerminalView {
                 col += runGlyphsCount
             }
 
-            // set caret position
-            if terminal.buffer.y == row - terminal.buffer.yDisp {
-                updateCursorPosition()
-            }
+//            // set caret position
+//            if terminal.buffer.y == row - terminal.buffer.yDisp {
+//                updateCursorPosition()
+//            }
         }
     }
     


### PR DESCRIPTION
 There is no need to draw the cursor in the draw method, as it is draw…
cc3ddc5

…n later by `updateDisplay(...)`.

This is removed because of some crash when a terminal is used inside of a SwiftUI `VSplitView` (maybe also others)

When the `updateCursorPostion` method is called in the drawDirtyRect method, it causes a crash at `addSubview(caretView)` in line 628. The message is:
"The window has been marked as needing another Update Constraints in Window pass, but it has already had more Update Constraints in Window passes than there are views in the window"

