### PR TITLE
Fix Home/End keys not sending escape sequences on macOS

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1075,7 +1075,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
                 if sendKittyFunctionalKey(.tab, modifiers: [.shift]) { return }
             case #selector(moveToBeginningOfLine(_:)):
                 if sendKittyFunctionalKey(.home) { return }
+            case #selector(scrollToBeginningOfDocument(_:)):
+                if sendKittyFunctionalKey(.home) { return }
             case #selector(moveToEndOfLine(_:)):
+                if sendKittyFunctionalKey(.end) { return }
+            case #selector(scrollToEndOfDocument(_:)):
                 if sendKittyFunctionalKey(.end) { return }
             case #selector(scrollPageUp(_:)):
                 fallthrough
@@ -1120,7 +1124,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             send (EscapeSequences.cmdBackTab)
         case #selector(moveToBeginningOfLine(_:)):
             send (terminal.applicationCursor ? EscapeSequences.moveHomeApp : EscapeSequences.moveHomeNormal)
+        case #selector(scrollToBeginningOfDocument(_:)):
+            send (terminal.applicationCursor ? EscapeSequences.moveHomeApp : EscapeSequences.moveHomeNormal)
         case #selector(moveToEndOfLine(_:)):
+            send (terminal.applicationCursor ? EscapeSequences.moveEndApp : EscapeSequences.moveEndNormal)
+        case #selector(scrollToEndOfDocument(_:)):
             send (terminal.applicationCursor ? EscapeSequences.moveEndApp : EscapeSequences.moveEndNormal)
         case #selector(scrollPageUp(_:)):
             fallthrough


### PR DESCRIPTION
## Summary

On macOS, pressing the Home/End keys triggers `scrollToBeginningOfDocument:` / `scrollToEndOfDocument:` via the NSResponder chain. `doCommand(by:)` only handled `moveToBeginningOfLine:` / `moveToEndOfLine:` (which map to Cmd+Left/Right), so Home/End fell through to the default case and were silently dropped with an "Unhandle selector" print.

This adds the missing cases in both the standard and Kitty keyboard protocol paths, sending the same escape sequences already used for `moveToBeginningOfLine:` / `moveToEndOfLine:`.

## Changes

- Handle `scrollToBeginningOfDocument:` → send Home escape sequence (`\e[H` / `\eOH`)
- Handle `scrollToEndOfDocument:` → send End escape sequence (`\e[F` / `\eOF`)
- Applied to both standard mode and Kitty keyboard protocol mode

## Test plan

- [x] Verified Home/End keys work at shell prompt (bash/zsh)
- [x] Verified Home/End keys work in vim (normal and insert mode)
