### PR TITLE
Add check for position when one of them is not defined 

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTextInput.swift
+++ b/Sources/SwiftTerm/iOS/iOSTextInput.swift
@@ -208,12 +208,13 @@ extension TerminalView: UITextInput {
     }
     
     public func compare(_ position: UITextPosition, to other: UITextPosition) -> ComparisonResult {
-        let first = position as! xTextPosition
-        let second = other as! xTextPosition
-        if first.start < second.start {
-            return .orderedAscending
-        } else if first.start == second.start {
-            return .orderedSame
+        if let first = position as? xTextPosition,
+           let second = other as? xTextPosition {
+            if first.start < second.start {
+                return .orderedAscending
+            } else if first.start == second.start {
+                return .orderedSame
+            }
         }
         return .orderedDescending
     }


### PR DESCRIPTION
Fix issue on macOS when a position is not defined on the compare( ) method 