### PR TITLE
Fix SGR 2 (dim/faint) rendering on light backgrounds

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -397,14 +397,15 @@ extension TerminalView {
         }
         
         var fgColor = mapColor (color: fg, isFg: true, isBold: isBold, useBrightColors: useBrightColors)
-        // Apply dim/faint attribute (SGR 2) - reduce color intensity
-        if flags.contains(.dim) {
-            fgColor = fgColor.dimmedColor()
+        let bgColor = mapColor (color: bg, isFg: false, isBold: false)
+        // Apply dim/faint attribute (SGR 2)
+        if flags.contains (.dim) {
+            fgColor = fgColor.dimmedColor (towards: bgColor)
         }
         var nsattr: [NSAttributedString.Key:Any] = [
             .font: tf,
             .foregroundColor: fgColor,
-            .backgroundColor: mapColor(color: bg, isFg: false, isBold: false)
+            .backgroundColor: bgColor
         ]
         if flags.contains (.underline) {
             let underlineColor = attribute.underlineColor.map {

--- a/Sources/SwiftTerm/Mac/MacExtensions.swift
+++ b/Sources/SwiftTerm/Mac/MacExtensions.swift
@@ -29,18 +29,22 @@ extension NSColor {
         return NSColor(calibratedRed: 1.0 - red, green: 1.0 - green, blue: 1.0 - blue, alpha: alpha)
     }
 
-    /// Returns a dimmed version of the color (for SGR 2 faint/dim text attribute)
-    /// Reduces the color intensity by approximately 50%
-    func dimmedColor() -> NSColor {
-        guard let color = self.usingColorSpace(.deviceRGB) else {
+    /// Returns a dimmed version of the color (SGR 2 faint/dim attribute) by
+    /// blending 50 % toward `background`. The result is fully opaque so that
+    /// adjacent box-drawing characters tile without visible seams.
+    func dimmedColor (towards background: NSColor) -> NSColor {
+        guard let fg = self.usingColorSpace(.deviceRGB),
+              let bg = background.usingColorSpace(.deviceRGB) else {
             return self
         }
-
-        var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
-        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        // Dim by reducing brightness to ~50% (blend toward black)
-        let dimFactor: CGFloat = 0.5
-        return NSColor(calibratedRed: red * dimFactor, green: green * dimFactor, blue: blue * dimFactor, alpha: alpha)
+        var fRed: CGFloat = 0.0, fGreen: CGFloat = 0.0, fBlue: CGFloat = 0.0, fAlpha: CGFloat = 1.0
+        fg.getRed(&fRed, green: &fGreen, blue: &fBlue, alpha: &fAlpha)
+        var bRed: CGFloat = 0.0, bGreen: CGFloat = 0.0, bBlue: CGFloat = 0.0, bAlpha: CGFloat = 1.0
+        bg.getRed(&bRed, green: &bGreen, blue: &bBlue, alpha: &bAlpha)
+        return NSColor (deviceRed: (fRed + bRed) * 0.5,
+                        green: (fGreen + bGreen) * 0.5,
+                        blue: (fBlue + bBlue) * 0.5,
+                        alpha: fAlpha)
     }
 
     static func make (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> NSColor

--- a/Sources/SwiftTerm/iOS/iOSExtensions.swift
+++ b/Sources/SwiftTerm/iOS/iOSExtensions.swift
@@ -25,14 +25,18 @@ extension UIColor {
         return UIColor (red: 1.0 - red, green: 1.0 - green, blue: 1.0 - blue, alpha: alpha)
     }
 
-    /// Returns a dimmed version of the color (for SGR 2 faint/dim text attribute)
-    /// Reduces the color intensity by approximately 50%
-    func dimmedColor() -> UIColor {
-        var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
-        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        // Dim by reducing brightness to ~50% (blend toward black)
-        let dimFactor: CGFloat = 0.5
-        return UIColor(red: red * dimFactor, green: green * dimFactor, blue: blue * dimFactor, alpha: alpha)
+    /// Returns a dimmed version of the color (SGR 2 faint/dim attribute) by
+    /// blending 50 % toward `background`. The result is fully opaque so that
+    /// adjacent box-drawing characters tile without visible seams.
+    func dimmedColor (towards background: UIColor) -> UIColor {
+        var fRed: CGFloat = 0.0, fGreen: CGFloat = 0.0, fBlue: CGFloat = 0.0, fAlpha: CGFloat = 1.0
+        self.getRed(&fRed, green: &fGreen, blue: &fBlue, alpha: &fAlpha)
+        var bRed: CGFloat = 0.0, bGreen: CGFloat = 0.0, bBlue: CGFloat = 0.0, bAlpha: CGFloat = 1.0
+        background.getRed(&bRed, green: &bGreen, blue: &bBlue, alpha: &bAlpha)
+        return UIColor (red: (fRed + bRed) * 0.5,
+                        green: (fGreen + bGreen) * 0.5,
+                        blue: (fBlue + bBlue) * 0.5,
+                        alpha: fAlpha)
     }
 
     static func make (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> TTColor


### PR DESCRIPTION
## Problem

`dimmedColor()` reduces each RGB component by 50 %, effectively blending toward black. On dark backgrounds this looks correct, but on light backgrounds it makes dim text darker.

A secondary issue: an alpha-based workaround (`withAlphaComponent(0.5)`) produces the right apparent color but leaves visible seams between adjacent box-drawing characters (e.g. `─────`) because each cell composites independently.
<img width="447" height="122" alt="image" src="https://github.com/user-attachments/assets/4409a89f-2142-41f5-8d80-83c69156ae2e" />


This problem is visible on Claude Code in light theme:

SwiftTerm:
<img width="341" height="207" alt="image" src="https://github.com/user-attachments/assets/f0698de5-f87c-4854-b6e0-f29c992b0219" />

macOS Terminal:
<img width="347" height="225" alt="image" src="https://github.com/user-attachments/assets/889c8356-0bb6-4ad4-b04a-22544ec0f102" />

## Fix

Replace the no-arg `dimmedColor()` with `dimmedColor(towards:)` that takes the cell's background color and produces a fully-opaque 50 % blend between foreground and background. This:

- Reduces contrast correctly regardless of whether the theme is light or dark
- Eliminates tiling artifacts on box-drawing character runs
- Applies to both macOS (`NSColor`) and iOS (`UIColor`)

The call site in `AppleTerminalView` already computes the background color for each cell, so passing it to the new method is straightforward.

Here is how it looks after the fix:
<img width="344" height="257" alt="image" src="https://github.com/user-attachments/assets/17c88dfb-4ea2-436a-b419-d666f669f5bb" />
