### PR TITLE
Fix Caret Drawing Artifacts

### DIFF
--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -16,12 +16,14 @@ extension CaretView {
         guard let terminal else {
             return
         }
+        context.saveGState()
+        context.clip(to: [bounds])
         context.setFillColor(TTColor.clear.cgColor)
         context.fill ([bounds])
         
         if !hasFocus {
             context.setStrokeColor(bgColor)
-            context.setLineWidth(2)
+            context.setLineWidth(3)
             context.stroke(bounds)
             return
         }
@@ -61,5 +63,6 @@ extension CaretView {
             }
             CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
         }
+        context.restoreGState()
     }
 }

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -85,6 +85,7 @@ class CaretView: NSView, CALayerDelegate {
     
     public var caretColor: NSColor = NSColor.selectedControlColor {
         didSet {
+            bgColor = caretColor.cgColor
             updateView()
         }
     }


### PR DESCRIPTION
Updates the caret drawing function to clip to it's bounds. Fixes a small visual bug where the unfocused box stuck around in the layer because it was never cleared due to it being outside the view's bounds. Fixes by first clearing the entire layer and then drawing.

Updates the macOS Caret background color when the color is set using the public variable. Fixes an issue where the caret color was not being used on macOS if it was changed after initialization.

**Screenshots**
Caret drawing is mostly the same, just that it's only drawing inside the bounds of the cell the cursor is in.

Caret drawing without patch, note leftover stroke artifacts from the unfocused box when focused:
![Screenshot 2024-08-08 at 10 27 27 AM](https://github.com/user-attachments/assets/9c6ee891-8717-48bb-8cae-9fab442a1b6d)
![Screenshot 2024-08-08 at 10 26 59 AM](https://github.com/user-attachments/assets/ae37365f-4b13-48f4-b0ae-aa456daa6297)
![Screenshot 2024-08-08 at 10 27 03 AM](https://github.com/user-attachments/assets/a500fd71-e0d8-4c8c-978b-27f83843b90b)
![Screenshot 2024-08-08 at 10 27 30 AM](https://github.com/user-attachments/assets/3f98a574-5e62-42ea-b22a-0fc816215bb1)


Caret drawing with patch:
macOS from CodeEdit
Focused, block
![Screenshot 2024-08-08 at 9 59 29 AM](https://github.com/user-attachments/assets/740feab0-7792-45e4-885c-ff986fc07db5)
![Screenshot 2024-08-08 at 9 59 25 AM](https://github.com/user-attachments/assets/dad4466c-1e03-4a0f-8e3b-335d88428a92)
Focused, underline
![Screenshot 2024-08-08 at 9 58 43 AM](https://github.com/user-attachments/assets/f6a6047c-5769-4dcf-901b-5a4bd6a05a1f)
![Screenshot 2024-08-08 at 9 58 40 AM](https://github.com/user-attachments/assets/ed808aff-fcef-4545-9aac-cc2e1b3770bf)
Focused, bar
![Screenshot 2024-08-08 at 9 58 32 AM](https://github.com/user-attachments/assets/86a84479-721f-437c-9a02-b5c7cbc6fadf)
Unfocused
![Screenshot 2024-08-08 at 9 59 33 AM](https://github.com/user-attachments/assets/0d2e8053-f829-4019-b3cb-0ab9254f7ea9)
![Screenshot 2024-08-08 at 9 59 38 AM](https://github.com/user-attachments/assets/e3fe784d-26cc-477d-b745-85004b82d2ae)
iOS from example SSH app
![IMG_8129](https://github.com/user-attachments/assets/8abad7a7-bc1d-48f8-9745-90209f58bd5a)
![IMG_8133](https://github.com/user-attachments/assets/18f200ce-99c2-41e0-8074-ac11d8a16659)
![IMG_8132](https://github.com/user-attachments/assets/a022f8f1-df11-4793-9151-93091af6f084)
![IMG_8131](https://github.com/user-attachments/assets/87b46775-e229-4dea-aa52-4b3752d888a6)

