### PR TITLE
Force terminal redraw to reflect new font and reflowed content

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -103,6 +103,12 @@ extension TerminalView {
         let newRows = Int(frame.height / cellDimension.height)
         resize(cols: newCols, rows: newRows)
         updateCaretView()
+        
+        #if os(macOS)
+        needsDisplay = true
+        #else
+        setNeedsDisplay(frame)
+        #endif
     }
     
     func updateCaretView ()


### PR DESCRIPTION
# Force terminal redraw to reflect new font and reflowed content
## Description
Implements a critical UI refresh fix for the terminal view by **forcing an immediate redraw** when the terminal's font is changed ensuring the new font settings and reflowed terminal content are rendered correctly across both macOS and iOS/iPadOS platforms.

### Changes Made
Modified the frame resize handler in `AppleTerminalView.swift` to add platform-specific display refresh logic:
- **macOS**: Sets `needsDisplay = true` to trigger an immediate view redraw
- **iOS/iPadOS**: Calls `setNeedsDisplay(frame)` to refresh the terminal rendering

### Why This Change Is Needed
Without explicit redraw instructions, the terminal view could fail to update visually after resizing:
1. New font configurations wouldn't be reflected immediately
2. Reflowed terminal content might not render properly
3. UI state would be out of sync with the underlying terminal data model

This fix guarantees the visual terminal output always matches the current state after resize operations.

### Test Coverage
- Tested on macOS: Terminal view redraws correctly with new font/size after resizing
- Tested on iOS/iPadOS: Frame resize triggers full content refresh
- Verified no breaking changes to existing resize/caret update functionality
