### PR TITLE
Fix terminal freeze caused by broken DispatchIO read chain

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -169,6 +169,10 @@ public class LocalProcess {
     var totalRead = 0
     func childProcessRead (done: Bool, data: DispatchData?, errno: Int32) {
         guard let data else {
+            // Re-schedule the read on transient errors to keep the chain alive
+            if !done, running {
+                io?.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+            }
             return
         }
         if debugIO {


### PR DESCRIPTION
## What's happening

If DispatchIO delivers a nil-data callback to `childProcessRead` (transient I/O error, `done: false`), the method returns early without scheduling the next read. Since each read completion is responsible for scheduling the next one, this silently kills the entire read chain.

The terminal appears frozen — no output, no error — but the shell process is still alive and the PTY is still open. The only recovery is closing and reopening the terminal.

## The fix

When `data` is nil but `done` is false, just re-schedule the read and carry on. If `done` is true, the channel is actually finished and we stop as before.

```swift
guard let data else {
    if !done, running {
        io?.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
    }
    return
}
```

## How I found it

I'm building a macOS terminal app on top of SwiftTerm and kept hitting intermittent freezes — the terminal would just stop updating mid-session. Traced it down to this guard statement. The freeze was non-deterministic and hard to reproduce, which is consistent with a transient I/O error that only happens under certain timing conditions.

After the fix, the terminal recovers instead of dying silently.