### PR TITLE
fix wrong selection range in scroll mode

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -895,7 +895,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             return Position (col: Int (x), row: Int (bounds.height-y))
         }
         let col = Int (point.x / cellDimension.width)
-        let row = Int ((frame.height-point.y) / cellDimension.height) + terminal.buffer.yDisp
+        let row = Int ((frame.height-point.y) / cellDimension.height)
         if row < 0 {
             return (Position(col: 0, row: 0), toInt (point))
         }


### PR DESCRIPTION
The display offset is incorrectly added to selection range, if the buffer line is larger than actual display height (display offset large than 0), the row selected is the actual row plus display offset.

Stop adding the offset, so the row selected is the row mouse pointed at.