### PR TITLE
Improved performance with large scrollback

### DIFF
--- a/Sources/SwiftTerm/BufferLine.swift
+++ b/Sources/SwiftTerm/BufferLine.swift
@@ -25,26 +25,26 @@ public class BufferLine: CustomDebugStringConvertible {
     var renderMode: RenderLineMode = .single
     lazy var data: [CharData] = {
         isDataInitialised = true
-        return Array(repeating: fillData, count: dataColumns)
+        return Array(repeating: fillCharacter, count: expectedDataSize)
     }()
     
     var isDataInitialised = false
-    private var fillData: CharData //used to initialise data
-    private var dataColumns: Int //used to initialise data
+    private var fillCharacter: CharData //used to initialise data
+    private var expectedDataSize: Int //used to initialise data
     
     var images: [TerminalImage]?
     
     public init (cols: Int, fillData: CharData? = nil, isWrapped: Bool = false)
     {
-        self.fillData = (fillData == nil) ? CharData.Null : fillData!
-        self.dataColumns = cols
+        self.fillCharacter = (fillData == nil) ? CharData.Null : fillData!
+        self.expectedDataSize = cols
         self.isWrapped = isWrapped
     }
     
     public init (from other: BufferLine)
     {
-        dataColumns = other.dataColumns
-        fillData = other.fillData
+        expectedDataSize = other.expectedDataSize
+        fillCharacter = other.fillCharacter
         isWrapped = other.isWrapped
         if other.isDataInitialised {
             data = other.data
@@ -58,7 +58,7 @@ public class BufferLine: CustomDebugStringConvertible {
             if self.isDataInitialised {
                 return data.count
             } else {
-                return self.dataColumns
+                return self.expectedDataSize
             }
         }
     }
@@ -164,8 +164,8 @@ public class BufferLine: CustomDebugStringConvertible {
     public func resize (cols: Int, fillData: CharData)
     {
         if !self.isDataInitialised {
-            self.dataColumns = cols
-            self.fillData = fillData
+            self.expectedDataSize = cols
+            self.fillCharacter = fillData
             return
         }
         


### PR DESCRIPTION
Improved performance for terminal will large scrollback values (over 10000 lines), so memory will not be allocated for buffers that are not used

- Implemented optimisation for BufferLine, so data array will not be allocated until it is needed
- modified resize method to be more efficient if data are not allocated yet


Problem background:
During initialization and window resize Terminal will call resize method for each buffer line during which triggers memory reallocation of BufferLine.data. This operation becomes bottleneck with terminal scrollback > 10000.

<img width="588" alt="Screenshot 2024-12-02 at 17 57 25" src="https://github.com/user-attachments/assets/7cf10527-f7d3-4530-8880-996c24c5efc7">


Implemented fix takes into account that most of the buffers will contains only blank charactes (until something useful will be printed into it) and can be lazy allocated using known fillCharacter and expectedDataSize. In this case resize method will be as simple as updating expectedDataSize value.


 