### PR TITLE
Fix NSScroller layout when TerminalView uses Auto Layout constraints

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -386,6 +386,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
 
     let scrollerStyle: NSScroller.Style = .legacy
+
     func getScrollerFrame() -> CGRect {
         let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
         return NSRect(x: bounds.maxX - scrollerWidth, y: 0, width: scrollerWidth, height: bounds.height)
@@ -393,17 +394,23 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 
     func setupScroller()
     {
-        let scrollerFrame = getScrollerFrame()
         if scroller == nil {
-            scroller = NSScroller(frame: scrollerFrame)
-        } else {
-            scroller?.frame = scrollerFrame
+            scroller = NSScroller(frame: .zero)
+            scroller.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(scroller)
+
+            // Use Auto Layout to position the scroller. This ensures correct layout
+            // whether the parent view uses frame-based or constraint-based layout.
+            NSLayoutConstraint.activate([
+                scroller.trailingAnchor.constraint(equalTo: trailingAnchor),
+                scroller.topAnchor.constraint(equalTo: topAnchor),
+                scroller.bottomAnchor.constraint(equalTo: bottomAnchor),
+                scroller.widthAnchor.constraint(equalToConstant: scrollerWidth)
+            ])
         }
-        scroller.autoresizingMask = [.minXMargin, .height]
         scroller.scrollerStyle = scrollerStyle
         scroller.knobProportion = 0.1
         scroller.isEnabled = false
-        addSubview (scroller)
         if let progressBarView {
             addSubview(progressBarView, positioned: .above, relativeTo: scroller)
         }
@@ -412,7 +419,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
 
     func updateScrollerFrame() {
-        scroller?.frame = getScrollerFrame()
+        // Scroller position is managed by Auto Layout constraints
     }
 
     /// This method sents the `nativeForegroundColor` and `nativeBackgroundColor`
@@ -431,17 +438,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         terminalDelegate?.send (source: self, data: data)
     }
         
+    private var scrollerWidth: CGFloat {
+        NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
+    }
+
     /**
      * Given the current set of columns and rows returns a frame that would host this control.
      */
     open func getOptimalFrameSize () -> NSRect
     {
-        return NSRect (x: 0, y: 0, width: cellDimension.width * CGFloat(terminal.cols) + scroller.frame.width, height: cellDimension.height * CGFloat(terminal.rows))
+        return NSRect (x: 0, y: 0, width: cellDimension.width * CGFloat(terminal.cols) + scrollerWidth, height: cellDimension.height * CGFloat(terminal.rows))
     }
-    
+
     func getEffectiveWidth (size: CGSize) -> CGFloat
     {
-        return (size.width-scroller.frame.width)
+        return (size.width - scrollerWidth)
     }
     
     open func scrolled(source terminal: Terminal, yDisp: Int) {


### PR DESCRIPTION
Fixes #161                                                                                                            
                                                                                                                        
  ## Problem                                                                                                            
                                                                                                                        
  When `TerminalView` is embedded using Auto Layout constraints (e.g., via SwiftUI's `NSViewRepresentable` with         
  `translatesAutoresizingMaskIntoConstraints = false`), the NSScroller appears mispositioned - stuck in the bottom-right
   corner, scrolling horizontally instead of vertically.                                                                
                                                                                                                        
  ## Root Cause                                                                                                         
                                                                                                                        
  The scroller was positioned using `autoresizingMask` (frame-based layout), which conflicts with constraint-based      
  layout. The frame calculations in `getScrollerFrame()` relied on `bounds.maxX` which may not be accurate before the   
  layout pass completes.                                                                                                
                                                                                                                        
  ## Solution                                                                                                           
                                                                                                                        
  Use Auto Layout constraints to position the scroller:                                                                 
                                                                                                                        
  - Scroller is pinned to trailing/top/bottom anchors of the parent view                                                
  - Width uses the system-provided `NSScroller.scrollerWidth()` value                                                   
  - Works correctly whether parent uses frame-based or constraint-based layout                                          
                                                                                                                        
  ## Changes                                                                                                            
                                                                                                                        
  - `setupScroller()` now uses Auto Layout constraints instead of autoresizing masks                                    
  - `updateScrollerFrame()` is now a no-op (constraints handle positioning)                                             
  - Added `scrollerWidth` computed property for reliable width calculation                                              
  - `getScrollerFrame()` preserved for backwards compatibility                                                          
                                                                                                                        
  ## Testing                                                                                                            
                                                                                                                        
  Tested with SwiftUI/NSViewRepresentable embedding. Scroller now appears correctly on the right edge and scrolls       
  vertically as expected. 

Thanks for maintaining SwiftTerm - it's been great to use in my project. 