### PR TITLE
Fix for visionOS compatibility

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTextStorage.swift
+++ b/Sources/SwiftTerm/iOS/iOSTextStorage.swift
@@ -83,7 +83,7 @@ class TextSelectionRect: UITextSelectionRect {
   let _containsStart: Bool
   let _containsEnd: Bool
   
-  override var writingDirection: UITextWritingDirection {
+  override var writingDirection: NSWritingDirection {
     return .leftToRight
   }
   


### PR DESCRIPTION
UITextWritingDirection is deprecated and is now an alias to NSWritingDirection. However, that alias is not available on visionOS.