### PR TITLE
Add support for SGR 2 dim/faint text attribute

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -390,7 +390,11 @@ extension TerminalView {
             tf = fontSet.normal
         }
         
-        let fgColor = mapColor (color: fg, isFg: true, isBold: isBold, useBrightColors: useBrightColors)
+        var fgColor = mapColor (color: fg, isFg: true, isBold: isBold, useBrightColors: useBrightColors)
+        // Apply dim/faint attribute (SGR 2) - reduce color intensity
+        if flags.contains(.dim) {
+            fgColor = fgColor.dimmedColor()
+        }
         var nsattr: [NSAttributedString.Key:Any] = [
             .font: tf,
             .foregroundColor: fgColor,

--- a/Sources/SwiftTerm/Mac/MacExtensions.swift
+++ b/Sources/SwiftTerm/Mac/MacExtensions.swift
@@ -23,10 +23,24 @@ extension NSColor {
         guard let color = self.usingColorSpace(.deviceRGB) else {
             return self
         }
-        
+
         var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
         color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         return NSColor(calibratedRed: 1.0 - red, green: 1.0 - green, blue: 1.0 - blue, alpha: alpha)
+    }
+
+    /// Returns a dimmed version of the color (for SGR 2 faint/dim text attribute)
+    /// Reduces the color intensity by approximately 50%
+    func dimmedColor() -> NSColor {
+        guard let color = self.usingColorSpace(.deviceRGB) else {
+            return self
+        }
+
+        var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        // Dim by reducing brightness to ~50% (blend toward black)
+        let dimFactor: CGFloat = 0.5
+        return NSColor(calibratedRed: red * dimFactor, green: green * dimFactor, blue: blue * dimFactor, alpha: alpha)
     }
 
     static func make (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> NSColor

--- a/Sources/SwiftTerm/iOS/iOSExtensions.swift
+++ b/Sources/SwiftTerm/iOS/iOSExtensions.swift
@@ -25,6 +25,16 @@ extension UIColor {
         return UIColor (red: 1.0 - red, green: 1.0 - green, blue: 1.0 - blue, alpha: alpha)
     }
 
+    /// Returns a dimmed version of the color (for SGR 2 faint/dim text attribute)
+    /// Reduces the color intensity by approximately 50%
+    func dimmedColor() -> UIColor {
+        var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        // Dim by reducing brightness to ~50% (blend toward black)
+        let dimFactor: CGFloat = 0.5
+        return UIColor(red: red * dimFactor, green: green * dimFactor, blue: blue * dimFactor, alpha: alpha)
+    }
+
     static func make (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> TTColor
     {
         


### PR DESCRIPTION
## Summary

This PR adds rendering support for the ANSI SGR code 2 (dim/faint) text attribute. The attribute was already being parsed in `Terminal.swift` (line 3398 sets the `.dim` flag), but the rendering in `getAttributes()` was not applying any visual change.

## Changes

1. Added `dimmedColor()` method to `NSColor` extension (MacExtensions.swift)
2. Added `dimmedColor()` method to `UIColor` extension (iOSExtensions.swift)  
3. Modified `getAttributes()` in AppleTerminalView.swift to check for `.dim` flag and apply dimming

## Implementation

The dim effect reduces color intensity by approximately 50%, which matches the behavior of other terminal emulators like iTerm2 and macOS Terminal.

## Use Case

Claude Code (Anthropic's terminal-based AI coding assistant) uses the dim attribute for its "suggested prompt" feature, which displays placeholder text that users can accept. Without this fix, the dim text appears as full-brightness white instead of the expected gray/dimmed appearance.

## Testing

Tested with:
- Claude Code's suggested prompt feature (dim text now renders correctly as gray)
- Manual ANSI escape sequences: `echo -e "\033[2mDim text\033[0m Normal text"`