### PR TITLE
Push window-size changes to the child process group and handle the swift-subprocess path

### DIFF
--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -98,8 +98,7 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
         guard process.running else {
             return
         }
-        var size = getWindowSize()
-        let _ = PseudoTerminalHelpers.setWinSize(masterPtyDescriptor: process.childfd, windowSize: &size)
+        process.updateWindowSize()
         
         processDelegate?.sizeChanged (source: self, newCols: newCols, newRows: newRows)
     }


### PR DESCRIPTION
This commit contains the following changes:
- added a single resize path that updates the PTY size and sends SIGWINCH, in Sources/SwiftTerm/LocalProcess.swift.
- hooked terminal view resize to that new path in Sources/SwiftTerm/Mac/MacLocalTerminalView.swift.
- captured the subprocess PID when using swift-subprocess, so SIGWINCH can be delivered in that path too.

As a result of these changes, $COLUMNS/$LINES can be updated correctly when terminal view is being resized.