### PR TITLE
don't percent encoding the url

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2238,12 +2238,8 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 extension TerminalViewDelegate {
     public func requestOpenLink (source: TerminalView, link: String, params: [String:String])
     {
-        if let fixedup = link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            if let url = NSURLComponents(string: fixedup) {
-                if let nested = url.url {
-                    NSWorkspace.shared.open(nested)
-                }
-            }
+        if let url = URL(string: link) {
+            NSWorkspace.shared.open(url)
         }
     }
     

--- a/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
+++ b/TerminalApp/iOSTerminal/UIKitSshTerminalView.swift
@@ -407,12 +407,8 @@ public class SshTerminalView: TerminalView, TerminalViewDelegate {
 
     public func requestOpenLink (source: TerminalView, link: String, params: [String:String])
     {
-        if let fixedup = link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            if let url = NSURLComponents(string: fixedup) {
-                if let nested = url.url {
-                    UIApplication.shared.open (nested)
-                }
-            }
+        if let url = URL(string: link) {
+            UIApplication.shared.open (url)
         }
     }
     


### PR DESCRIPTION
NSURL handles that itself, percent encoding whole url is not allowed.

from: https://developer.apple.com/documentation/foundation/nsstring/addingpercentencoding(withallowedcharacters:)

> Entire URL strings cannot be percent-encoded, because each URL component specifies a different set of allowed characters.

Encoding the url with query character set will cause url anchor to be invalid. For example, https://github.com/migueldeicaza/SwiftTerm/blob/main/README.md?plain=1#L11 becomes https://github.com/migueldeicaza/SwiftTerm/blob/main/README.md?plain=1%23L11