### PR TITLE
Fix: initialize buffer margins so CSI T scroll-down works on alt screen

### DIFF
--- a/Sources/SwiftTerm/Buffer.swift
+++ b/Sources/SwiftTerm/Buffer.swift
@@ -281,6 +281,8 @@ public final class Buffer {
         xBase = 0
         _scrollTop = 0
         _scrollBottom = rows - 1
+        _marginLeft = 0
+        _marginRight = cols - 1
         linesTop = 0
         _x = 0
         _y = 0
@@ -362,6 +364,8 @@ public final class Buffer {
         _linesWithImagesCount = 0
         scrollTop = 0
         scrollBottom = rows - 1
+        marginLeft = 0
+        marginRight = cols - 1
 
         // Figure out how to do this elegantly
         // SetupTabStops ()

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -4688,19 +4688,29 @@ open class Terminal {
         let p = min (max (pars.count == 0 ? 1 : pars [0], 1), rows)
         let da = CharData.defaultAttr
 
-        let row = buffer.scrollTop + buffer.yBase
+        if marginMode {
+            let row = buffer.scrollTop + buffer.yBase
 
-        let columnCount = buffer.marginRight-buffer.marginLeft+1
-        let rowCount = buffer.scrollBottom-buffer.scrollTop
-        for _ in 0..<p {
-            for i in (0..<rowCount).reversed() {
-                let src = buffer.lines [row+i]
-                let dst = buffer.lines [row+i+1]
-                
-                dst.copyFrom(src, srcCol: buffer.marginLeft, dstCol: buffer.marginLeft, len: columnCount)
+            let columnCount = buffer.marginRight-buffer.marginLeft+1
+            let rowCount = buffer.scrollBottom-buffer.scrollTop
+            for _ in 0..<p {
+                for i in (0..<rowCount).reversed() {
+                    let src = buffer.lines [row+i]
+                    let dst = buffer.lines [row+i+1]
+
+                    dst.copyFrom(src, srcCol: buffer.marginLeft, dstCol: buffer.marginLeft, len: columnCount)
+                }
+                let last = buffer.lines [row]
+                last.fill (with: CharData (attribute: da), atCol: buffer.marginLeft, len: columnCount)
             }
-            let last = buffer.lines [row]
-            last.fill (with: CharData (attribute: da), atCol: buffer.marginLeft, len: columnCount)
+        } else {
+            for _ in 0..<p {
+                buffer.lines.splice (start: buffer.yBase + buffer.scrollBottom, deleteCount: 1,
+                                     items: [], change: { line in updateRange (line)})
+                buffer.lines.splice (start: buffer.yBase + buffer.scrollTop, deleteCount: 0,
+                                     items: [buffer.getBlankLine (attribute: da)],
+                                     change: { line in updateRange (line) })
+            }
         }
         // this.maxRange();
         updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)


### PR DESCRIPTION
Buffer.init never set _marginRight, leaving it at 0 instead of cols-1. cmdScrollDown (CSI T) unconditionally used marginRight to determine how many columns to copy per line, so on the alternate buffer it only copied 1 column, making scroll-down appear to update only the first lines.

This caused visible corruption in TUI apps like htop when scrolling up via mouse wheel, since htop uses CSI T to shift content down within its scroll region. reverseIndex (ESC M) was unaffected because it checks marginMode and moves whole line objects when margins aren't active.

Before screencap (notice the top ~10 processes are the only ones that refresh on scroll up):

https://github.com/user-attachments/assets/cf59b5ec-01a4-443c-968e-dc22cd57a3a3


