### PR TITLE
Rebind Metal renderer when TerminalView is reparented to a new window

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -17,6 +17,9 @@ import Carbon.HIToolbox
 #if canImport(MetalKit)
 import MetalKit
 #endif
+#if canImport(os)
+import os.log
+#endif
 
 /**
  * TerminalView provides an AppKit front-end to the `Terminal` termininal emulator.
@@ -131,6 +134,13 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     /// Experimental GPU path: CoreText glyph atlas + Metal quads.
     /// Limitations: image caching is basic; GPU path is still evolving.
     private var useMetalRenderer = false
+    /// The NSWindow that the current `metalView`'s CAMetalLayer is bound to.
+    /// CAMetalLayer's binding to a window's WindowServer surface doesn't
+    /// survive being reparented across NSWindow instances — `present(_:)`
+    /// silently no-ops on the new window, leaving the terminal frozen on its
+    /// last frame. When `viewDidMoveToWindow` fires with a different window,
+    /// we rebuild the MTKView so a fresh CAMetalLayer binds to it.
+    private weak var metalBoundWindow: NSWindow?
     var metalDirtyRange: ClosedRange<Int>?
     var pendingMetalDisplay: Bool = false
     /// Controls how the Metal renderer builds GPU buffers each frame.
@@ -297,30 +307,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             guard let device = MTLCreateSystemDefaultDevice() else {
                 throw MetalError.deviceUnavailable
             }
-            let mtkView = MTKView(frame: bounds, device: device)
-            mtkView.autoresizingMask = [.width, .height]
-            mtkView.isPaused = true
-            mtkView.enableSetNeedsDisplay = true
-            mtkView.autoResizeDrawable = false
-            mtkView.framebufferOnly = true
-            mtkView.colorPixelFormat = .bgra8Unorm
+            let mtkView = makeMetalView(frame: bounds, device: device)
             let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: self)
             mtkView.delegate = renderer
-            if let caretView = caretView {
-                addSubview(mtkView, positioned: .below, relativeTo: caretView)
-                caretView.disableAnimations()
-                caretView.isHidden = true
-            } else {
-                addSubview(mtkView, positioned: .below, relativeTo: nil)
-            }
+            insertMetalView(mtkView, replacing: nil)
             metalView = mtkView
             metalRenderer = renderer
+            metalBoundWindow = window
             needsDisplay = false
             mtkView.setNeedsDisplay(mtkView.bounds)
         } else {
+            metalView?.delegate = nil
             metalView?.removeFromSuperview()
             metalView = nil
             metalRenderer = nil
+            metalBoundWindow = nil
             if let caretView = caretView {
                 caretView.isHidden = false
                 caretView.updateCursorStyle()
@@ -331,6 +332,139 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 
     func metalRenderingScaleFactor() -> CGFloat {
         max(1, metalScaleFactorOverride ?? backingScaleFactor())
+    }
+
+    /// Builds an MTKView configured for terminal rendering. Used by both
+    /// initial Metal enablement and `rebindMetalRendererToWindow` so the two
+    /// paths can never drift out of sync on MTKView configuration.
+    private func makeMetalView(frame: CGRect, device: MTLDevice) -> MTKView {
+        let mtkView = MTKView(frame: frame, device: device)
+        mtkView.autoresizingMask = [.width, .height]
+        mtkView.isPaused = true
+        mtkView.enableSetNeedsDisplay = true
+        mtkView.autoResizeDrawable = false
+        mtkView.framebufferOnly = true
+        mtkView.colorPixelFormat = .bgra8Unorm
+        // Tag the metal layer with sRGB so the compositor color-manages our
+        // pixels the same way it color-manages the layer-backed NSView
+        // (whose backing store is in the display colorspace). Without this,
+        // CAMetalLayer is untagged and our raw bytes are treated as
+        // already-in-display-gamut, producing oversaturated colors on
+        // wide-gamut displays — most visible on selection highlights and
+        // any non-default cell backgrounds. NSColor components resolved via
+        // `usingColorSpace(.deviceRGB)` are sRGB-encoded on modern macOS,
+        // so this is the colorspace they actually live in.
+        if let metalLayer = mtkView.layer as? CAMetalLayer {
+            metalLayer.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+        }
+        return mtkView
+    }
+
+    /// Inserts the Metal view into the view hierarchy with the correct
+    /// z-order: below the caret (which is hidden while Metal owns the
+    /// cursor), with the scroller above it. When there is no caret view
+    /// and `replacing` is non-nil, the new view takes the old one's
+    /// z-position instead. Actually removing the old view is the caller's
+    /// responsibility — the rebind path defers removal until after the new
+    /// view has drawn its first frame so the hierarchy is never empty.
+    private func insertMetalView(_ newView: MTKView, replacing oldView: MTKView?) {
+        if let caretView = caretView {
+            addSubview(newView, positioned: .below, relativeTo: caretView)
+            caretView.disableAnimations()
+            caretView.isHidden = true
+        } else if let oldView = oldView {
+            addSubview(newView, positioned: .above, relativeTo: oldView)
+        } else {
+            addSubview(newView, positioned: .below, relativeTo: nil)
+        }
+        if let scroller = scroller {
+            addSubview(scroller, positioned: .above, relativeTo: newView)
+        }
+    }
+
+    /// Swaps in a fresh MTKView (and therefore a fresh CAMetalLayer) bound
+    /// to the current window's CAContext.
+    ///
+    /// CAMetalLayer's WindowServer binding does not survive being reparented
+    /// across NSWindow instances. After the reparent, `present(_:)` silently
+    /// no-ops on the new window and the terminal stays frozen on its last
+    /// frame. Apple exposes no public API to rebind an existing layer to a
+    /// new context, so the only reliable fix is to recreate the MTKView.
+    ///
+    /// To avoid the visible CoreGraphics-fallback flash that a naive
+    /// disable/enable toggle produces, the new view is built and inserted
+    /// before the old one is removed, and we force a synchronous draw plus a
+    /// belt-and-braces `setNeedsDisplay` so the new layer has content the
+    /// moment it is in the hierarchy.
+    ///
+    /// On failure (renderer init throws), we fall back to CoreGraphics
+    /// rendering rather than leaving a frozen Metal view in place — a
+    /// degraded but responsive terminal beats a dead one.
+    private func rebindMetalRendererToWindow(_ targetWindow: NSWindow) {
+        guard useMetalRenderer, let oldView = metalView else { return }
+        // Reuse the old view's MTLDevice when possible so we don't churn
+        // GPUs unnecessarily on multi-GPU or eGPU setups.
+        guard let device = oldView.device ?? MTLCreateSystemDefaultDevice() else {
+            disableMetalRendererAfterRebindFailure(error: MetalError.deviceUnavailable)
+            return
+        }
+
+        let newView = makeMetalView(frame: oldView.frame, device: device)
+
+        let newRenderer: MetalTerminalRenderer
+        do {
+            newRenderer = try MetalTerminalRenderer(view: newView, terminalView: self)
+        } catch {
+            disableMetalRendererAfterRebindFailure(error: error)
+            return
+        }
+        newView.delegate = newRenderer
+
+        // Critical sequence: the new layer must have visible content before
+        // the old view is removed. Force a synchronous draw, plus a
+        // `setNeedsDisplay` belt-and-braces in case the synchronous draw bails
+        // out (e.g. the new layer hasn't acquired its first drawable yet).
+        insertMetalView(newView, replacing: oldView)
+        newView.draw()
+        newView.setNeedsDisplay(newView.bounds)
+
+        oldView.delegate = nil
+        oldView.removeFromSuperview()
+
+        metalView = newView
+        metalRenderer = newRenderer
+        metalBoundWindow = targetWindow
+    }
+
+    /// Tears down the Metal renderer and reverts to CoreGraphics rendering
+    /// after an unrecoverable rebind failure. Keeps the terminal usable when
+    /// the GPU path can't be restored.
+    private func disableMetalRendererAfterRebindFailure(error: Error) {
+#if canImport(os)
+        os_log("SwiftTerm: Metal renderer rebind failed; falling back to CoreGraphics: %{public}@",
+               type: .error, String(describing: error))
+#endif
+        metalView?.delegate = nil
+        metalView?.removeFromSuperview()
+        metalView = nil
+        metalRenderer = nil
+        metalBoundWindow = nil
+        useMetalRenderer = false
+        if let caretView = caretView {
+            caretView.isHidden = false
+            caretView.updateCursorStyle()
+        }
+        needsDisplay = true
+    }
+#endif
+
+#if canImport(MetalKit)
+    open override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard useMetalRenderer, let currentWindow = window else { return }
+        if currentWindow !== metalBoundWindow {
+            rebindMetalRendererToWindow(currentWindow)
+        }
     }
 #endif
     


### PR DESCRIPTION
> **Note**: Overlaps with #546 (sRGB colorspace tag). The `makeMetalView` helper introduced here includes that tag, so the two PRs touch the same setup code. Merging #546 first lets this one rebase trivially. Either merge order preserves the sRGB behavior, since the helper is the new single source of truth for MTKView configuration.

## Problem

If a `TerminalView` is moved between `NSWindow` instances (e.g. a SwiftUI host that sets `applicationShouldTerminateAfterLastWindowClosed = false` and rebuilds its `WindowGroup` window on dock-icon reopen), the Metal-rendered terminal comes back frozen on its last frame. PTY output keeps flowing, typed input reaches the shell, but nothing renders.

`CAMetalLayer` binds to its window's WindowServer surface on first attach and Apple exposes no public API to refresh that binding. After the reparent the layer keeps minting drawables and `commandBuffer.commit()` succeeds, but `present(_:)` silently no-ops against the stale binding. `MTKView.releaseDrawables()` doesn't help. The only reliable fix is to recreate the `MTKView` so a fresh layer binds to the new window.

I hit this in Maestri (terminals survive the main window being closed-to-dock), but it applies to any SwiftTerm host that re-parents.


https://github.com/user-attachments/assets/08d30ad0-747f-4095-b965-3614d69ad507



## Fix

Track which window the current `metalView` is bound to via a `weak var metalBoundWindow`. In `viewDidMoveToWindow`, if `window !== metalBoundWindow`, rebuild the MTKView.

The naive disable-then-re-enable causes a one-frame flash because the hierarchy briefly contains no Metal view. The rebind path instead builds the new view and renderer, inserts in the old view's z-position, forces a synchronous first frame, then detaches the stale view, so there's never a frame where CoreAnimation can commit the CoreGraphics fallback.

Two private helpers (`makeMetalView`, `insertMetalView`) are extracted so the initial-enable path and the rebind path share their MTKView configuration and z-order logic and can't drift apart.

On renderer init failure during rebind, fall back to CoreGraphics rather than leaving a frozen view in place. Errors go through `os_log`.

## Tests

Manually verified in Maestri with Metal enabled. Closing the window to dock and reopening now returns to a live terminal with no flash. Repeated close/reopen cycles work. Typing during the brief reparent doesn't lose input.