### PR TITLE
Stretch last col/row to fill the view frame

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -526,7 +526,23 @@ extension TerminalView {
                     context.setFillColor(backgroundColor.cgColor)
 
                     let transform = CGAffineTransform (translationX: positions[0].x, y: 0)
-                    let rect = CGRect (origin: lineOrigin, size: CGSize (width: CGFloat (cellDimension.width * CGFloat(runGlyphsCount)), height: cellDimension.height))
+
+                    // Stretch last col/row to full frame size.
+                    // TODO: need apply this kind of fixup to selection too
+                    var size = CGSize (width: CGFloat (cellDimension.width * CGFloat(runGlyphsCount)), height: cellDimension.height)
+                    var origin: CGPoint = lineOrigin
+
+                    if row >= terminal.rows - 1 {
+                        let missing = frame.height - (cellDimension.height + CGFloat(row) + 1)
+                        size.height += missing
+                        origin.y -= missing
+                    }
+
+                    if col + runGlyphsCount >= terminal.cols - 1 {
+                        size.width += frame.width - size.width
+                    }
+
+                    let rect = CGRect (origin: origin, size: size)
                     #if os(macOS)
                     rect.applying(transform).fill(using: .destinationOver)
                     #else


### PR DESCRIPTION
Stretch last col/row to fill the view frame.


Problem: If the view frame is not exactly the size of the grid, the background does not cover the whole frame - that looks like here:

https://user-images.githubusercontent.com/758033/105563386-2a98ef80-5d1e-11eb-8dd0-ed37ff5e7004.mov

