### PR TITLE
Render local input responses immediately

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -380,6 +380,14 @@ extension TerminalView {
                 self.queuePendingDisplay()
                 self.terminalDelegate?.scrolled(source: self, position: self.scrollPosition)
             }
+            guard syncSequenceSettleMs > 0 else {
+                if Thread.isMainThread {
+                    work.perform()
+                } else {
+                    DispatchQueue.main.async(execute: work)
+                }
+                return
+            }
             syncEndRenderTimer = work
             DispatchQueue.main.asyncAfter(
                 deadline: .now() + .milliseconds(syncSequenceSettleMs),
@@ -1971,7 +1979,29 @@ extension TerminalView {
     func feedFinish ()
     {
         suspendDisplayUpdates ()
+        if shouldDisplayImmediatelyAfterUserInput() {
+            displayImmediately()
+            return
+        }
         queuePendingDisplay()
+    }
+
+    private func shouldDisplayImmediatelyAfterUserInput() -> Bool {
+        guard !terminal.synchronizedOutputActive && !inSyncSequence else { return false }
+        guard lastUserInputUptimeNs > 0 else { return false }
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now >= lastUserInputUptimeNs else { return false }
+        return now - lastUserInputUptimeNs <= interactiveInputDisplayWindowNs
+    }
+
+    private func displayImmediately() {
+        guard !Thread.isMainThread else {
+            updateDisplay()
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.updateDisplay()
+        }
     }
     
     /// Sends data to the terminal emulator for interpretation, this can be invoked from a background thread
@@ -2019,6 +2049,7 @@ extension TerminalView {
      */
     public func send(data: ArraySlice<UInt8>)
     {
+        lastUserInputUptimeNs = DispatchTime.now().uptimeNanoseconds
         ensureCaretIsVisible ()
         #if os(iOS) || os(visionOS)
         if TerminalView.textInputDebugEnabled {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -117,6 +117,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     var syncEndRenderTimer: DispatchWorkItem? = nil
     /// True from first BSU until syncSequenceSettleMs after last ESU.
     var inSyncSequence: Bool = false
+    /// Output received shortly after local input is likely echo or prompt redraw; render it without frame throttling.
+    var lastUserInputUptimeNs: UInt64 = 0
+    let interactiveInputDisplayWindowNs: UInt64 = 150_000_000
     /// Milliseconds to wait after the last ESU before rendering.
     /// Terminal multiplexers deliver screen repaints as multiple BSU/ESU
     /// pairs across separate I/O callbacks. This window lets the full

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -195,6 +195,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var syncEndRenderTimer: DispatchWorkItem? = nil
     /// True from first BSU until syncSequenceSettleMs after last ESU.
     var inSyncSequence: Bool = false
+    /// Output received shortly after local input is likely echo or prompt redraw; render it without frame throttling.
+    var lastUserInputUptimeNs: UInt64 = 0
+    let interactiveInputDisplayWindowNs: UInt64 = 150_000_000
     /// Milliseconds to wait after the last ESU before rendering.
     var syncSequenceSettleMs: Int = 100
 #if canImport(MetalKit)


### PR DESCRIPTION
## Problem

When DEC synchronized output mode is active, SwiftTerm can defer redraws while waiting for the sync sequence to settle. That is correct for application output, but it can make local interactive input feel stale when a TUI leaves synchronized output enabled longer than expected.

The typed bytes are processed, but the visual echo may appear delayed.

## Fix

Force an immediate redraw for local input responses so typing remains responsive even when synchronized output throttling is active.

The synchronized-output coalescing path is preserved for normal application output.

## Tests

Manually verified in Maestri with interactive terminal input while running TUIs that use synchronized output. Typed characters now render immediately without waiting for the settle fallback.
