### PR TITLE
fix: WindowManipulationCommand crash and toSgr truecolor

### DIFF
--- a/Sources/SwiftTerm/CharData.swift
+++ b/Sources/SwiftTerm/CharData.swift
@@ -135,7 +135,6 @@ public struct Attribute: Equatable, Hashable {
             result += ";8"
         }
         
-        print ("Attribute.toSgr() BROKEN - THIS ONLY HANDLES 8 bits")
         switch fg {
         case .ansi256(let c):
             if c > 16 {
@@ -144,12 +143,11 @@ public struct Attribute: Equatable, Hashable {
                 result += ";\(c >= 8 ? 9 : 3)\(c >= 8 ? c - 8 : c);"
             }
         case .trueColor(let r, let g, let b):
-            print ("Here  is where truecolor needs to be handled \(r), \(g), \(b)")
-            break
+            result += ";38;2;\(r);\(g);\(b)"
         default:
             break
         }
-        
+
         switch bg {
         case .ansi256(let c):
             if c > 16 {
@@ -158,8 +156,7 @@ public struct Attribute: Equatable, Hashable {
                 result += ";\(c >= 8 ? 10 : 4)\(c >= 8 ? c - 8 : c);"
             }
         case .trueColor(let r, let g, let b):
-            print ("Here  is where truecolor needs to be handled \(r), \(g), \(b)")
-            break
+            result += ";48;2;\(r);\(g);\(b)"
         default:
             break
         }

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2193,6 +2193,8 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             return nil
         case .sendToBack:
             return nil
+        case .resizeTo(_, _):
+            return nil
         case .resizeTo(_):
             return nil
         case .restoreMaximizedWindow:


### PR DESCRIPTION
## Summary

Two fixes:

1. **`TerminalView.windowCommand` crash** — `case .resizeTo(_)` in `MacTerminalView.swift` only matches the single-argument `resizeTo(lines:)` variant. The two-argument `resizeTo(cols:rows:)` variant dispatched by `cmdWindowOptions` at line 2877 falls through with no match, causing a runtime crash: `Fatal error: unexpected enum case while switching on value of type 'WindowManipulationCommand'`. Split into explicit cases for both arities.

2. **`Attribute.toSgr()` debug spam** — Had `print("BROKEN")` statements instead of actually encoding truecolor values. Implemented proper SGR `38;2;r;g;b` and `48;2;r;g;b` sequences for truecolor foreground/background.

## Repro for crash

Run any program that sends `CSI 8 ; rows ; cols t` (xterm resize request) — e.g., neovim does this on startup. The crash is in `TerminalView.windowCommand` because the exhaustive switch doesn't cover `resizeTo(cols:rows:)`.

## Test plan

- [x] `swift build --target SwiftTerm` compiles clean
- [ ] Run neovim in a terminal — no longer crashes on window manipulation sequences
- [ ] Truecolor SGR output verified (programs using 24-bit color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)