### PR TITLE
Tag CAMetalLayer with sRGB colorspace to match CoreGraphics rendering

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -304,6 +304,18 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             mtkView.autoResizeDrawable = false
             mtkView.framebufferOnly = true
             mtkView.colorPixelFormat = .bgra8Unorm
+            // Tag the metal layer with sRGB so the compositor color-manages our
+            // pixels the same way it color-manages the layer-backed NSView
+            // (whose backing store is in the display colorspace). Without this,
+            // CAMetalLayer is untagged and our raw bytes are treated as
+            // already-in-display-gamut, producing oversaturated colors on
+            // wide-gamut displays — most visible on selection highlights and
+            // any non-default cell backgrounds. NSColor components resolved via
+            // `usingColorSpace(.deviceRGB)` are sRGB-encoded on modern macOS,
+            // so this is the colorspace they actually live in.
+            if let metalLayer = mtkView.layer as? CAMetalLayer {
+                metalLayer.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+            }
             let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: self)
             mtkView.delegate = renderer
             if let caretView = caretView {

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -380,6 +380,14 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             mtkView.framebufferOnly = true
             mtkView.colorPixelFormat = .bgra8Unorm
             mtkView.isUserInteractionEnabled = false
+            // Tag the metal layer with sRGB so the compositor color-manages our
+            // pixels the same way as a regular UIView's layer. Without this,
+            // CAMetalLayer is untagged and raw bytes are treated as
+            // already-in-display-gamut, oversaturating colors on wide-gamut
+            // displays.
+            if let metalLayer = mtkView.layer as? CAMetalLayer {
+                metalLayer.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+            }
             let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: self)
             mtkView.delegate = renderer
             if let caretView = caretView {


### PR DESCRIPTION
## Problem

A regular layer-backed `NSView`/`UIView` writes its `draw(_:)` output to a backing store whose colorspace is set to the display colorspace, so the compositor color-manages those pixels, sRGB content gets converted to the display's gamut (sRGB or Display P3) at scan-out.

`CAMetalLayer.colorspace` defaults to `nil`, which tells the compositor to treat the layer's bytes as already-in-display-gamut and skip color management. On a wide-gamut display, `NSColor` values resolved via `usingColorSpace(.deviceRGB)`, which are sRGB-encoded on modern macOS, end up displayed as if they were Display P3 values, producing oversaturated, harsh-looking colors.

Most visible on selection highlights and any non-default cell backgrounds: the GPU-rendered selection looks solid and saturated while the CG-rendered selection looks subdued and translucent, even though both pipelines are fed the same source color.

I noticed this in my app (Maestri) where users could toggle Metal on/off and the selection color shifted noticeably between the two.

<img width="376" height="86" alt="cg-selection-correct" src="https://github.com/user-attachments/assets/595cd995-ca68-47ee-9d5a-7182094e3318" />
Non metal text selection

<img width="393" height="82" alt="metal-selection-broken" src="https://github.com/user-attachments/assets/da7c16a1-910d-42f3-8be2-507a7424c46b" />
Metal text selection

## Fix

Tag the metal layer with `CGColorSpace.sRGB` after creating the `MTKView` (both macOS and iOS paths) so the compositor applies the same conversion it applies to the layer-backed `NSView`/`UIView` backing store. Same source color, same on-screen pixel through both renderers.

## Tests

Manually verified in Maestri on a wide-gamut display. Selection highlights now match between the Metal and CoreGraphics paths.