### PR TITLE
Fix keyboard toggle flicker on iOS

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSAccessoryView.swift
+++ b/Sources/SwiftTerm/iOS/iOSAccessoryView.swift
@@ -149,9 +149,7 @@ public class TerminalAccessory: UIInputView, UIInputViewAudioFeedback {
 
     @objc func toggleInputKeyboard (_ sender: UIButton) {
         guard let tv = terminalView else { return }
-        let wasResponder = tv.isFirstResponder
-        if wasResponder { _ = tv.resignFirstResponder() }
-        
+
         if tv.inputView == nil {
             #if os(visionOS)
             tv.inputView = KeyboardView (frame: CGRect (origin: CGPoint.zero,
@@ -167,8 +165,9 @@ public class TerminalAccessory: UIInputView, UIInputViewAudioFeedback {
         } else {
             tv.inputView = nil
         }
-        if wasResponder { _ = tv.becomeFirstResponder() }
-
+        UIView.performWithoutAnimation {
+            tv.reloadInputViews()
+        }
     }
 
     @objc func toggleTouch (_ sender: UIButton) {


### PR DESCRIPTION
## Problem

When toggling between the system keyboard and the custom accessory keyboard on iOS using `iOSAccessoryView`, there was a visible flicker. The old code called `resignFirstResponder()` + `becomeFirstResponder()` which triggered a full keyboard dismiss/show animation cycle.

## Fix

Replace `resignFirstResponder()`/`becomeFirstResponder()` with `reloadInputViews()`, which swaps the input view in place without dismissing the keyboard. This eliminates the flicker entirely.

The change is minimal: just the toggle method in `iOSAccessoryView.swift`.