### PR TITLE
Fix: Undefined reference to `initialize(fromContentsOf:)`  linker error on Linux

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,96 @@
+{
+  "originHash" : "b5ff689c86958c5a25a1a8946ddd3297f24a4ac1033e88edd10786f2c69a6415",
+  "pins" : [
+    {
+      "identity" : "hdrhistogram-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift.git",
+      "state" : {
+        "revision" : "de0b9b8a27956b9bfc9b4dce7d1c38ad7c579f19",
+        "version" : "0.1.4"
+      }
+    },
+    {
+      "identity" : "package-benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-benchmark",
+      "state" : {
+        "revision" : "a1075611342d4b164bf6e977edb02a3db4434afd",
+        "version" : "1.29.11"
+      }
+    },
+    {
+      "identity" : "package-jemalloc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-jemalloc.git",
+      "state" : {
+        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "texttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/TextTable.git",
+      "state" : {
+        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
+        "version" : "0.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sources/SwiftTerm/BufferLine.swift
+++ b/Sources/SwiftTerm/BufferLine.swift
@@ -48,7 +48,14 @@ public final class BufferLine: CustomDebugStringConvertible {
         images = other.images
         let otherSize = other.dataSize
         let buf = UnsafeMutableBufferPointer<CharData>.allocate(capacity: otherSize)
+        #if os(Linux) || os(Windows)
+        for i in 0..<otherSize {
+            buf.initializeElement(at: i, to: other.data[i])
+        }
+        #else
         _ = buf.initialize(fromContentsOf: other.data[0..<otherSize])
+        #endif
+        
         data = buf
         dataSize = otherSize
     }
@@ -182,10 +189,20 @@ public final class BufferLine: CustomDebugStringConvertible {
 
         if cols > len {
             let newBuf = UnsafeMutableBufferPointer<CharData>.allocate(capacity: cols)
+            
             // Copy existing data
+#if os(Linux) || os(Windows)
+            if len > 0 {
+                for i in 0..<len {
+                    newBuf.initializeElement(at: i, to: data[i])
+                }
+            }
+#else
             if len > 0 {
                 _ = newBuf.initialize(fromContentsOf: data[0..<len])
             }
+#endif
+            
             // Fill remainder with fillData
             for i in len..<cols {
                 newBuf.initializeElement(at: i, to: fillData)
@@ -196,7 +213,13 @@ public final class BufferLine: CustomDebugStringConvertible {
         } else {
             if cols > 0 {
                 let newBuf = UnsafeMutableBufferPointer<CharData>.allocate(capacity: cols)
+#if os(Linux) || os(Windows)
+                for i in 0..<cols {
+                    newBuf.initializeElement(at: i, to: data[i])
+                }
+#else
                 _ = newBuf.initialize(fromContentsOf: data[0..<cols])
+#endif
                 data.deinitialize()
                 data.deallocate()
                 data = newBuf
@@ -236,7 +259,13 @@ public final class BufferLine: CustomDebugStringConvertible {
             data.deinitialize()
             data.deallocate()
             let newBuf = UnsafeMutableBufferPointer<CharData>.allocate(capacity: srcSize)
+#if os(Linux) || os(Windows)
+            for i in 0..<srcSize {
+                newBuf.initializeElement(at: i, to: line.data[i])
+            }
+#else
             _ = newBuf.initialize(fromContentsOf: line.data[0..<srcSize])
+#endif
             data = newBuf
         } else {
             for i in 0..<srcSize {


### PR DESCRIPTION
### Description
This PR fixes a critical linker error that prevents `SwiftTerm` from compiling successfully on Linux (e.g., Ubuntu) and Windows environments, especially when using newer Swift toolchains (like Swift 6.2).

### Motivation and Context
When building on Linux, the clang linker fails with the following error in `BufferLine.swift`:
`undefined reference to '$sSr22_FoundationCollectionsE10initialize14fromContentsOfSis5SliceVySryxGG_tF'`

This happens because `UnsafeMutableBufferPointer.initialize(fromContentsOf:)` currently fails to export the correct underlying binary symbols for array slices in the Swift Corelibs implementation for non-Apple platforms. 

### What Changed?
I introduced `#if os(Linux) || os(Windows)` compiler directives around the 4 occurrences of `initialize(fromContentsOf:)` in `BufferLine.swift` (`init`, `resize` for growing/shrinking, and `copyFrom`).
- **On Linux & Windows:** Safely initializes memory element-by-element using a `for` loop and `initializeElement(at:to:)` to bypass the missing symbol bug.
- **On Apple Platforms:** Preserves the original `initialize(fromContentsOf:)` implementation to maintain optimal memory copy performance.

### How Has This Been Tested?
Compiled and tested successfully on Ubuntu 22.04 with Swift 6.2. The linker errors are completely resolved and the buffer lines initialize correctly.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)