### PR TITLE
Use weak ref to fix crash when process exits after view is released

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -68,7 +68,7 @@ public class LocalProcess {
     var sendCount = 0
     var total = 0
 
-    unowned var delegate: LocalProcessDelegate?
+    weak var delegate: LocalProcessDelegate?
     
     // Queue used to send the data received from the local process
     var dispatchQueue: DispatchQueue


### PR DESCRIPTION
If a LocalProcess is terminated or exits right before the hosting LocalProcessTerminalView is released, the processTerminated call crashes the app with the following error:

```
Fatal error: Attempted to read an unowned reference but the object was already deallocated
```

All usages of delegate already have nil checks, so just change the variable from unowned to weak to fix the issue. There's no point in calling the delegate when it no longer exists.