### PR TITLE
MacLocalTerminalView: Add currentDirectory parameter to startProcess()

### DIFF
--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -156,10 +156,11 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
      * - Parameter args: an array of strings that is passed as the arguments to the underlying process
      * - Parameter environment: an array of environment variables to pass to the child process, if this is null, this picks a good set of defaults from `Terminal.getEnvironmentVariables`.
      * - Parameter execName: If provided, this is used as the Unix argv[0] parameter, otherwise, the executable is used as the args [0], this is used when the intent is to set a different process name than the file that backs it.
+     * - Parameter currentDirectory: If provided, the process will be launched with this as the current working directory.
      */
-    public func startProcess(executable: String = "/bin/bash", args: [String] = [], environment: [String]? = nil, execName: String? = nil)
+    public func startProcess(executable: String = "/bin/bash", args: [String] = [], environment: [String]? = nil, execName: String? = nil, currentDirectory: String? = nil)
     {
-        process.startProcess(executable: executable, args: args, environment: environment, execName: execName)
+        process.startProcess(executable: executable, args: args, environment: environment, execName: execName, currentDirectory: currentDirectory)
     }
 
     /**


### PR DESCRIPTION
The underlying `LocalProcess.startProcess()` already supports a `currentDirectory` parameter for specifying the working directory when launching a process, but `MacLocalTerminalView.startProcess()` did not expose this parameter.

This required users to access the internal `process` property directly:

```swift
// Required workaround:
terminalView.process.startProcess(executable: shell, args: ["--login"], currentDirectory: homeDir)
```

With this change, the API is consistent:

```swift
// Clean API:
terminalView.startProcess(executable: shell, args: ["--login"], currentDirectory: homeDir)
```

**Changes:**
- Added `currentDirectory: String? = nil` parameter to `MacLocalTerminalView.startProcess()`
- Updated documentation to describe the new parameter
- Passes the parameter through to the underlying `process.startProcess()` call

**Use case:** When building a terminal app that should start the shell in a specific directory (e.g., user's home directory rather than the app's working directory), this parameter allows clean configuration without accessing internal properties.