### PR TITLE
Make cellDimension, CellDimension, and BufferLine.isWrapped public

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -57,7 +57,7 @@ struct ViewLineInfo {
 }
 
 extension TerminalView {
-    typealias CellDimension = CGSize
+    public typealias CellDimension = CGSize
     
     func resetCaches ()
     {

--- a/Sources/SwiftTerm/BufferLine.swift
+++ b/Sources/SwiftTerm/BufferLine.swift
@@ -21,7 +21,7 @@ public final class BufferLine: CustomDebugStringConvertible {
         /// Renders the bottom of a character, using two cells
         case doubledDown
     }
-    var isWrapped: Bool
+    public var isWrapped: Bool
     var renderMode: RenderLineMode = .single
     private var data: UnsafeMutableBufferPointer<CharData>
     private var dataSize: Int

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -155,7 +155,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var search: SearchService!
     var debug: UIView?
     var pendingDisplay: Bool = false
-    var cellDimension: CellDimension!
+    public var cellDimension: CellDimension!
     var caretView: CaretView?
     var terminal: Terminal!
     private var progressBarView: TerminalProgressBarView?


### PR DESCRIPTION
## Summary

Makes three properties public so embedding apps can implement tap-to-open-URL and other position-aware features:

- `TerminalView.cellDimension` (`iOSTerminalView.swift`) — needed to convert tap coordinates to terminal rows/columns
- `CellDimension` typealias (`AppleTerminalView.swift`) — required because `cellDimension`'s type must also be public
- `BufferLine.isWrapped` (`BufferLine.swift`) — needed to distinguish soft-wrapped lines from hard newlines

## Motivation

Terminal apps commonly need to detect URLs under a user's tap. This requires:
1. Converting a UIKit tap point to a terminal row (needs `cellDimension`)
2. Joining soft-wrapped lines to reconstruct full URLs (needs `isWrapped`)

These are read-only access patterns — no behavior changes, no API surface increase beyond visibility.

## Changes

Three `internal` → `public` visibility changes. No logic changes, no new API.