### PR TITLE
Use serial queue to send bytes

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -97,7 +97,7 @@ public class LocalProcess {
                 print ("[SEND-\(copy)] Queuing data to client: \(data) ")
             }
 
-            DispatchIO.write(toFileDescriptor: childfd, data: ddata, runningHandlerOn: DispatchQueue.global(qos: .userInitiated), handler:  { dd, errno in
+            DispatchIO.write(toFileDescriptor: childfd, data: ddata, runningHandlerOn: dispatchQueue, handler:  { dd, errno in
                 self.total += copyCount
                 if self.debugIO {
                     print ("[SEND-\(copy)] completed bytes=\(self.total)")


### PR DESCRIPTION
This looks like a typo, documentation says the `dispatchQueue` will be used to post data.
The handler code is not thread-safe anyway.