### PR TITLE
Fix Package.swift trailing commas causing build failures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,7 @@ let targets: [Target] = [
         name: "SwiftTerm",
         dependencies: [],
         path: "Sources/SwiftTerm",
-        exclude: platformExcludes + ["Mac/README.md"],
-//        swiftSettings: [
-//            .unsafeFlags(["-enforce-exclusivity=none"])
-//        ]
+        exclude: platformExcludes + ["Mac/README.md"]
     ),
     .executableTarget (
         name: "SwiftTermFuzz",
@@ -58,10 +55,7 @@ let targets: [Target] = [
 //            .product(name: "Subprocess", package: "swift-subprocess", condition: .when(platforms: [.macOS, .linux]))
 //        ],
         path: "Sources/SwiftTerm",
-        exclude: platformExcludes + ["Mac/README.md"],
-//        swiftSettings: [
-//            .unsafeFlags(["-enforce-exclusivity=none"])
-//        ]
+        exclude: platformExcludes + ["Mac/README.md"]
     ),
     .executableTarget (
         name: "SwiftTermFuzz",


### PR DESCRIPTION
## Summary

The `exclude` parameter in both `.target` definitions (Windows and non-Windows) has a trailing comma left over from commenting out the `swiftSettings` parameter that followed it. This causes `unexpected ',' separator` errors when the Swift compiler strips comments during Package.swift manifest parsing.

```
/Package.swift:29:5: error: unexpected ',' separator
 27 | //            .unsafeFlags(["-enforce-exclusivity=none"])
 28 | //        ]
 29 |     ),
    |     `- error: unexpected ',' separator
```

## Fix

Remove the trailing commas after `exclude: platformExcludes + ["Mac/README.md"]` and the associated commented-out `swiftSettings` blocks in both the `#if os(Windows)` and `#else` branches.

## Impact

This prevents any downstream project from resolving SwiftTerm as a dependency when using Xcode 16.1+ / Swift 5.9+ compilers, which are strict about trailing commas in function argument lists.