### PR TITLE
Fix a build issue on LocalProcess with Environment

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -292,7 +292,7 @@ public class LocalProcess {
                     let result = try await Subprocess.run(
                         .name(executable),
                         arguments: Arguments(executablePathOverride: execName ?? executable, remainingValues: Array(args)),
-                        environment: .custom(env),
+                        environment: .custom(Dictionary(uniqueKeysWithValues: env.map { (Environment.Key(stringLiteral: $0.key), $0.value) })),
                         workingDirectory: currentDirectory.map { System.FilePath($0) },
                         platformOptions: options,
                         input: .fileDescriptor(slaveFileDescriptor, closeAfterSpawningProcess: true),


### PR DESCRIPTION
Build was failing on LocalProcess L495 with `Cannot convert value of type '[String : String]' to expected argument type '[Environment.Key : String]'`