### PR TITLE
Add default value to `updateCursorStyle()` in `MacCareView.swift`

### DIFF
--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -36,7 +36,7 @@ class CaretView: NSView {
         }
     }
     
-    func updateCursorStyle (style: CursorStyle) {
+    func updateCursorStyle (style: CursorStyle = .blinkBlock) {
         switch style {
         case .blinkUnderline, .blinkBlock, .blinkBar:
             let anim = CABasicAnimation.init(keyPath: #keyPath (CALayer.opacity))


### PR DESCRIPTION
Fixes build issue in `AppleTerminalView.swift` line 64
```swift
    func updateCaretView ()
    {
        caretView.frame.size = CGSize(width: cellDimension.width, height: cellDimension.height)
        caretView.updateCursorStyle()
    }
```