### PR TITLE
The caret will now render the character underneath it.

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -238,14 +238,62 @@ extension TerminalView {
         colorsChanged()
     }
     
-    public func setCursorColor(source: Terminal, color: Color?) {
+    /// Sets the color for the cursor block, and the text when it is under that cursor in block mode
+    public func setCursorColor(source: Terminal, color: Color?, textColor: Color?) {
         if let setColor = color {
             caretColor = TTColor.make (color: setColor)
         } else {
             caretColor = caretView.defaultCaretColor
         }
+        if let setColor = textColor {
+            caretTextColor = TTColor.make (color: setColor)
+        } else {
+            caretTextColor = caretView.defaultCaretTextColor
+        }
     }
     
+    func getAttributedValue (_ attribute: Attribute, usingFg: TTColor, andBg: TTColor) -> [NSAttributedString.Key:Any]?
+    {
+        guard let terminal else {
+            return nil
+        }
+        let flags = attribute.style
+        var bg = andBg
+        var fg = usingFg
+        
+        if flags.contains (.inverse) {
+            swap (&bg, &fg)
+        }
+        
+        var tf: TTFont
+        let isBold = flags.contains(.bold)
+        if isBold {
+            if flags.contains (.italic) {
+                tf = fontSet.boldItalic
+            } else {
+                tf = fontSet.bold
+            }
+        } else if flags.contains (.italic) {
+            tf = fontSet.italic
+        } else {
+            tf = fontSet.normal
+        }
+        
+        var nsattr: [NSAttributedString.Key:Any] = [
+            .font: tf,
+            .foregroundColor: fg,
+            .backgroundColor: bg
+        ]
+        if flags.contains (.underline) {
+            nsattr [.underlineColor] = fg
+            nsattr [.underlineStyle] = NSUnderlineStyle.single.rawValue
+        }
+        if flags.contains (.crossedOut) {
+            nsattr [.strikethroughColor] = fg
+            nsattr [.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+        }
+        return nsattr
+    }
     
     //
     // Given a vt100 attribute, return the NSAttributedString attributes used to render it

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -92,7 +92,7 @@ extension TerminalView {
         
         // Install carret view
         if caretView == nil {
-            caretView = CaretView(frame: CGRect(origin: .zero, size: CGSize(width: cellDimension.width, height: cellDimension.height)), cursorStyle: terminal.options.cursorStyle)
+            caretView = CaretView(frame: CGRect(origin: .zero, size: CGSize(width: cellDimension.width, height: cellDimension.height)), cursorStyle: terminal.options.cursorStyle, terminal: self)
             addSubview(caretView)
         } else {
             updateCaretView ()
@@ -488,7 +488,8 @@ extension TerminalView {
     {
         let lineDescent = CTFontGetDescent(fontSet.normal)
         let lineLeading = CTFontGetLeading(fontSet.normal)
-
+        let yOffset = ceil(lineDescent+lineLeading)
+        
         func calcLineOffset (forRow: Int) -> CGFloat {
             cellDimension.height * CGFloat (forRow-bufferOffset+1) + offset
         }
@@ -582,7 +583,7 @@ extension TerminalView {
                 }
 
                 var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
-                    CGPoint(x: lineOrigin.x + (cellDimension.width * CGFloat(col + i)), y: lineOrigin.y + ceil(lineLeading + lineDescent))
+                    CGPoint(x: lineOrigin.x + (cellDimension.width * CGFloat(col + i)), y: lineOrigin.y + yOffset)
                 }
 
                 var backgroundColor: TTColor?
@@ -803,6 +804,7 @@ extension TerminalView {
         let lineOrigin = CGPoint(x: 0, y: frame.height - offset)
         #endif
         caretView.frame.origin = CGPoint(x: lineOrigin.x + (cellDimension.width * doublePosition * CGFloat(buffer.x)), y: lineOrigin.y)
+        caretView.setText (ch: buffer.lines [vy][buffer.x])
     }
     
     // Does not use a default argument and merge, because it is called back

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -44,6 +44,7 @@ extension CaretView {
         guard style == .steadyBlock || style  == .blinkBlock else {
             return
         }
+        let caretFG = caretTextColor ?? terminal.nativeForegroundColor
         context.setFillColor(TTColor.black.cgColor)
         for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
             let runGlyphsCount = CTRunGetGlyphCount(run)

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -1,0 +1,61 @@
+//
+//  File.swift
+//  
+//
+//  Created by Miguel de Icaza on 4/16/23.
+//
+
+import Foundation
+import UIKit
+import CoreText
+
+extension CaretView {
+    func drawCursor (in context: CGContext) {
+        guard let ctline else {
+            return
+        }
+        guard let terminal else {
+            return
+        }
+        let lineDescent = CTFontGetDescent(terminal.fontSet.normal)
+        let lineLeading = CTFontGetLeading(terminal.fontSet.normal)
+        let yOffset = ceil(lineDescent+lineLeading)
+        
+        context.setFillColor(TTColor.clear.cgColor)
+        context.fill ([bounds])
+        
+        context.setFillColor(bgColor)
+        let region: CGRect
+        switch style {
+        case .blinkBar, .steadyBar:
+            region = CGRect (x: 0, y: 0, width: bounds.width, height: 2)
+        case .blinkBlock, .steadyBlock:
+            region = bounds
+        case .blinkUnderline, .steadyUnderline:
+            region = CGRect (x: 0, y: 0, width: bounds.width, height: 2)
+        }
+        context.fill([region])
+
+        guard style == .steadyBlock || style  == .blinkBlock else {
+            return
+        }
+        context.setFillColor(TTColor.black.cgColor)
+        for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
+            let runGlyphsCount = CTRunGetGlyphCount(run)
+            let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
+            let runFont = runAttributes[.font] as! TTFont
+
+            let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
+                CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
+                count = runGlyphsCount
+            }
+
+            var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
+                CGPoint(x: 0, y: yOffset)
+            }
+            CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
+
+        }
+    }
+
+}

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -6,24 +6,25 @@
 //
 
 import Foundation
-import UIKit
 import CoreText
 
 extension CaretView {
-    func drawCursor (in context: CGContext) {
+    func drawCursor (in context: CGContext, hasFocus: Bool) {
         guard let ctline else {
             return
         }
         guard let terminal else {
             return
         }
-        let lineDescent = CTFontGetDescent(terminal.fontSet.normal)
-        let lineLeading = CTFontGetLeading(terminal.fontSet.normal)
-        let yOffset = ceil(lineDescent+lineLeading)
-        
         context.setFillColor(TTColor.clear.cgColor)
         context.fill ([bounds])
         
+        if !hasFocus {
+            context.setStrokeColor(bgColor)
+            context.setLineWidth(2)
+            context.stroke(bounds)
+            return
+        }
         context.setFillColor(bgColor)
         let region: CGRect
         switch style {
@@ -36,6 +37,10 @@ extension CaretView {
         }
         context.fill([region])
 
+        let lineDescent = CTFontGetDescent(terminal.fontSet.normal)
+        let lineLeading = CTFontGetLeading(terminal.fontSet.normal)
+        let yOffset = ceil(lineDescent+lineLeading)
+        
         guard style == .steadyBlock || style  == .blinkBlock else {
             return
         }
@@ -54,8 +59,6 @@ extension CaretView {
                 CGPoint(x: 0, y: yOffset)
             }
             CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
-
         }
     }
-
 }

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -11,16 +11,84 @@ import Foundation
 import AppKit
 import CoreText
 import CoreGraphics
+import CoreText
 
 // The CaretView is used to show the cursor
-class CaretView: NSView {
+class CaretView: NSView, CALayerDelegate {
+    weak var terminal: TerminalView?
     var sub: CALayer
+    var ctline: CTLine?
+    var backgroundColor: CGColor?
     
-    public init (frame: CGRect, cursorStyle: CursorStyle)
+    func getAttributes (_ attribute: Attribute) -> [NSAttributedString.Key:Any]?
     {
+        guard let terminal else {
+            return nil
+        }
+        let flags = attribute.style
+        var bg = attribute.bg
+        var fg = attribute.fg
+        
+        if flags.contains (.inverse) {
+            swap (&bg, &fg)
+            
+            if fg == .defaultColor {
+                fg = .defaultInvertedColor
+            }
+            if bg == .defaultColor {
+                bg = .defaultInvertedColor
+            }
+        }
+        
+        var tf: TTFont
+        let isBold = flags.contains(.bold)
+        if isBold {
+            if flags.contains (.italic) {
+                tf = terminal.fontSet.boldItalic
+            } else {
+                tf = terminal.fontSet.bold
+            }
+        } else if flags.contains (.italic) {
+            tf = terminal.fontSet.italic
+        } else {
+            tf = terminal.fontSet.normal
+        }
+        
+        // TODO: let fgColor = mapColor (color: fg, isFg: true, isBold: isBold)
+        let nsattr: [NSAttributedString.Key:Any] = [
+            .font: tf,
+            .foregroundColor: NSColor.black,
+            .backgroundColor: TTColor.make(color: terminal.terminal.cursorColor ?? Color (red: 0xffff, green: 0xffff, blue: 0xffff))
+        ]
+//        if flags.contains (.underline) {
+//            nsattr [.underlineColor] = fgColor
+//            nsattr [.underlineStyle] = NSUnderlineStyle.single.rawValue
+//        }
+//        if flags.contains (.crossedOut) {
+//            nsattr [.strikethroughColor] = fgColor
+//            nsattr [.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+//        }
+//        if withUrl {
+//            nsattr [.underlineStyle] = NSUnderlineStyle.single.rawValue | NSUnderlineStyle.patternDash.rawValue
+//            nsattr [.underlineColor] = fgColor
+//
+//            // Add to cache
+//            urlAttributes [attribute] = nsattr
+//        } else {
+//            // Just add to cache
+//            attributes [attribute] = nsattr
+//        }
+        return nsattr
+    }
+    
+    public init (frame: CGRect, cursorStyle: CursorStyle, terminal: TerminalView)
+    {
+        self.terminal = terminal
         style = cursorStyle
+        //style = .steadyBlock
         sub = CALayer ()
         super.init(frame: frame)
+        //sub.delegate = self
         wantsLayer = true
         layer?.addSublayer(sub)
         
@@ -29,6 +97,15 @@ class CaretView: NSView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setText (ch: CharData) {
+        var res = NSAttributedString (
+            string: String (ch.getCharacter()),
+            attributes: getAttributes(ch.attribute))
+        ctline = CTLineCreateWithAttributedString(res)
+
+        setNeedsDisplay(bounds)
     }
     
     var style: CursorStyle {
@@ -41,16 +118,16 @@ class CaretView: NSView {
         switch style {
         case .blinkUnderline, .blinkBlock, .blinkBar:
             let anim = CABasicAnimation.init(keyPath: #keyPath (CALayer.opacity))
-            anim.duration = 0.7
+            anim.duration = 1
             anim.autoreverses = true
             anim.repeatCount = Float.infinity
             anim.fromValue = NSNumber (floatLiteral: 1)
-            anim.toValue = NSNumber (floatLiteral: 0.3)
+            anim.toValue = NSNumber (floatLiteral: 0)
             anim.timingFunction = CAMediaTimingFunction (name: .easeInEaseOut)
-            sub.add(anim, forKey: #keyPath (CALayer.opacity))
+            layer?.add(anim, forKey: #keyPath (CALayer.opacity))
         case .steadyBar, .steadyBlock, .steadyUnderline:
-            sub.removeAllAnimations()
-            sub.opacity = 1
+            layer?.removeAllAnimations()
+            layer?.opacity = 1
         }
         
         guard let layer = self.layer else {
@@ -91,7 +168,56 @@ class CaretView: NSView {
         sub.frame = CGRect (origin: CGPoint.zero, size: layer.frame.size)
         sub.borderWidth = isFirst ? 0 : 1
         sub.borderColor = caretColor.cgColor
-        sub.backgroundColor = isFirst ? caretColor.cgColor : NSColor.clear.cgColor
+        setNeedsDisplay(bounds)
+        //sub.backgroundColor = isFirst ? caretColor.cgColor : NSColor.clear.cgColor
+        //sub.backgroundColor = NSColor.red.cgColor
+        backgroundColor = isFirst ? caretColor.cgColor : NSColor.clear.cgColor
+    }
+    
+    func draw(_ layer: CALayer, in context: CGContext) {
+        drawCursor (in: context)
+    }
+    
+    func drawCursor (in context: CGContext) {
+        guard let ctline else {
+            return
+        }
+        guard let terminal else {
+            return
+        }
+        let lineDescent = CTFontGetDescent(terminal.fontSet.normal)
+        let lineLeading = CTFontGetLeading(terminal.fontSet.normal)
+        let yOffset = ceil(lineDescent+lineLeading)
+
+        if let backgroundColor {
+            context.setFillColor(backgroundColor)
+            context.fill([bounds])
+        }
+        context.setFillColor(NSColor.black.cgColor)
+        for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
+            let runGlyphsCount = CTRunGetGlyphCount(run)
+            let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
+            let runFont = runAttributes[.font] as! TTFont
+
+            let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
+                CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
+                count = runGlyphsCount
+            }
+
+            var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
+                CGPoint(x: 0, y: yOffset)
+            }
+            CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
+
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            return
+        }
+        //drawCursor(in: dirtyRect)
+        
     }
     
     override func hitTest(_ point: NSPoint) -> NSView? {

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -38,7 +38,7 @@ class CaretView: NSView, CALayerDelegate {
     func setText (ch: CharData) {
         let res = NSAttributedString (
             string: String (ch.getCharacter()),
-            attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor))
+            attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor ?? terminal?.nativeForegroundColor ?? NSColor.black))
         ctline = CTLineCreateWithAttributedString(res)
 
         setNeedsDisplay(bounds)
@@ -88,8 +88,8 @@ class CaretView: NSView, CALayerDelegate {
         }
     }
 
-    public var defaultCaretTextColor = NSColor.black
-    public var caretTextColor: NSColor = NSColor.black {
+    public var defaultCaretTextColor: NSColor? = nil
+    public var caretTextColor: NSColor? = nil {
         didSet {
             updateView()
         }

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -212,7 +212,13 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         get { caretView.caretColor }
         set { caretView.caretColor = newValue }
     }
-    
+
+    /// Controls the color for the text in the caret when using a block cursor
+    public var caretTextColor: NSColor {
+        get { caretView.caretTextColor }
+        set { caretView.caretTextColor = newValue }
+    }
+
     var _selectedTextBackgroundColor = NSColor.selectedTextBackgroundColor
     /// The color used to render the selection
     public var selectedTextBackgroundColor: NSColor {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -235,8 +235,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         set { caretView.caretColor = newValue }
     }
 
-    /// Controls the color for the text in the caret when using a block cursor
-    public var caretTextColor: NSColor {
+    /// Controls the color for the text in the caret when using a block cursor, if not set
+    /// the cursor will render with the foreground color
+    public var caretTextColor: NSColor? {
         get { caretView.caretTextColor }
         set { caretView.caretTextColor = newValue }
     }

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -14,11 +14,16 @@ import CoreGraphics
 // The CaretView is used to show the cursor
 class CaretView: UIView {
     var sub: CALayer
+    weak var terminal: TerminalView?
+    var ctline: CTLine?
+    var bgColor: CGColor
     
-    public init (frame: CGRect, cursorStyle: CursorStyle)
+    public init (frame: CGRect, cursorStyle: CursorStyle, terminal: TerminalView)
     {
         style = cursorStyle
         sub = CALayer ()
+        bgColor = caretColor.cgColor
+        self.terminal = terminal
         super.init(frame: frame)
         layer.addSublayer(sub)
         isUserInteractionEnabled = false
@@ -61,8 +66,8 @@ class CaretView: UIView {
             return
         }
         if to {
-            UIView.animate(withDuration: 0.7, delay: 0, options: [.autoreverse, .repeat, .curveEaseInOut], animations: {
-                self.layer.opacity = 0.3
+            UIView.animate(withDuration: 0.7, delay: 0, options: [.autoreverse, .repeat, .curveEaseIn], animations: {
+                self.layer.opacity = 0.0
             }, completion: { [weak self] done in
                 // Attempt again, could be the window transitioning
                 if done {
@@ -70,6 +75,15 @@ class CaretView: UIView {
                 }
             })
         }
+    }
+    
+    func setText (ch: CharData) {
+        var res = NSAttributedString (
+            string: String (ch.getCharacter()),
+            attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor))
+        ctline = CTLineCreateWithAttributedString(res)
+
+        setNeedsDisplay(bounds)
     }
     
     func updateCursorStyle () {
@@ -102,13 +116,64 @@ class CaretView: UIView {
         }
     }
 
+    public var defaultCaretTextColor = UIColor.black
+    public var caretTextColor: UIColor = UIColor.black {
+        didSet {
+            updateView()
+        }
+    }
+
     func updateView() {
         let isFirst = self.superview?.isFirstResponder ?? true || true
         sub.frame = CGRect (origin: CGPoint.zero, size: layer.frame.size)
 
         sub.borderWidth = isFirst ? 0 : 2
         sub.borderColor = caretColor.cgColor
-        sub.backgroundColor = isFirst ? caretColor.cgColor : UIColor.clear.cgColor
+        bgColor = isFirst ? caretColor.cgColor : UIColor.clear.cgColor
+    }
+
+    override public func draw (_ dirtyRect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext () else {
+            return
+        }
+        UIColor.red.setFill()
+        context.fill([bounds])
+        drawCursor(in: context)
+    }
+    
+    func drawCursor (in context: CGContext) {
+        guard let ctline else {
+            return
+        }
+        guard let terminal else {
+            return
+        }
+        context.scaleBy (x: 1, y: -1)
+        context.translateBy(x: 0, y: -frame.height)
+
+        let lineDescent = CTFontGetDescent(terminal.fontSet.normal)
+        let lineLeading = CTFontGetLeading(terminal.fontSet.normal)
+        let yOffset = ceil(lineDescent+lineLeading)
+        
+        context.setFillColor(bgColor)
+        context.fill([bounds])
+        context.setFillColor(UIColor.black.cgColor)
+        for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
+            let runGlyphsCount = CTRunGetGlyphCount(run)
+            let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
+            let runFont = runAttributes[.font] as! TTFont
+            
+            let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
+                CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
+                count = runGlyphsCount
+            }
+            
+            var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
+                CGPoint(x: 0, y: yOffset)
+            }
+            CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
+
+        }
     }
 }
 #endif

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -79,7 +79,7 @@ class CaretView: UIView {
     func setText (ch: CharData) {
         let res = NSAttributedString (
             string: String (ch.getCharacter()),
-            attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor))
+            attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor ?? terminal?.nativeForegroundColor ?? TTColor.black))
         ctline = CTLineCreateWithAttributedString(res)
         setNeedsDisplay(bounds)
     }
@@ -107,8 +107,8 @@ class CaretView: UIView {
         }
     }
 
-    public var defaultCaretTextColor = UIColor.black
-    public var caretTextColor: UIColor = UIColor.black {
+    public var defaultCaretTextColor: UIColor? = nil
+    public var caretTextColor: UIColor? = nil {
         didSet {
             updateView()
         }

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -5,6 +5,11 @@
 //
 //  Created by Miguel de Icaza on 3/20/20.
 //
+// TODO for the branch: render the cursor in a distinctive shape
+// when the focus is gone.
+// Ensure the Mac also gets the proper blinking/underline feature
+// Bring to the Mac the updateANimation code from here, which is nicer
+
 #if os(iOS)
 import Foundation
 import UIKit
@@ -25,7 +30,8 @@ class CaretView: UIView {
         bgColor = caretColor.cgColor
         self.terminal = terminal
         super.init(frame: frame)
-        layer.addSublayer(sub)
+        //layer.addSublayer(sub)
+        layer.isOpaque = false
         isUserInteractionEnabled = false
         updateView()
     }
@@ -82,7 +88,6 @@ class CaretView: UIView {
             string: String (ch.getCharacter()),
             attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor))
         ctline = CTLineCreateWithAttributedString(res)
-
         setNeedsDisplay(bounds)
     }
     
@@ -136,44 +141,11 @@ class CaretView: UIView {
         guard let context = UIGraphicsGetCurrentContext () else {
             return
         }
-        UIColor.red.setFill()
-        context.fill([bounds])
-        drawCursor(in: context)
-    }
-    
-    func drawCursor (in context: CGContext) {
-        guard let ctline else {
-            return
-        }
-        guard let terminal else {
-            return
-        }
         context.scaleBy (x: 1, y: -1)
         context.translateBy(x: 0, y: -frame.height)
 
-        let lineDescent = CTFontGetDescent(terminal.fontSet.normal)
-        let lineLeading = CTFontGetLeading(terminal.fontSet.normal)
-        let yOffset = ceil(lineDescent+lineLeading)
-        
-        context.setFillColor(bgColor)
-        context.fill([bounds])
-        context.setFillColor(UIColor.black.cgColor)
-        for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
-            let runGlyphsCount = CTRunGetGlyphCount(run)
-            let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
-            let runFont = runAttributes[.font] as! TTFont
-            
-            let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
-                CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
-                count = runGlyphsCount
-            }
-            
-            var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
-                CGPoint(x: 0, y: yOffset)
-            }
-            CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
-
-        }
+        drawCursor(in: context)
     }
+
 }
 #endif

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -817,13 +817,13 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         set { caretView.caretColor = newValue }
     }
     
-    /// Controls the color for the caret
-    public var caretTextColor: UIColor {
+    /// Controls the color for the text in the caret when using a block cursor, if not set
+    /// the cursor will render with the foreground color
+    public var caretTextColor: UIColor? {
         get { caretView.caretTextColor }
         set { caretView.caretTextColor = newValue }
     }
 
-    
     var _selectedTextBackgroundColor = UIColor (red: 204.0/255.0, green: 221.0/255.0, blue: 237.0/255.0, alpha: 1.0)
     /// The color used to render the selection
     public var selectedTextBackgroundColor: UIColor {

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -817,6 +817,13 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         set { caretView.caretColor = newValue }
     }
     
+    /// Controls the color for the caret
+    public var caretTextColor: UIColor {
+        get { caretView.caretTextColor }
+        set { caretView.caretTextColor = newValue }
+    }
+
+    
     var _selectedTextBackgroundColor = UIColor (red: 204.0/255.0, green: 221.0/255.0, blue: 237.0/255.0, alpha: 1.0)
     /// The color used to render the selection
     public var selectedTextBackgroundColor: UIColor {

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1124,6 +1124,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         
         if code {
             caretView.disableAnimations()
+            caretView.updateView()
             keyRepeat?.invalidate()
             keyRepeat = nil
             

--- a/TerminalApp/MacTerminal/ViewController.swift
+++ b/TerminalApp/MacTerminal/ViewController.swift
@@ -136,6 +136,14 @@ class ViewController: NSViewController, LocalProcessTerminalViewDelegate, NSUser
         view.addSubview(terminal)
         logging = NSUserDefaultsController.shared.defaults.bool(forKey: "LogHostOutput")
         updateLogging ()
+        
+        #if DEBUG_MOUSE_FOCUS
+        var t = NSTextField(frame: NSRect (x: 0, y: 100, width: 200, height: 30))
+        t.backgroundColor = NSColor.white
+        t.stringValue = "Hello - here to test focus switching"
+        
+        view.addSubview(t)
+        #endif
     }
     
     override func viewWillDisappear() {

--- a/TerminalApp/iOSTerminal/ViewController.swift
+++ b/TerminalApp/iOSTerminal/ViewController.swift
@@ -95,6 +95,12 @@ class ViewController: UIViewController {
         setupKeyboardMonitor()
         tv.becomeFirstResponder()
         self.tv.feed(text: "Welcome to SwiftTerm - connecting to my localhost\r\n\n")
+        
+        var text = UITextField(frame: CGRect (x: 0, y: 100, width: 300, height: 20))
+        view.addSubview(text)
+        text.backgroundColor = UIColor.white
+        text.text = "HELLO WORLD"
+        text.font = UIFont(name: "Courier", size: 30)
     }
     
     override func viewWillLayoutSubviews() {


### PR DESCRIPTION
This solves a long-standing problem where block cursors hid the text underneath, a problem
that had been sort of masked with blinking, colors or underline/bar cursors, but they always 
bothered me.

Now we will respect the cursor background color, and allows themes to set the text color
when the cursor is highlighted - if not set, it defaults to the foreground color for the text.
