### PR TITLE
Fix: preserve text selection when mouse reporting is disabled

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1570,7 +1570,12 @@ extension TerminalView {
     func feedPrepare()
     {
         search.invalidate()
-        selection.active = false
+        // Only clear selection when mouse reporting is enabled.
+        // When mouse reporting is disabled, the user is manually selecting
+        // text and expects it to persist across incoming data.
+        if allowMouseReporting {
+            selection.active = false
+        }
         startDisplayUpdates()
     }
     

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -462,7 +462,12 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
     
     open func linefeed(source: Terminal) {
-        selection.selectNone()
+        // Only clear selection when mouse reporting is enabled.
+        // Same rationale as feedPrepare(): when the user has disabled
+        // mouse reporting, they expect manual text selections to persist.
+        if allowMouseReporting {
+            selection.selectNone()
+        }
     }
     
     /// This vaiable controls whether mouse events are sent to the application running under the


### PR DESCRIPTION
## Problem

When `allowMouseReporting` is set to `false`, users expect to manually select text in the terminal. However, both `feedPrepare()` and `linefeed()` unconditionally clear the active selection on every data feed.

This causes **selection flickering and loss** in high-throughput scenarios — for example, when running streaming CLI tools (like AI coding assistants) that continuously write to the terminal. The user selects text, but it's immediately cleared by the next incoming data chunk.

## Fix

Guard both selection-clearing calls behind `allowMouseReporting`:

- `AppleTerminalView.feedPrepare()`: only set `selection.active = false` when mouse reporting is enabled
- `MacTerminalView.linefeed()`: only call `selection.selectNone()` when mouse reporting is enabled

This preserves the existing behavior when mouse reporting is on (selection is managed by the application), while allowing manual selections to persist when mouse reporting is off.

## Context

We discovered this while embedding SwiftTerm in [GroAsk](https://groask.com) (a macOS menu bar AI launcher) to run Claude Code sessions. The terminal receives high-frequency output, and users need to select and copy text while output is streaming.

Really appreciate your work on SwiftTerm — it's an incredibly well-architected terminal engine. The clean separation between the core emulator and platform-specific views made it straightforward to integrate. Thank you for open-sourcing it! 🙏