### PR TITLE
Improved management of multi-char keyboards (Vietnamese and Korean)

### DIFF
--- a/Sources/SwiftTerm/Utilities.swift
+++ b/Sources/SwiftTerm/Utilities.swift
@@ -159,8 +159,8 @@ struct UnicodeUtil {
         LH (lo: 0x26ce, hi: 0x26ce),
         // ⛔
         LH (lo: 0x26d4, hi: 0x26d4),
-        // ⛩️ ⛪
-        LH (lo: 0x26e9, hi: 0x26ea),
+        // ⛪
+        LH (lo: 0x26ea, hi: 0x26ea),
         //
         LH (lo: 0x26f2, hi: 0x26f5),
         // ⛺


### PR DESCRIPTION
These changes improve upon PR #409 in the following way: 
- allow Vietnamese keyboard input (Tiếng Việt Telex). To test: 
    - activate the Tiếng Việt Telex keyboard
    - type R a s t [space] v u i [space] d d u w o j c [space] g a j w p [space] b a j n
    - observe on screen: Rất vui được gặp bạn
    - see e.g. https://vietnameselab.com/blog/vietnamese-typing for example for more information.

- improve Korean keybard input. To test:
    - activate Korean keyboard
    - type ㅇ ㅜ ㅇ
    - observe 웅 (that one wasn't working with #409, but I didn't detect it because, well, I'm not good in Korean).
    
The way these work is by calling `resetInputBuffer()` after every text insertion in `insertText()`, but only for Vietnamese and Korean keyboards. I tried enabling it for other multi-char keyboards (Japanese), but it causes a crash elsewhere (which may be due to a different issue, but we'll deal with it later).