### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,38 +7,34 @@ on:
     branches: [ main ]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+  # for testing
+  PYTHON_BIN: /usr/local/bin/python
 
 jobs:
   build:
 
     runs-on: macos-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Fixup url for submodules
-      run: perl -pi -e 's/git\@github.com:/https:\/\/github.com\//' .git/config .gitmodules
-  
-    - name: Submodule update
-      run: git submodule init; git submodule update --recursive
+    - uses: actions/checkout@v3
 
     - name: Checkout esctest for testing
-      run: git clone https://github.com/migueldeicaza/esctest.git
+      uses: actions/checkout@v3
+      with:
+        repository: migueldeicaza/esctest
+        path: esctest
 
     - name: List all files, because this is driving me insane, this does not repro anywhere but github
-      run: ls -lR 
+      run: ls -lR
 
     - name: Xcode Mac Build
-      #run: swift build -v
-      run: xcodebuild -project  TerminalApp/MacTerminal.xcodeproj -scheme MacTerminal
+      run: xcodebuild -project TerminalApp/MacTerminal.xcodeproj -scheme MacTerminal
 
     - name: Xcode iOS Build
       run: |
-      	   targetId=`xcrun xctrace list devices 2>&1 | grep '^iPhone' | sed -e 's/.*(//' -e 's/)//' | head -1`
-      	   xcodebuild -scheme iOSTerminal -workspace SwiftTerm.xcworkspace -destination "platform=iOS Simulator,id=targetId"
+        targetId=`xcrun xctrace list devices 2>&1 | sed -n -E '/^iPhone/s/.*\(|\)//gp' | head -1`
+        xcodebuild -project TerminalApp/iOSTerminal.xcodeproj -scheme iOSTerminal -destination "platform=iOS Simulator,id=$targetId"
 
     - name: Swift Package Build
       run: swift build -v

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Swift](https://github.com/migueldeicaza/SwiftTerm/actions/workflows/swift.yml/badge.svg)](https://github.com/migueldeicaza/SwiftTerm/actions/workflows/swift.yml)
 
 
 SwiftTerm
@@ -198,7 +199,3 @@ that was licensed under a license that allowed for maximum reuse.
 Mac
 * [Anders Borum](https://github.com/palmin) has contributed reliability fixes, the sixel parser and changes required to put SwiftTerm to use in production.
 * [Miguel de Icaza](https://tirania.org/) -me- who have been looking for an excuse to write some Swift code.
-
-This build is broken until GitHub installs the new Xcode:
-
-![Swift](https://github.com/migueldeicaza/SwiftTerm/workflows/Swift/badge.svg)

--- a/Tests/SwiftTermTests/SwiftTermTests.swift
+++ b/Tests/SwiftTermTests/SwiftTermTests.swift
@@ -18,7 +18,14 @@ final class SwiftTermTests: XCTestCase {
     var termConfig = "--expected-terminal xterm --xterm-checksum=334"
     var logfile = NSTemporaryDirectory() + "log"
     
-    func runTester (_ includeRegexp: String) -> String?
+    func python27Bin() -> String? {
+        guard let python27 = getenv("PYTHON_BIN") else {
+            return "/Users/miguel/bin/python2.7"
+        }
+        return String(validatingUTF8: python27)
+    }
+    
+    func runTester(_ includeRegexp: String) -> String?
     {
         let psem = DispatchSemaphore(value: 0)
         
@@ -26,7 +33,7 @@ final class SwiftTermTests: XCTestCase {
             Thread.sleep(forTimeInterval: 1)
             psem.signal ()
         }
-        let python27 = "/Users/miguel/bin/python2.7"
+        let python27 = python27Bin()!
         var args: [String] = ["--expected-terminal", "xterm", "--xterm-checksum=334", "--logfile", logfile]
         args += ["--include=\(includeRegexp)"]
         


### PR DESCRIPTION
And I want to confirm:

* Should disable pages-build-deployment action; it always fails since there is no longer "docs" directory.
* Why use your mirror esctest instead of the original repo for testing?
