### PR TITLE
Allow overriding Metal renderer scale

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -323,8 +323,11 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
 #if os(macOS)
         rasterizer.fontSmoothing = terminalView.fontSmoothing
-#endif
+        let scale = terminalView.metalRenderingScaleFactor()
+        view.layer?.contentsScale = scale
+#else
         let scale = terminalView.backingScaleFactor()
+#endif
         view.drawableSize = CGSize(width: view.bounds.width * scale, height: view.bounds.height * scale)
         let cursorStyle = terminalView.terminal.options.cursorStyle
         let shouldBlink = isBlinkStyle(cursorStyle) && !terminalView.terminal.cursorHidden

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -144,6 +144,18 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     /// new mode on the next frame.
     public var metalBufferingMode: MetalBufferingMode = .perRowPersistent
 
+    /// Overrides the backing scale used by the Metal renderer.
+    ///
+    /// Client applications that apply their own view transforms can set this
+    /// to the effective on-screen pixels-per-point value so Metal rasterizes
+    /// glyphs at the same scale the transformed view is displayed at.
+    public var metalScaleFactorOverride: CGFloat? {
+        didSet {
+            guard useMetalRenderer else { return }
+            requestMetalDisplay()
+        }
+    }
+
     /// Whether the terminal view is currently using the Metal GPU renderer.
     ///
     /// Returns `true` after a successful call to ``setUseMetal(_:)`` with
@@ -288,6 +300,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             mtkView.autoresizingMask = [.width, .height]
             mtkView.isPaused = true
             mtkView.enableSetNeedsDisplay = true
+            mtkView.autoResizeDrawable = false
             mtkView.framebufferOnly = true
             mtkView.colorPixelFormat = .bgra8Unorm
             let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: self)
@@ -313,6 +326,10 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             }
             needsDisplay = true
         }
+    }
+
+    func metalRenderingScaleFactor() -> CGFloat {
+        max(1, metalScaleFactorOverride ?? backingScaleFactor())
     }
 #endif
     


### PR DESCRIPTION
## Problem

The Metal renderer derives its scale from the view/window backing scale. Embedders that render terminal views inside transformed containers can need a different effective scale so glyphs remain sharp and correctly sized.

## Fix

Add an optional Metal scale factor override that embedders can set when they know the terminal is being rendered under an additional transform.

When unset, SwiftTerm keeps using the existing backing-scale behavior.

## Tests

Manually verified in Maestri with the Metal renderer inside a zoomable canvas. The default behavior remains unchanged when no override is set.
