### PR TITLE
iOSCaretView fix random `t` in source

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -56,7 +56,7 @@ class CaretView: UIView {
         updateCursorStyle ();
     }
     
-t    func updateAnimation (to: Bool) {
+    func updateAnimation (to: Bool) {
         layer.removeAllAnimations()
         self.layer.opacity = 1
         if window == nil {


### PR DESCRIPTION
extra character in source code

![image](https://user-images.githubusercontent.com/399864/176746185-3d4ec04e-4b9f-47c0-9d07-80a5d8f91b41.png)
