### PR TITLE
Fix iOS rendering: use contentOffset.y for firstRow instead of dirtyRect.minY

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1035,10 +1035,15 @@ extension TerminalView {
         }
         // draw lines
         #if os(iOS) || os(visionOS)
-        // On iOS, we are drawing the exposed region
+        // On iOS, use contentOffset.y to determine the first visible row rather than
+        // dirtyRect.minY. UIKit coalesces dirty rects across scroll and data updates and
+        // can deliver a rect with minY=0 even when the scroll position (contentOffset.y)
+        // is non-zero. This causes SwiftTerm to draw scrollback-buffer rows at viewport
+        // positions, producing garbled output. contentOffset.y is always correct because
+        // the scroll view is kept in sync with yDisp (contentOffset.y == yDisp * cellHeight).
         let cellHeight = cellDimension.height
-        let firstRow = Int (dirtyRect.minY/cellHeight)
-        let lastRow = Int(dirtyRect.maxY/cellHeight)
+        let firstRow = Int(contentOffset.y / cellHeight)
+        let lastRow = firstRow + Int(ceil(bounds.height / cellHeight))
         #else
         // On Mac, we are drawing the terminal buffer
         let cellHeight = cellDimension.height


### PR DESCRIPTION
## Problem

On iOS, UIKit coalesces dirty rects across scroll and data-update events and can deliver a `draw()` call with `dirtyRect.minY == 0` even when the `UIScrollView`'s `contentOffset.y` is non-zero (i.e. the terminal has scrolled or `yDisp > 0`).

The current code uses `dirtyRect.minY` to compute the first terminal row to render:

```swift
let firstRow = Int(dirtyRect.minY / cellHeight)
```

When UIKit delivers a coalesced rect starting at 0, the drawing loop starts from row 0 of the scroll-content (scrollback history) rather than the currently visible viewport. This paints characters from old scrollback rows over the live terminal area, producing garbled / ghosted output.

This is particularly visible when:
- Typing commands rapidly (UIKit coalesces the input dirty rect with a prior scroll update)
- Switching alternate screen buffers (vim, tmux)
- Any scenario where `setNeedsDisplay` is called shortly after a scroll

## Fix

Derive `firstRow` directly from `contentOffset.y`:

```swift
let firstRow = Int(contentOffset.y / cellHeight)
let lastRow = firstRow + Int(ceil(bounds.height / cellHeight))
```

This is always correct because the scroll view's `contentOffset` is kept in sync with `yDisp` (`contentOffset.y == yDisp * cellHeight`). `lastRow` is computed as `firstRow` + the number of rows that fit in the current bounds height, equivalent to the previous `dirtyRect.maxY` calculation but anchored to the correct starting row.

The Mac path (`#else` branch) is unchanged.

## Testing

Verified on a physical iPhone running an SSH terminal app against a remote Linux server:
- `vim` — correct rendering, no ghosting on open/close/edit
- `tmux` — alternate screen switch renders cleanly  
- Rapid `ls` / `clear` cycles — no stale rows bleed through
- Scrollback — scrolling up/down shows correct history rows