### PR TITLE
Fix: macOS background color rendering using incorrect color

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -766,6 +766,9 @@ extension TerminalView {
                             }
                             
                             #if os(macOS)
+                            // NSRect.fill() uses NSColor (set via NSColor.set()/setFill()),
+                            // not CGContext's fill color. Must call setFill() before fill().
+                            backgroundColor.setFill()
                             rect.fill(using: .destinationOver)
                             #else
                             context.fill(rect)


### PR DESCRIPTION
On macOS, NSRect.fill(using:) uses NSColor (set via NSColor.set() or setFill()), not the CGContext's fill color that was set via context.setFillColor().

This caused background colors to be rendered incorrectly - for example, when running `ls --color` in a terminal, files that should have colored foreground text would instead appear with that color as background.

The fix adds backgroundColor.setFill() before calling rect.fill() to ensure the correct NSColor is used for background rendering.