### PR TITLE
Fix terminal clear on resize

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1121,7 +1121,7 @@ extension TerminalView {
     {
         terminal.resize (cols: cols, rows: rows)
         sizeChanged (source: terminal)
-        terminal.resetToInitialState()
+        terminal.softReset()
     }
     
     /**


### PR DESCRIPTION
On resize in iOS, terminal would clear which is a problem. Replaced hard reset with soft reset as suggested in https://github.com/migueldeicaza/SwiftTerm/discussions/366
