### PR TITLE
Report PTY pixel size from terminal cells

### DIFF
--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -196,8 +196,10 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
      */
     open func getWindowSize () -> winsize
     {
-        let f: CGRect = self.frame
-        return winsize(ws_row: UInt16(terminal.rows), ws_col: UInt16(terminal.cols), ws_xpixel: UInt16 (f.width), ws_ypixel: UInt16 (f.height))
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1
+        let pxW = Int((cellDimension?.width ?? 0) * CGFloat(terminal.cols) * scale)
+        let pxH = Int((cellDimension?.height ?? 0) * CGFloat(terminal.rows) * scale)
+        return winsize(ws_row: UInt16(terminal.rows), ws_col: UInt16(terminal.cols), ws_xpixel: UInt16(pxW), ws_ypixel: UInt16(pxH))
     }
 }
 


### PR DESCRIPTION
## Problem

`getWindowSize()` reports the view's raw frame size as `ws_xpixel`/`ws_ypixel`. When the view size includes fractional extra space outside the terminal grid, applications that inspect the PTY pixel size can see dimensions that do not match the reported row/column grid.

## Fix

Report PTY pixel dimensions from the actual terminal grid: `cols * cellWidth` and `rows * cellHeight`, converted to backing pixels.

This keeps the pixel size consistent with the row and column count.

## Tests

Manually verified in Maestri that local terminals continue resizing correctly after the change.
