### PR TITLE
Fixed CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -32,9 +32,7 @@ jobs:
       run: xcodebuild -project TerminalApp/MacTerminal.xcodeproj -scheme MacTerminal
 
     - name: Xcode iOS Build
-      run: |
-        targetId=`xcrun xctrace list devices 2>&1 | sed -n -E '/^iPhone/s/.*\(|\)//gp' | head -1`
-        xcodebuild -project TerminalApp/iOSTerminal.xcodeproj -scheme iOSTerminal -destination "platform=iOS Simulator,id=$targetId"
+      run: xcodebuild -project TerminalApp/iOSTerminal.xcodeproj -scheme iOSTerminal -destination generic/platform='iOS Simulator' EXCLUDED_ARCHS="arm64"
 
     - name: Swift Package Build
       run: swift build -v

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
   # for testing
   PYTHON_BIN: /usr/local/bin/python
 


### PR DESCRIPTION
- bumped xcode version to 15.4, since 14.2 is not available on macos-latest (mac os 15) runner
- fixed iOS simulator build.: disabled arm64 architecture build, since SwiftSH does not supports it