### PR TITLE
Fix terminal background margin rendering

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1376,13 +1376,28 @@ extension TerminalView {
                             #endif
 
                             if endColumn >= terminal.cols {
-                                rect.size.width = frame.width - rect.origin.x
+                                if backgroundColor == nativeBackgroundColor {
+                                    rect.size.width = frame.width - rect.origin.x
+                                } else {
+                                    let marginX = rect.origin.x + rect.size.width
+                                    if marginX < frame.width {
+                                        let marginRect = CGRect(x: marginX, y: rect.origin.y, width: frame.width - marginX, height: rect.size.height)
+                                        #if os(macOS)
+                                        nativeBackgroundColor.setFill()
+                                        marginRect.fill()
+                                        #else
+                                        context.setFillColor(nativeBackgroundColor.cgColor)
+                                        context.fill(marginRect)
+                                        #endif
+                                    }
+                                }
                             }
 
                             #if os(macOS)
                             backgroundColor.setFill()
                             rect.fill()
                             #else
+                            context.setFillColor(backgroundColor.cgColor)
                             context.fill(rect)
                             #endif
                         }

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -1016,7 +1016,19 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                             let y0 = lineOriginPx.y
                             var x1 = lineOriginPx.x + (CGFloat(startColumn + columnSpan) * cellWidthPx)
                             if endColumn >= buffer.cols {
-                                x1 = lineOriginPx.x + viewWidthPx
+                                if backgroundColor == terminalView.nativeBackgroundColor {
+                                    x1 = lineOriginPx.x + viewWidthPx
+                                } else {
+                                    let marginX0 = x1
+                                    let marginX1 = lineOriginPx.x + viewWidthPx
+                                    if marginX1 > marginX0 {
+                                        let (mx0, my0, mx1, my1) = transformRect(x0: marginX0, y0: y0, x1: marginX1, y1: lineOriginPx.y + cellHeightPx)
+                                        if let mClipped = self.clipRect(mx0, my0, mx1, my1, clipRect) {
+                                            let defaultBg = colorToSIMD(terminalView.nativeBackgroundColor)
+                                            backgroundCells.append(makeColorCell(x0: mClipped.0, y0: mClipped.1, x1: mClipped.2, y1: mClipped.3, color: defaultBg))
+                                        }
+                                    }
+                                }
                             }
                             let y1 = lineOriginPx.y + cellHeightPx
                             let (tx0, ty0, tx1, ty1) = transformRect(x0: x0, y0: y0, x1: x1, y1: y1)


### PR DESCRIPTION
## Problem

When the terminal view width is not an exact multiple of the cell width, there is a small margin outside the grid on the right edge.

SwiftTerm was extending the last cell's background color into that margin. That makes application-controlled backgrounds visually protrude outside the terminal grid. If that extension is removed without filling the margin, the right edge can instead show an unpainted black strip.

<img width="772" height="395" alt="right-margin-background-protrudes-full" src="https://github.com/user-attachments/assets/cffccd73-c36b-4484-9589-01e30de013f4" />


## Fix

Keep application-set background colors inside the grid cells, and fill the non-grid margin with the terminal's default background color.

This matches the expected terminal behavior: applications control cell backgrounds, while the view margin belongs to the terminal background.

## Tests

Manually verified in Maestri with Gemini CLI in both the Core Graphics and Metal renderers. The input row no longer protrudes into the right margin, and the margin no longer appears as an unpainted strip.
