### PR TITLE
fix: Add periodic Kitty image garbage collection during scroll

### DIFF
--- a/Sources/SwiftTerm/KittyGraphics.swift
+++ b/Sources/SwiftTerm/KittyGraphics.swift
@@ -1703,7 +1703,9 @@ extension Terminal {
         return right >= screenLeft && left <= screenRight && bottom >= screenTop && top <= screenBottom
     }
 
-    private func cleanupUnusedKittyImages() {
+    /// Removes images from `imagesById` that are no longer referenced by any buffer line.
+    /// Called periodically during scroll to prevent memory accumulation.
+    func cleanupUnusedKittyImages() {
         var used = Set<UInt32>()
         collectUsedKittyImageIds(from: normalBuffer, into: &used)
         collectUsedKittyImageIds(from: altBuffer, into: &used)


### PR DESCRIPTION
Problem:
When using Kitty graphics protocol, orphan images accumulate in `kittyGraphicsState.imagesById` because `cleanupUnusedKittyImages()` is only called on explicit delete commands.

During long-running terminal sessions with heavy output (e.g., CI/CD logs, AI agent sessions), this causes memory to grow unbounded. Observed: 11GB+ memory usage, terminal freeze, inability to scroll.

Solution:
- Add counter-based garbage collection in `scroll()`
- Track lines scrolled since last cleanup
- Trigger `cleanupUnusedKittyImages()` every 500 lines when buffer is trimmed
- Change function visibility from `private` to `internal`

Results:
- Memory usage reduced from 11GB+ to ~400MB (96%+ improvement)
- Terminal remains responsive during long sessions