### PR TITLE
Exclude Mac/README.md from package target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 #if os(Linux) || os(Windows)
 let platformExcludes = ["Apple", "Mac", "iOS"]
 #else
-let platformExcludes: [String] = []
+let platformExcludes = ["Mac/README.md"]
 #endif
 
 #if os(Windows)


### PR DESCRIPTION
## Summary
- While building another project that uses SwiftTerm I get an error: 
```
warning: 'swiftterm': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
.../.build/checkouts/SwiftTerm/Sources/SwiftTerm/Mac/README.md
```

- Adds `Mac/README.md` to the excludes list on non-Linux/Windows platforms to remove this warning.

## Test plan
- [x] Build succeeds locally without warning

🤖 co-Generated with [Claude Code](https://claude.com/claude-code)