### PR TITLE
Fix for TerminalView growing out of bounds in Sonoma (#330)

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -161,6 +161,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         if isBigSur {
             disableFullRedrawOnAnyChanges = true
         }
+        if #available(macOS 14, *) {
+            self.clipsToBounds = true
+        }
         setupScroller()
         setupOptions()
         setupFocusNotification()


### PR DESCRIPTION
View clipping needs to be set explicitly in App/UIKit on Sonoma, see here: https://indiestack.com/2023/06/view-clipping-sonoma/

This PR just adds the flag to `TerminalView`'s `setup` function.