### PR TITLE
Fix macOS dictation support in NSTextInputClient

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -137,6 +137,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     var cellDimension: CellDimension!
     var caretView: CaretView!
     public var terminal: Terminal!
+
+    /// Marked (uncommitted) text from an input source (IME, dictation, etc.).
+    private var markedTextStorage: NSAttributedString?
+    private var markedSelectedRange: NSRange = NSRange(location: NSNotFound, length: 0)
+    private var markedTextOverlay: NSTextField?
     private var progressBarView: TerminalProgressBarView?
     private var progressReportTimer: Timer?
     private var lastProgressValue: UInt8?
@@ -1160,6 +1165,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
     
     func insertText(_ string: Any, replacementRange: NSRange, isPaste: Bool) {
+        markedTextStorage = nil
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
+        updateMarkedTextOverlay()
         if let str = string as? NSString {
             if !terminal.keyboardEnhancementFlags.isEmpty {
                 if isPaste, terminal.bracketedPasteMode {
@@ -1198,7 +1206,61 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        switch string {
+        case let attributed as NSAttributedString:
+            markedTextStorage = attributed.length > 0 ? attributed : nil
+        case let plain as String:
+            markedTextStorage = plain.isEmpty ? nil : NSAttributedString(string: plain)
+        default:
+            markedTextStorage = nil
+        }
+        markedSelectedRange = selectedRange
         kittyIsComposing = true
+        updateMarkedTextOverlay()
+    }
+
+    /// Shows or hides a floating overlay that previews in-progress marked text
+    /// (e.g. dictation hypotheses or IME composition) at the current cursor position.
+    private func updateMarkedTextOverlay() {
+        guard let markedTextStorage, markedTextStorage.length > 0 else {
+            markedTextOverlay?.removeFromSuperview()
+            markedTextOverlay = nil
+            return
+        }
+
+        let overlay: NSTextField
+        if let existing = markedTextOverlay {
+            overlay = existing
+        } else {
+            overlay = NSTextField(labelWithString: "")
+            overlay.isBezeled = false
+            overlay.isEditable = false
+            overlay.drawsBackground = true
+            overlay.backgroundColor = nativeBackgroundColor.withAlphaComponent(0.9)
+            overlay.wantsLayer = true
+            overlay.layer?.cornerRadius = 3
+            addSubview(overlay, positioned: .above, relativeTo: nil)
+            markedTextOverlay = overlay
+        }
+
+        // Style the text to match the terminal font/colors with an underline.
+        let displayString = NSMutableAttributedString(attributedString: markedTextStorage)
+        let fullRange = NSRange(location: 0, length: displayString.length)
+        displayString.addAttributes([
+            .font: font,
+            .foregroundColor: nativeForegroundColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ], range: fullRange)
+        overlay.attributedStringValue = displayString
+
+        // Position at the caret.
+        overlay.sizeToFit()
+        overlay.frame.origin = caretView.frame.origin
+
+        // Clamp to view bounds so the overlay doesn't extend off-screen.
+        if overlay.frame.maxX > bounds.maxX {
+            overlay.frame.origin.x = max(0, bounds.maxX - overlay.frame.width)
+        }
     }
 
     private func kittyEncoder() -> KittyKeyboardEncoder {
@@ -1571,54 +1633,62 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func unmarkText() {
+        markedTextStorage = nil
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
         kittyIsComposing = false
+        updateMarkedTextOverlay()
     }
     
     // NSTextInputClient protocol implementation
     open func selectedRange() -> NSRange {
-        guard let selection = self.selection, selection.active else {
-            // This means "no selection":
-            return NSRange.empty
+        if let selection = self.selection, selection.active {
+            let displayBuffer = terminal.displayBuffer
+            var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
+            var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
+            if startLocation > endLocation {
+                swap(&startLocation, &endLocation)
+            }
+            let length = endLocation - startLocation
+            if length > 0 {
+                return NSRange(location: startLocation, length: length)
+            }
         }
-        
-        let displayBuffer = terminal.displayBuffer
-        var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
-        var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
-        if startLocation > endLocation {
-            swap(&startLocation, &endLocation)
-        }
-        let length = endLocation - startLocation
-        if length == 0 {
-            return NSRange.empty
-        }
-        return NSRange(location: startLocation, length: endLocation - startLocation)
+        // Return the cursor position as a zero-length selection (insertion point).
+        // The input system needs a valid location to anchor dictation and IME input.
+        let cursorLocation = terminal.buffer.y * terminal.cols + terminal.buffer.x
+        return NSRange(location: cursorLocation, length: 0)
     }
     
     // NSTextInputClient protocol implementation
     open func markedRange() -> NSRange {
-        print ("markedRange: This should return the actual range from the selection")
-        
-        // This means "no marked" - when we fix, we should address
-        return NSRange.empty
+        guard let marked = markedTextStorage else {
+            return NSRange.empty
+        }
+        return NSRange(location: 0, length: marked.length)
     }
     
     // NSTextInputClient protocol implementation
     open func hasMarkedText() -> Bool {
-        // print ("hasMarkedText: This should return the actual range from the selection")
-        // TODO
-        return false
+        markedTextStorage != nil
     }
     
     // NSTextInputClient protocol implementation
     open func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
-        print ("Attribuetd string")
+        // Return the marked text when the requested range overlaps it.
+        if let marked = markedTextStorage, range.location != NSNotFound, range.location < marked.length {
+            let clampedLength = min(range.length, marked.length - range.location)
+            if clampedLength > 0 {
+                let clampedRange = NSRange(location: range.location, length: clampedLength)
+                actualRange?.pointee = clampedRange
+                return marked.attributedSubstring(from: clampedRange)
+            }
+        }
         return nil
     }
-    
+
     // NSTextInputClient Protocol implementation
     open func validAttributesForMarkedText() -> [NSAttributedString.Key] {
-        // TODO print ("validAttributesForMarkedText: This should return the actual range from the selection")
-        return []
+        [.underlineStyle, .markedClauseSegment, .glyphInfo]
     }
     
     // NSTextInputClient protocol implementation
@@ -1634,8 +1704,10 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func characterIndex(for point: NSPoint) -> Int {
-        print ("characterIndex:for point: This should return the actual range from the selection")
-        return NSNotFound
+        let local = convert(point, from: nil)
+        let col = Int(local.x / cellDimension.width)
+        let row = Int((bounds.height - local.y) / cellDimension.height)
+        return row * terminal.cols + col
     }
     
     open func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {


### PR DESCRIPTION
It would behave identical to Apple terminal app with these changes

Generated with Claude:

The NSTextInputClient implementation on macOS had stub/incomplete marked text methods that caused dictation to silently fail (system "bonk" sound) and IME composition to not track state properly.

Changes:
- Track marked text state (markedTextStorage/markedSelectedRange) across setMarkedText, unmarkText, and insertText
- selectedRange() now returns the cursor position as a zero-length range instead of NSRange(NSNotFound, 0) when there is no selection, giving the input system a valid anchor for dictation/IME
- hasMarkedText() and markedRange() return actual state instead of hardcoded false/empty
- attributedSubstring(forProposedRange:) returns marked text content when the requested range overlaps
- validAttributesForMarkedText() returns standard attributes
- characterIndex(for:) computes grid position from screen coordinates
- Add a floating overlay (NSTextField) at the caret position that shows live dictation/IME composition text with an underline, matching the terminal font and colors