### PR TITLE
fix: control combos without special mappings are eaten

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -927,7 +927,8 @@ extension TerminalView {
             case " ":
                 value = 0
             default:
-                return []
+                let chs = "\(arr[0])".compactMap { $0.asciiValue }
+                return [ 0x1B, 0x5B ] + chs + [ 0x3B, 0x35, 0x75 ]
             }
             return [value]
         }


### PR DESCRIPTION
This fixes the problem mentioned in Discussion #322 