### PR TITLE
Fix auto-scroll and SIGINT/Ctrl+C on macOS

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess",
+      "state" : {
+        "branch" : "main",
+        "revision" : "426790f3f24afa60b418450da0afaa20a8b3bdd4"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -233,7 +233,11 @@ public class LocalProcess {
             return
         }
         
-        #if canImport(Subprocess)
+        // Force forkpty on macOS for proper controlling terminal (SIGINT) support
+        // The Subprocess path doesn't set up a controlling terminal, breaking Ctrl+C
+        #if os(macOS)
+        startProcessWithForkpty(executable: executable, args: args, environment: environment, execName: execName, currentDirectory: currentDirectory)
+        #elseif canImport(Subprocess)
         startProcessWithSubprocess(executable: executable, args: args, environment: environment, execName: execName, currentDirectory: currentDirectory)
         #else
         startProcessWithForkpty(executable: executable, args: args, environment: environment, execName: execName, currentDirectory: currentDirectory)


### PR DESCRIPTION
This PR contains two fixes for macOS:

  ## 1. Fix auto-scroll timer for drag selection

  When drag-selecting text past the terminal edges, the view should auto-scroll. This fix addresses multiple issues:

  1. Added timer management:
     - autoScrollTimer property to hold the timer reference
     - startAutoScrollTimer() to create timer with .common run loop mode
     - stopAutoScrollTimer() to invalidate and clean up
     - Timer start/stop calls in mouseDragged() and cleanup in mouseUp()

  2. Fixed scroll direction in scrollingTimerElapsed():
     - Was calling scrollUp() in both branches
     - Now correctly calls scrollDown() when autoScrollDelta > 0

  3. Added selection extension during scroll:
     - Calls selection.dragExtend() after scrolling to include newly visible rows

  4. Fixed scroll-down detection in mouseDragged():
     - calculateMouseHit() clamps row to valid range, so scroll-down condition was never triggered
     - Now uses raw pixel coordinates from mouse event to detect when mouse is outside view bounds

  Uses .common run loop mode to ensure timer fires during mouse tracking.

  ---

  ## 2. Fix SIGINT/Ctrl+C by forcing forkpty on macOS

  ### Problem

  On modern macOS with swift-subprocess available, `LocalProcess.startProcess()` uses the `startProcessWithSubprocess()` path. This breaks Ctrl+C (SIGINT) because:

  1. The Subprocess path uses `POSIX_SPAWN_SETSID` which creates a new session **without a controlling terminal**
  2. Without a controlling terminal, the kernel's line discipline doesn't convert ETX (0x03) to SIGINT
  3. `tcgetpgrp(childfd)` returns -1 (ENOTTY) because there's no controlling terminal
  4. `shellPid` is never set in the Subprocess path (remains 0)

  The result: pressing Ctrl+C shows `^C` but doesn't interrupt the running process.

  ### Solution

  Force the `forkpty` path on macOS. The `forkpty` function internally calls `login_tty()` which:
  - Calls `setsid()` to create a new session
  - Calls `ioctl(TIOCSCTTY)` to set the PTY slave as the controlling terminal
  - Properly sets up stdin/stdout/stderr

  This is a minimal change - just a `#if os(macOS)` conditional to prefer `forkpty` on macOS while preserving the Subprocess path for other platforms.

  ### Testing

  1. Run a terminal with SwiftTerm on macOS
  2. Execute `sleep 100`
  3. Press Ctrl+C
  4. **Before fix**: `^C` appears but sleep continues
  5. **After fix**: Process terminates immediately, `echo $?` shows 130 (128 + signal 2)

  ### References

  - [The TTY demystified](https://www.linusakesson.net/programming/tty/) - Explains controlling terminal requirements
  - [PTY man page](https://man7.org/linux/man-pages/man7/pty.7.html) - Documents signal generation requirements
