### PR TITLE
feat: expose userScrolling for scroll-lock during output

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1945,7 +1945,8 @@ extension TerminalView {
     {
         search.invalidate()
         // Preserve manual selection while output is streaming when mouse reporting is disabled.
-        if allowMouseReporting {
+        // Also preserve when user is scrolled back (viewing history while output arrives).
+        if allowMouseReporting && !terminal.userScrolling {
             selection.active = false
         }
         startDisplayUpdates()

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -601,7 +601,8 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     open func linefeed(source: Terminal) {
         // Preserve manual selection while output is streaming when mouse reporting is disabled.
-        if allowMouseReporting {
+        // Also preserve when user is scrolled back (viewing history while output arrives).
+        if allowMouseReporting && !source.userScrolling {
             selection.selectNone()
         }
     }
@@ -2259,7 +2260,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
     }
     
-    public override func scrollWheel(with event: NSEvent) {
+    open override func scrollWheel(with event: NSEvent) {
         if event.deltaY == 0 {
             return
         }

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -422,7 +422,7 @@ open class Terminal {
     var refreshEnd = -1
     var scrollInvariantRefreshStart = Int.max
     var scrollInvariantRefreshEnd = -1
-    var userScrolling = false
+    public var userScrolling = false
     var lineFeedMode = false
     
     // We do not implement smooth scrolling here, dubious value, but


### PR DESCRIPTION
## Summary
- Make `Terminal.userScrolling` public so host apps can set it when the user scrolls away from the bottom
- Guard selection clearing in `feedPrepare()` and `linefeed()` with the `userScrolling` flag so active selections persist while new output streams in
- `scrollWheel` changed from `public` to `open` in `MacTerminalView` to allow subclass override

The `userScrolling` flag already exists and is checked in `Terminal.scroll()` (lines 5245, 5255, 5281) — these changes simply wire it up for external consumers.

## Motivation
When using terminal-based AI tools (like Claude Code) that produce long streaming output, users cannot:
1. Scroll up to read earlier output without being snapped back to the bottom
2. Select text without the selection being cleared by incoming data
3. Maintain a selection while new content arrives

These 3 minimal changes (~6 lines) fix all three issues by leveraging the existing `userScrolling` infrastructure.

## Test plan
- [ ] Verify default behavior unchanged (`userScrolling` defaults to `false`)
- [ ] Set `terminal.userScrolling = true` and verify scroll position is preserved during `feed()`
- [ ] Set `terminal.userScrolling = true` and verify text selection persists through `feed()`
- [ ] Verify `scrollWheel` can be overridden in subclass

🤖 Generated with [Claude Code](https://claude.com/claude-code)