### PR TITLE
CADisplayLink  retain TerminalView fix

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -238,6 +238,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         link.isPaused = true
     }
     
+    public func updateUiClosed() {
+        self.link.invalidate()
+    }
+    
     @objc open override func paste (_ sender: Any?) {
         disableSelectionPanGesture()
         if let start = UIPasteboard.general.string {


### PR DESCRIPTION
expose a call to invalidate CADisplayLink in order to prevent retain of TerminalView