### PR TITLE
Fix: getSelectedText() incorrectly calculates max position

### DIFF
--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -532,7 +532,7 @@ class SelectionService: CustomDebugStringConvertible {
         } else {
             end
         }
-        let max = if Position.compare(start, end) == .after {
+        let max = if Position.compare(start, end) == .before {
             end
         } else {
             start


### PR DESCRIPTION
## Problem

`getSelectedText()` in `SelectionService.swift` always returns an empty string, making text selection non-functional.

## Root Cause

The `max` position calculation has an inverted condition:

```swift
// Bug: Checking for .after when it should check for .before
let max = if Position.compare(start, end) == .after {
    end
} else {
    start
}
```

When `start=(25,1)` and `end=(28,1)`:
- `Position.compare(start, end)` returns `.before` (start is before end)
- The condition `.after` is false, so `max = start = (25,1)`
- This makes `min == max`, causing `getSelectedLines()` to return early with empty result

## Fix

Change the condition from `.after` to `.before`:

```swift
let max = if Position.compare(start, end) == .before {
    end
} else {
    start
}
```

Now when start is before end, max correctly equals end.

## Testing

Tested with a macOS terminal app using SwiftTerm:
- Mouse text selection now works correctly
- Cmd+C copies selected text
- Middle-click paste works