### PR TITLE
Consider Buffer Y Offset In Mouse Hit

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -881,13 +881,18 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     func calculateMouseHit (with event: NSEvent) -> (grid: Position, pixels: Position)
     {
+        let point = convert(event.locationInWindow, from: nil)
+        return calculateMouseHit(at: point)
+    }
+
+    func calculateMouseHit (at point: CGPoint) -> (grid: Position, pixels: Position)
+    {
         func toInt (_ p: NSPoint) -> Position {
-            
+
             let x = min (max (p.x, 0), bounds.width)
             let y = min (max (p.y, 0), bounds.height)
             return Position (col: Int (x), row: Int (bounds.height-y))
         }
-        let point = convert(event.locationInWindow, from: nil)
         let col = Int (point.x / cellDimension.width)
         let row = Int ((frame.height-point.y) / cellDimension.height) + terminal.buffer.yDisp
         if row < 0 {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -889,11 +889,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
         let point = convert(event.locationInWindow, from: nil)
         let col = Int (point.x / cellDimension.width)
-        let row = Int ((frame.height-point.y) / cellDimension.height)
+        let row = Int ((frame.height-point.y) / cellDimension.height) + terminal.buffer.yDisp
         if row < 0 {
             return (Position(col: 0, row: 0), toInt (point))
         }
-        return (Position(col: min (max (0, col), terminal.cols-1), row: min (row, terminal.rows-1)), toInt (point))
+        return (Position(col: min (max (0, col), terminal.cols-1), row: row), toInt (point))
     }
     
     private func sharedMouseEvent (with event: NSEvent)

--- a/Tests/SwiftTermTests/SelectionTests.swift
+++ b/Tests/SwiftTermTests/SelectionTests.swift
@@ -38,4 +38,20 @@ final class SelectionTests: XCTestCase, TerminalDelegate {
         selection.selectWordOrExpression(at: Position (col: 0, row: -1), in: terminal.buffer)
 
     }
+
+    func testMouseHitCorrectWhenScrolled() {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 10, height: 10)))
+
+        for _ in 0..<100 {
+            view.terminal.feed (text: "12345")
+        }
+
+        // Scroll all the way down, check the bottom-left corner
+        view.scrollTo(row: 100)
+        XCTAssertEqual(view.calculateMouseHit(at: CGPoint(x: 0, y: 0)).grid.row, 100)
+
+        // Scroll all the way back up, check the top-left corner
+        view.scrollTo(row: 1)
+        XCTAssertEqual(view.calculateMouseHit(at: CGPoint(x: 0, y: 10)).grid.row, 1)
+    }
 }

--- a/Tests/SwiftTermTests/SelectionTests.swift
+++ b/Tests/SwiftTermTests/SelectionTests.swift
@@ -39,7 +39,10 @@ final class SelectionTests: XCTestCase, TerminalDelegate {
 
     }
 
-    func testMouseHitCorrectWhenScrolled() {
+#if os(macOS)
+    // Test only on macOS due to differences in how frames are handled on mac and iOS
+    func testMouseHitCorrectWhenScrolled()
+    {
         let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 10, height: 10)))
 
         for _ in 0..<100 {
@@ -54,4 +57,5 @@ final class SelectionTests: XCTestCase, TerminalDelegate {
         view.scrollTo(row: 1)
         XCTAssertEqual(view.calculateMouseHit(at: CGPoint(x: 0, y: 10)).grid.row, 1)
     }
+#endif
 }


### PR DESCRIPTION
Fixes a bug where selecting text when the terminal was scrolled would select the text as if the terminal was not scrolled.

Before: 

https://github.com/user-attachments/assets/7446776b-fbe2-4176-a756-09c1fadf2dad

With changes:

https://github.com/user-attachments/assets/fe38189b-0a19-4c0e-a46d-b22666090832

