### PR TITLE
Fix hidden scroller layout on macOS

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -299,6 +299,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             } else {
                 addSubview(mtkView, positioned: .below, relativeTo: nil)
             }
+            if let scroller = scroller {
+                addSubview(scroller, positioned: .above, relativeTo: mtkView)
+            }
             metalView = mtkView
             metalRenderer = renderer
             needsDisplay = false
@@ -538,8 +541,8 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
 
     func getScrollerFrame() -> CGRect {
-        let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
-        return NSRect(x: bounds.maxX - scrollerWidth, y: 0, width: scrollerWidth, height: bounds.height)
+        let width = reservedScrollerWidth
+        return NSRect(x: bounds.maxX - width, y: 0, width: width, height: bounds.height)
     }
 
     func setupScroller()
@@ -592,17 +595,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
     }
 
+    private var reservedScrollerWidth: CGFloat {
+        scroller?.isHidden == true ? 0 : scrollerWidth
+    }
+
     /**
      * Given the current set of columns and rows returns a frame that would host this control.
      */
     open func getOptimalFrameSize () -> NSRect
     {
-        return NSRect (x: 0, y: 0, width: cellDimension.width * CGFloat(terminal.cols) + scrollerWidth, height: cellDimension.height * CGFloat(terminal.rows))
+        return NSRect (x: 0, y: 0, width: cellDimension.width * CGFloat(terminal.cols) + reservedScrollerWidth, height: cellDimension.height * CGFloat(terminal.rows))
     }
 
     func getEffectiveWidth (size: CGSize) -> CGFloat
     {
-        return (size.width - scrollerWidth)
+        max(0, size.width - reservedScrollerWidth)
     }
     
     open func scrolled(source terminal: Terminal, yDisp: Int) {


### PR DESCRIPTION
## Problem

On macOS, hiding SwiftTerm's built-in standalone scroller can still leave layout space reserved for it. Embedders that provide their own native scroller or no visible scroller can end up with an unnecessary blank strip on the right side of the terminal.

## Fix

Make the effective scroller width follow the scroller's visibility so hidden scrollers do not reserve layout width. Also ensure the scroller stays above the Metal view when it is visible.

## Tests

Manually verified in Maestri with both renderers. Hiding the built-in scroller no longer leaves a right-side gap, and the scroller is not covered when Metal is enabled at startup.
