### PR TITLE
Add support for setting child process working directory in LocalProcess

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -188,7 +188,7 @@ public class LocalProcess {
      * - Parameter environment: an array of environment variables to pass to the child process, if this is null, this picks a good set of defaults from `Terminal.getEnvironmentVariables`.
      * - Parameter execName: If provided, this is used as the Unix argv[0] parameter, otherwise, the executable is used as the args [0], this is used when the intent is to set a different process name than the file that backs it.
      */
-    public func startProcess(executable: String = "/bin/bash", args: [String] = [], environment: [String]? = nil, execName: String? = nil)
+    public func startProcess(executable: String = "/bin/bash", args: [String] = [], environment: [String]? = nil, execName: String? = nil, currentDirectory: String? = nil)
      {
         if running {
             return
@@ -208,8 +208,8 @@ public class LocalProcess {
         } else {
             env = environment!
         }
-        
-        if let (shellPid, childfd) = PseudoTerminalHelpers.fork(andExec: executable, args: shellArgs, env: env, desiredWindowSize: &size) {
+
+        if let (shellPid, childfd) = PseudoTerminalHelpers.fork(andExec: executable, args: shellArgs, env: env, currentDirectory: currentDirectory, desiredWindowSize: &size) {
             childMonitor = DispatchSource.makeProcessSource(identifier: shellPid, eventMask: .exit, queue: dispatchQueue)
             if let cm = childMonitor {
                 if #available(macOS 10.12, *) {

--- a/Sources/SwiftTerm/Pty.swift
+++ b/Sources/SwiftTerm/Pty.swift
@@ -65,7 +65,7 @@ public class PseudoTerminalHelpers {
      *
      * - Returns: nil on error, or a tuple containing the process ID, and the file descriptor to the primary side of the newly created pseudo-terminal.
      */
-    public static func fork (andExec: String, args: [String], env: [String], desiredWindowSize: inout winsize) -> (pid: pid_t, masterFd: Int32)?
+    public static func fork (andExec: String, args: [String], env: [String], currentDirectory: String? = nil, desiredWindowSize: inout winsize) -> (pid: pid_t, masterFd: Int32)?
     {
         var master: Int32 = 0
         
@@ -74,6 +74,12 @@ public class PseudoTerminalHelpers {
             return nil
         }
         if pid == 0 {
+            if let currentDirectory {
+                _ = currentDirectory.withCString { p in
+                    chdir(p)
+                }
+            }
+            
             withArrayOfCStrings(args, { pargs in
                 withArrayOfCStrings(env, { penv in
                     let _ = execve(andExec, pargs, penv)


### PR DESCRIPTION
Allows specifying a custom currentDirectory when launching a process. Modifies PseudoTerminalHelpers.fork to accept an optional working directory parameter and calls chdir() before execve().

LocalProcess.startProcess() now propagates this new parameter.