### PR TITLE
Make HeadlessTerminal.process public

### DIFF
--- a/Sources/SwiftTerm/HeadlessTerminal.swift
+++ b/Sources/SwiftTerm/HeadlessTerminal.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 public class HeadlessTerminal : TerminalDelegate, LocalProcessDelegate {
     public private(set) var terminal: Terminal!
-    var process: LocalProcess!
+    public var process: LocalProcess!
     var onEnd: (_ exitCode: Int32?) -> ()
     var dir: String?
     
@@ -34,11 +34,11 @@ public class HeadlessTerminal : TerminalDelegate, LocalProcessDelegate {
         terminal.feed(buffer: slice)
     }
     
-    func send(data: ArraySlice<UInt8>) {
+    public func send(data: ArraySlice<UInt8>) {
         process.send (data: data)
     }
 
-    func send(_ text: String) {
+    public func send(_ text: String) {
         send (data: ([UInt8] (text.utf8))[...])
         
     }


### PR DESCRIPTION
The `process` property in `HeadlessTerminal` was internal, making it inaccessible from external modules that import SwiftTerm. This prevented users from calling `startProcess()` on the `LocalProcess` instance.

Since `HeadlessTerminal` is designed to provide a headless terminal emulator that can be scripted and screen-scraped, users need access to the underlying `LocalProcess` to start a child process after initialization.

This change aligns with the existing pattern in the package's own `CaptureOutput` target, which also accesses the `process` property directly (but works because it's in the same package).