### PR TITLE
Fix MacCaretView transparency support

### DIFF
--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -28,13 +28,20 @@ class CaretView: NSView, CALayerDelegate {
         bgColor = caretColor.cgColor
         super.init(frame: frame)
         wantsLayer = true
-        layer?.isOpaque = false  // Enable transparency support (matches iOS)
 
         updateView()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // Enable transparency support for the cursor (matches iOS behavior)
+    override func makeBackingLayer() -> CALayer {
+        let layer = super.makeBackingLayer()
+        layer.isOpaque = false
+        layer.backgroundColor = NSColor.clear.cgColor
+        return layer
     }
     
     func setText (ch: CharData) {


### PR DESCRIPTION
Add `layer?.isOpaque = false` to match the iOS implementation in iOSCaretView.swift. This enables proper cursor rendering when the terminal view has a transparent background.

Without this fix, the cursor becomes invisible when nativeBackgroundColor has alpha < 1.0 because CoreAnimation's layer compositing doesn't properly handle the CaretView's drawing.