### PR TITLE
Clamp savedY to valid bounds on terminal resize

### DIFF
--- a/Sources/SwiftTerm/Buffer.swift
+++ b/Sources/SwiftTerm/Buffer.swift
@@ -486,6 +486,7 @@ public final class Buffer {
             }
 
             savedX = min (savedX, newCols - 1)
+            savedY = max (min (savedY, newRows - 1), 0)
 
             scrollTop = 0
         }

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -760,7 +760,7 @@ open class Terminal {
         // correct the savedY cursor to follow changes to y
         let dy = normalBuffer.savedY - normalBuffer.y
         normalBuffer.resize (newCols: newColumns, newRows: newRows)
-        normalBuffer.savedY = normalBuffer.y + dy
+        normalBuffer.savedY = max(normalBuffer.y + dy, 0)
         
         altBuffer.resize (newCols: newColumns, newRows: newRows)
 


### PR DESCRIPTION
## Summary

- `Buffer.resize()` clamps `savedX` to `newCols - 1` but does not clamp `savedY`, allowing it to exceed the new row count after resize
- `Terminal.resizeBuffers()` can produce a negative `savedY` when recomputing the offset after resize (`normalBuffer.y + dy` where `dy` was captured before resize)
- Both cases cause `abort()` in the `Buffer.y` setter on DEBUG builds when `cmdRestoreCursor` assigns `buffer.y = buffer.savedY`

## Fix

- Clamp `savedY` to `[0, newRows - 1]` in `Buffer.resize()`, matching the existing `savedX` clamp
- Clamp `savedY` to `>= 0` in `Terminal.resizeBuffers()` after recomputing the offset

## Test plan

- [x] Verify terminal resize no longer crashes when a saved cursor position exceeds new row count
- [ ] Run existing SwiftTerm test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)