### PR TITLE
Fix Selected Text

### DIFF
--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -527,7 +527,17 @@ class SelectionService: CustomDebugStringConvertible {
     }
     
     public func getSelectedText () -> String {
-        let r = terminal.getText(start: self.start, end: self.end)
+        let min = if Position.compare(start, end) == .before {
+            start
+        } else {
+            end
+        }
+        let max = if Position.compare(start, end) == .after {
+            end
+        } else {
+            start
+        }
+        let r = terminal.getText(start: min, end: max)
         return r
     }
     


### PR DESCRIPTION
The selection service's start/end positions can be reversed (usually when dragging backwards in the text). This orders the start/end positions before calling `terminal.getText`.