### PR TITLE
Made terminal variable public, so custom implementation can be used

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -93,7 +93,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     var cellDimension: CellDimension!
     var caretView: CaretView!
-    var terminal: Terminal!
+    public var terminal: Terminal!
 
     var selection: SelectionService!
     private var scroller: NSScroller!


### PR DESCRIPTION
Fixes problem when you can subclass MacTerminalView and can subclass Terminal, but you can not initialize your "CustomMacTerminalView" with "CustomTerminal"