### PR TITLE
Send arrow keys on scroll wheel when alternate screen buffer is active

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2173,7 +2173,18 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         if event.deltaY == 0 {
             return
         }
-        if terminal.isDisplayBufferAlternate {
+        if allowMouseReporting && terminal.mouseMode != .off {
+            let hit = calculateMouseHit(with: event)
+            let displayBuffer = terminal.displayBuffer
+            let screenRow = max (0, min (displayBuffer.rows - 1, hit.grid.row - displayBuffer.yDisp))
+            let button = event.deltaY > 0 ? 4 : 5
+            let flags = event.modifierFlags
+            let buttonFlags = terminal.encodeButton(button: button, release: false, shift: flags.contains(.shift), meta: flags.contains(.option), control: flags.contains(.control))
+            let lines = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
+            for _ in 0..<lines {
+                terminal.sendEvent(buttonFlags: buttonFlags, x: hit.grid.col, y: screenRow, pixelX: hit.pixels.col, pixelY: hit.pixels.row)
+            }
+        } else if terminal.isDisplayBufferAlternate {
             let lines = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
             for _ in 0..<lines {
                 if event.deltaY > 0 {


### PR DESCRIPTION
## Summary

When applications like vim, less, or man are using the alternate screen buffer, scroll wheel (Touchpad scroll) events now send up/down arrow key escape sequences instead of scrolling the terminal scrollback history. This matches the standard behavior of Terminal.app, iTerm2, Alacritty, and kitty.

Normal screen scrollback behavior is unchanged.

## Changes

- Modified `scrollWheel(with:)` in `MacTerminalView.swift` to check `terminal.isDisplayBufferAlternate`
- When alternate screen is active, scroll events are converted to up/down arrow key sequences via `sendKeyUp()`/`sendKeyDown()`, which already handle `applicationCursor` mode
- When mouse reporting is enabled (`allowMouseReporting && terminal.mouseMode != .off`), `scrollWheel(with:)` now sends scroll events as mouse button  
  4/5 via `terminal.encodeButton()` and `terminal.sendEvent()`, allowing applications like vim, tmux, and htop to receive proper scroll events through  the mouse protocol (SGR, X10, UTF-8, etc.)
- When on the normal screen, existing scrollback behavior is preserved


## Future considerations

~~Scroll wheel events are not currently sent as mouse protocol events (button 4/5) when mouse reporting is enabled. Applications that use mouse reporting (e.g., vim with `set mouse=a`, tmux, htop) would ideally receive scroll as mouse events rather than arrow keys. This is a pre-existing gap unrelated to this change and could be addressed separately.~~ **Added, see "Changes"**
