### PR TITLE
Disable opportunistic Subprocess imports in LocalProcess

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -9,13 +9,9 @@
 #if !os(iOS) && !os(Windows)
 import Foundation
 import Dispatch
-#if canImport(Subprocess)
+#if false //canImport(Subprocess)
 import Subprocess
-#if canImport(System)
 import System
-#else
-import SystemPackage
-#endif
 #endif
 
 /// Delegate that is invoked by the ``LocalProcess`` class in response to various
@@ -98,7 +94,7 @@ public class LocalProcess {
     private var pendingScheduled = false
     private let pendingLock = NSLock()
     
-    #if canImport(Subprocess)
+    #if false //canImport(Subprocess)
     // Swift Subprocess related properties
     private var subprocessTask: Task<Void, Error>?
     private var masterFd: Int32 = -1
@@ -204,7 +200,7 @@ public class LocalProcess {
     /* Used to generate the next file name counter */
     var logFileCounter = 0
     
-    #if canImport(Subprocess)
+    #if false //canImport(Subprocess)
     // Create pseudo-terminal pair using openpty
     private func createPseudoTerminal() throws -> (master: Int32, slave: Int32) {
         var master: Int32 = -1
@@ -322,14 +318,14 @@ public class LocalProcess {
             return
         }
         
-        #if canImport(Subprocess)
+        #if false //canImport(Subprocess)
         startProcessWithSubprocess(executable: executable, args: args, environment: environment, execName: execName, currentDirectory: currentDirectory)
         #else
         startProcessWithForkpty(executable: executable, args: args, environment: environment, execName: execName, currentDirectory: currentDirectory)
         #endif
     }
     
-    #if canImport(Subprocess)
+    #if false //canImport(Subprocess)
     private func startProcessWithSubprocess(executable: String, args: [String], environment: [String]?, execName: String?, currentDirectory: String?) {
         do {
             var size = delegate?.getWindowSize () ?? winsize()
@@ -477,7 +473,7 @@ public class LocalProcess {
 
     public func terminate()
     {
-        #if canImport(Subprocess)
+        #if false //canImport(Subprocess)
         if let task = subprocessTask {
             task.cancel()
             subprocessTask = nil


### PR DESCRIPTION
## Summary

This change disables the dormant `swift-subprocess` code path in `LocalProcess` by replacing all `#if canImport(Subprocess)` checks with `#if false //canImport(Subprocess)`.

## Why

`SwiftTerm` does not currently declare `Subprocess` as a target dependency, but `LocalProcess.swift` still contains conditional imports and execution paths for it.

In downstream projects, adding `swift-subprocess` at the app level can unexpectedly make `SwiftTerm` try to compile against `Subprocess`, even though `SwiftTerm` itself does not own that dependency. This can lead to build failures such as:

`missing required module '_SubprocessCShims'`

## What changed

- Disabled all `Subprocess`-guarded blocks in `LocalProcess`
- Kept `LocalProcess` on the existing `forkpty` implementation
- Prevented parent package dependencies from implicitly changing SwiftTerm's compile path

## Scope

This is an intentionally small stability fix. It does not introduce new behavior; it only prevents an undeclared optional dependency from affecting SwiftTerm builds.

## Validation

- `swift build --target SwiftTerm`
