### PR TITLE
Fix iOS compile error: wrap cmdBackTab in .bytes()

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1566,7 +1566,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
                 
             case .keyboardTab:
                 if key.modifierFlags.contains ([.shift]) {
-                    data = EscapeSequences.cmdBackTab
+                    data = .bytes (EscapeSequences.cmdBackTab)
                 } else {
                     data = .bytes ([9])
                 }


### PR DESCRIPTION
v1.11.0 introduced `SendData` enum for iOS key handling, but the shift-tab case assigns `EscapeSequences.cmdBackTab` (`[UInt8]`) directly to a `SendData?` variable without wrapping it in `.bytes()`.

This causes a compile error on iOS:
```
cannot assign value of type '[UInt8]' to type 'TerminalView.SendData'
```

One-line fix: wrap in `.bytes()` like all other key assignments in the same method.