### PR TITLE
Fix Metal row cache stale content

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -94,6 +94,7 @@ struct RowDrawBuffers {
 }
 
 struct RowCacheEntry {
+    var fingerprint: Int
     var data: RowDrawData?
     var buffers: RowDrawBuffers?
 }
@@ -647,9 +648,12 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         var rebuiltRows = 0
         var cachedRows = 0
         for row in visibleRange {
+            let fingerprint = rowFingerprint(buffer.lines[row])
             var entry = rowCache[row]
+            let contentChanged = entry.map { $0.fingerprint != fingerprint } ?? false
             let needsRebuild = needsFullRebuild ||
                 (rebuildRange?.contains(row) ?? false) ||
+                contentChanged ||
                 entry == nil ||
                 (bufferingMode == .perFrameAggregated && entry?.data == nil)
             let rowBuffers: RowDrawBuffers?
@@ -665,7 +669,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                entry = RowCacheEntry(data: rowData, buffers: buffers)
+                entry = RowCacheEntry(fingerprint: fingerprint, data: rowData, buffers: buffers)
                 rowCache[row] = entry
                 rowBuffers = buffers
                 rebuiltRows += 1
@@ -680,7 +684,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                                           scale: scale,
                                                           virtualPlacementsByImageId: virtualPlacementsByImageId)
                 if cached.data == nil {
-                    entry = RowCacheEntry(data: rowData, buffers: cached.buffers)
+                    entry = RowCacheEntry(fingerprint: fingerprint, data: rowData, buffers: cached.buffers)
                     rowCache[row] = entry
                 }
                 if bufferingMode == .perRowPersistent {
@@ -707,7 +711,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                entry = RowCacheEntry(data: rowData, buffers: buffers)
+                entry = RowCacheEntry(fingerprint: fingerprint, data: rowData, buffers: buffers)
                 rowCache[row] = entry
                 rowBuffers = buffers
                 rebuiltRows += 1
@@ -755,6 +759,44 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
         atlasResetHandled = false
         return result
+    }
+
+    private func rowFingerprint(_ line: BufferLine) -> Int {
+        var hasher = Hasher()
+        hasher.combine(line.count)
+        hasher.combine(line.isWrapped)
+        hasher.combine(renderModeFingerprint(line.renderMode))
+        if let images = line.images {
+            hasher.combine(images.count)
+            for image in images {
+                hasher.combine(image.col)
+                hasher.combine(image.pixelWidth)
+                hasher.combine(image.pixelHeight)
+            }
+        } else {
+            hasher.combine(0)
+        }
+        for col in 0..<line.count {
+            let cell = line[col]
+            hasher.combine(cell.code)
+            hasher.combine(cell.width)
+            hasher.combine(cell.payload.code)
+            hasher.combine(cell.attribute)
+        }
+        return hasher.finalize()
+    }
+
+    private func renderModeFingerprint(_ renderMode: BufferLine.RenderLineMode) -> Int {
+        switch renderMode {
+        case .single:
+            return 0
+        case .doubleWidth:
+            return 1
+        case .doubledTop:
+            return 2
+        case .doubledDown:
+            return 3
+        }
     }
 
     private func intersect(_ range: ClosedRange<Int>?, _ other: ClosedRange<Int>) -> ClosedRange<Int>? {


### PR DESCRIPTION
## Problem

The Metal renderer can reuse a cached row even when the underlying `BufferLine` content changed in place. In alt-screen TUIs this can leave stale visual state on screen until another redraw happens.

I saw this with a long prompt where inserting a newline caused a blank line to visually disappear and glue adjacent rows together. Typing another character forced a repaint and healed the display.


Here some images to exemplify the issue:
<img width="799" height="273" alt="metal-row-cache-before-shift-enter" src="https://github.com/user-attachments/assets/e11b9d11-1725-4978-aa26-d476de891b24" />
I start with this, then add a new line

<img width="818" height="283" alt="metal-row-cache-after-stale-line-glue" src="https://github.com/user-attachments/assets/50f06653-c559-4981-b91d-4c4a3e3939d3" />
it incorrectly removes the empty line above text block and show this stale state until we type another letter.

## Fix

Track a lightweight fingerprint for each rendered row and include that fingerprint in the Metal row cache decision. Rows are now reused only when their rendered content is still the same.

## Tests

Manually verified in Maestri with the Metal renderer enabled using an alt-screen TUI and long wrapped input. Inserting a newline now updates immediately without stale glued rows.
