### PR TITLE
Make Mac mouse event overrides open

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1959,7 +1959,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
     }
     
-    public override func mouseDown(with event: NSEvent) {
+    open override func mouseDown(with event: NSEvent) {
         if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
             sharedMouseEvent(with: event)
             return
@@ -1998,7 +1998,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     var didSelectionDrag: Bool = false
     
-    public override func mouseUp(with event: NSEvent) {
+    open override func mouseUp(with event: NSEvent) {
         let hit = calculateMouseHit(with: event).grid
         updateHoverLink(at: hit, commandOverride: commandActive || event.modifierFlags.contains(.command))
         if let result = linkForClick(at: hit, hasCommandModifier: event.modifierFlags.contains(.command)) {
@@ -2018,7 +2018,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         didSelectionDrag = false
     }
     
-    public override func mouseDragged(with event: NSEvent) {
+    open override func mouseDragged(with event: NSEvent) {
         let displayBuffer = terminal.displayBuffer
         let mouseHit = calculateMouseHit(with: event)
         let hit = mouseHit.grid


### PR DESCRIPTION
## Summary

Promotes three method declarations in `MacTerminalView.swift` from `public override` to `open override`, so subclasses outside the SwiftTerm module can override `mouseDown` / `mouseUp` / `mouseDragged`.

## Why

I'm building a terminal app on top of SwiftTerm and needed to add three small behaviors via a `TerminalView` subclass:

- focus-on-click (so pane switching feels right)
- shift-click selection anchoring
- drag-to-select auto-scroll when the cursor reaches the pane edge

All three call `super` — I just want to add to SwiftTerm's handling, not replace it. The only blocker was the access level. Most override-friendly hooks on `TerminalView` are already `open`; this aligns these three with the rest of the class.

## How I'd been getting away with it

For an embarrassing number of weeks I was hand-editing `.build/checkouts/SwiftTerm/.../MacTerminalView.swift` every time SPM re-resolved, which I had quietly convinced myself was a reasonable life choice. Then I spun up a git worktree, watched five unrelated branches fail to build, and rediscovered that `.build/checkouts/` is, in fact, not a durable storage medium.

## What changes

Three lines, same pattern:

```diff
-    public override func mouseDown(with event: NSEvent) {
+    open override func mouseDown(with event: NSEvent) {
...
-    public override func mouseUp(with event: NSEvent) {
+    open override func mouseUp(with event: NSEvent) {
...
-    public override func mouseDragged(with event: NSEvent) {
+    open override func mouseDragged(with event: NSEvent) {
```

No behavioral changes, binary-compatible with existing consumers, no new tests required — it's an access-level change only.

Thanks for SwiftTerm — it's been a genuine pleasure to build on. Happy to adjust the approach if you'd prefer a different angle.