### PR TITLE
Rendering emojis and wide characters on iOS

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -724,7 +724,8 @@ extension TerminalView {
                     let rect = CGRect (origin: origin, size: size)
                     #if os(macOS)
                     rect.applying(transform).fill(using: .destinationOver)
-                    #else
+                    #elseif (false)
+                    // iOS: do not clear the background so characters are well rendered:
                     context.fill(rect.applying(transform))
                     #endif
                     context.restoreGState()

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -1200,7 +1200,12 @@ open class Terminal {
 
             if let firstScalar = ch.unicodeScalars.first {
                 // If this is a Unicode combining character
-                if firstScalar.properties.canonicalCombiningClass != .notReordered {
+                var alwaysCombine = false
+                #if os(iOS)
+                // iOS specificity: always go through this loop for combine Unicode
+                alwaysCombine = true
+                #endif
+                if alwaysCombine || firstScalar.properties.canonicalCombiningClass != .notReordered {
                     // Determine if the last time we poked at a character is still valid
                     let last = buffer.lastBufferStorage
                     if last.cols == cols && last.rows == rows {


### PR DESCRIPTION
This is more a Request For Comment than a fully formed Pull Request. 

It solves my two issues with emojis and wide characters (#341 and #406), with minimal changes to the code, but not in the most elegant way. Those lines must have been there for a reason, but the only thing that works for me is to deactivate them.

#341 : compose emojis. Deactivate the line ` if firstScalar.properties.canonicalCombiningClass != .notReordered {` in `Sources/SwiftTerm/Terminal.swift` for iOS. On the iOS emoji keyboard, you can have a combined emoji whose first character is `notReordered` and must still be combined (🖐🏾 = combine + 🖐️ + skin color modifier, for example).

#406 : white squares on wide characters. The only solution that works on iOS is to deactivate the line `context.fill(rect.applying(transform))` in `Apple/AppleTerminalView.swift`, but this might have some side effects.

My goal is to help others who encounter similar issues with a quick workaround, until you have a better solution in the code.