### PR TITLE
Update Scroller When Exists - Fix Layout Exception

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -303,13 +303,14 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     func setupScroller()
     {
-        if scroller != nil {
-            scroller.removeFromSuperview()
-        }
-
         let style: NSScroller.Style = .legacy
         let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: style)
-        scroller = NSScroller(frame: NSRect(x: bounds.maxX - scrollerWidth, y: 0, width: scrollerWidth, height: bounds.height))
+        let scrollerFrame = NSRect(x: bounds.maxX - scrollerWidth, y: 0, width: scrollerWidth, height: bounds.height)
+        if scroller == nil {
+            scroller = NSScroller(frame: scrollerFrame)
+        } else {
+            scroller?.frame = scrollerFrame
+        }
         scroller.autoresizingMask = [.minXMargin, .height]
         scroller.scrollerStyle = style
         scroller.knobProportion = 0.1


### PR DESCRIPTION
Fixes a layout exception due to the removal of the scroller during constraint layout. This happened when the view was embedded in a SwiftUI view and SwiftUI attempted to update its frame, which caused the scroller to be removed from the view hierarchy which is illegal.

To fix I just removed the removal of the old scroller and updated its frame if it's not `nil`. This avoids a view tree update and still updates the scroller's position and size.