### PR TITLE
Allow keyboard input on iOS for languages with multi-char input (Japanese, Chinese, Korean, Hindi)

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1330,8 +1330,14 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
                 } else if key.modifierFlags.contains (.alternate) && optionAsMetaKey {
                     data = .text("\u{1b}\(key.charactersIgnoringModifiers)")
                 } else if !key.modifierFlags.contains (.command){
-                    if key.characters.count > 0 {
-                        data = .text (key.characters)
+                    if let keyboardLanguage = self.textInputMode?.primaryLanguage {
+                        // Is the keyboard language one of the multi-input languages? Chinese, Japanese, Korean and Hindi-Transliteration
+                        // If so, do not process the input yet (we'll do it later in unmarkText())
+                        if (!keyboardLanguage.hasPrefix("hi") && !keyboardLanguage.hasPrefix("zh") && !keyboardLanguage.hasPrefix("ja") && !keyboardLanguage.hasPrefix("ko")) {
+                            if key.characters.count > 0 {
+                                data = .text (key.characters)
+                            }
+                        }
                     }
                 }
             }

--- a/Sources/SwiftTerm/iOS/iOSTextInput.swift
+++ b/Sources/SwiftTerm/iOS/iOSTextInput.swift
@@ -188,6 +188,13 @@ extension TerminalView: UITextInput {
     public func unmarkText() {
         uitiLog("unmarkText() textInputStorage:\"\(String(textInputStorage))\" count:\(textInputStorage.count) marked:\(_markedTextRange?.description ?? "nil") selected:\(_selectedTextRange.description)")        
         if let previouslyMarkedRange = _markedTextRange {
+            // Ensure that multi-char input (Chinese-Japanese keyboards) works:
+            if let previouslyMarkedText = text(in: previouslyMarkedRange) {
+                if previouslyMarkedText.count > 0 {
+                    insertText(previouslyMarkedText)
+                }
+            }
+            //
             let rangeEndPosition = previouslyMarkedRange.endPosition
             _selectedTextRange = TextRange(from: rangeEndPosition, to: rangeEndPosition)
             _markedTextRange = nil


### PR DESCRIPTION
This is potential fix for #407 (entering Chinese, Japanese, Korean ... characters from the keyboard on iOS), with a minimal set of changes to the code.

It works in two steps: 
- in `iOS/iOSTerminalView.swift`, do not treat the keyboard event if the keyboard language is one of "ja", "zh", "hi" or "ko", and let the system handle it.
- in `iOS/iOSTextInput.swift`, when the user has clicked on a character or group of characters, `unmarkText()` is called and we get the string to insert from `_markedRange`.

The languages themselves work in different ways: Chinese and Japanese will bring a menu with a set of choices, depending on what the user has typed, while Korean with send an "deleteBackward()" event when two characters should be combined (type "d" followed by "n" on a US external keyboard to see what I mean, or use an on-screen Korean iOS keyboard and type "ㅇ" followed by "ㅜ". The result should be: "우").

There is another language with a specific input method, "Tiếng Việt Télex", and that one is still not working with these changes. The way it works (in other apps, like Pages) is that you type "Tieng Viet Telex" and iOS adds the diacritics depending on the context. But *how* that works is still a mystery for me (there are no keyboard events visible).