### PR TITLE
Fix Terminal retain cycle in resetNormalBuffer()

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -777,7 +777,7 @@ open class Terminal {
     
     public func resetNormalBuffer() {
         normalBuffer = Buffer(cols: cols, rows: rows, tabStopWidth: tabStopWidth, scrollback: options.scrollback)
-        normalBuffer.scroll = scroll(isWrapped:)
+        normalBuffer.scroll = { [weak self] wrapped in self?.scroll(isWrapped: wrapped) }
 
         normalBuffer.fillViewportRows()
         normalBuffer.setupTabStops(tabStopWidth: tabStopWidth)

--- a/Tests/SwiftTermTests/RetainCycleTests.swift
+++ b/Tests/SwiftTermTests/RetainCycleTests.swift
@@ -1,0 +1,41 @@
+#if os(macOS)
+import Foundation
+import Testing
+
+@testable import SwiftTerm
+
+private class NoOpTerminalDelegate: TerminalDelegate {
+    func send(source: Terminal, data: ArraySlice<UInt8>) {}
+}
+
+final class RetainCycleTests {
+
+    @Test("Terminal deallocates after resetNormalBuffer()")
+    func terminalDeallocatesAfterResetNormalBuffer() {
+        weak var weakTerminal: Terminal?
+
+        autoreleasepool {
+            let delegate = NoOpTerminalDelegate()
+            let terminal = Terminal(delegate: delegate, options: TerminalOptions(cols: 80, rows: 24))
+            weakTerminal = terminal
+            terminal.resetNormalBuffer()
+        }
+
+        #expect(weakTerminal == nil, "Terminal leaked — retain cycle in resetNormalBuffer() scroll closure")
+    }
+
+    @Test("Terminal deallocates after resetToInitialState()")
+    func terminalDeallocatesAfterResetToInitialState() {
+        weak var weakTerminal: Terminal?
+
+        autoreleasepool {
+            let delegate = NoOpTerminalDelegate()
+            let terminal = Terminal(delegate: delegate, options: TerminalOptions(cols: 80, rows: 24))
+            weakTerminal = terminal
+            terminal.resetToInitialState()
+        }
+
+        #expect(weakTerminal == nil, "Terminal leaked — retain cycle after resetToInitialState()")
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

`resetNormalBuffer()` assigns the scroll closure using a bare method reference (`scroll(isWrapped:)`), which captures `self` strongly. This creates a retain cycle: Terminal → Buffer → scroll closure → Terminal.

The `init()` already does this correctly with `[weak self]`, but `resetNormalBuffer()` — called by `resetToInitialState()` and any ESC c (RIS) sequence — doesn't. So every buffer clear permanently leaks the entire Terminal object along with its scrollback, both Buffers, KittyGraphicsState, and all BufferLine allocations. Over long sessions with periodic clears (agents running `clear`, TUI apps resetting state), memory just keeps growing.

I noticed this in my app where terminals run for hours — memory would climb steadily and never come back down.

## Fix

One-line change: wrap the scroll closure in `[weak self]` to match how `init()` already does it.

## Tests

Added `RetainCycleTests.swift` with two tests — one for `resetNormalBuffer()` and one for `resetToInitialState()`. They use a weak reference to verify the Terminal actually deallocates. Without the fix both tests fail (confirming the leak), with the fix both pass.