### PR TITLE
Expose public hasActiveSelection on iOSTerminalView

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1270,6 +1270,22 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         }
     }
 
+    /// Whether the terminal currently has an active text selection.
+    ///
+    /// Exposed publicly so embedders (e.g. a UIScrollView subclass that
+    /// hosts the terminal) can veto their own gesture recognisers while
+    /// the user is dragging a selection handle. The underlying
+    /// `SelectionService` is intentionally `internal`; this read-only
+    /// accessor is the minimum public surface needed for the common
+    /// "don't scroll while I'm dragging the selection handle" pattern.
+    ///
+    /// Added by the meshTerm fork (`v1.13.0-meshterm.1`). An upstream
+    /// PR has been filed mirroring this accessor; once merged we will
+    /// switch back to upstream and drop the fork.
+    public var hasActiveSelection: Bool {
+        return selection?.active ?? false
+    }
+
     var lineAscent: CGFloat = 0
     var lineDescent: CGFloat = 0
     var lineLeading: CGFloat = 0


### PR DESCRIPTION
## Summary

Adds a minimal public accessor:

```swift
public var hasActiveSelection: Bool {
    return selection?.active ?? false
}
```

The underlying `var selection: SelectionService!` is declared with default (internal) access, so subclasses outside the SwiftTerm module can't observe whether the user is currently dragging a selection handle.

## Why

A common embedder pattern on iOS is "host the terminal in a UIScrollView subclass and veto my own pan gesture while the user is interacting with the selection handle". Without a public accessor, the embedder either lives with the bug ("dragging the selection handle scrolls the underlying content") or forks SwiftTerm to expose it locally.

The accessor is read-only and doesn't expose the internal `SelectionService` type, so there's no API surface commitment beyond the boolean.

## Context

We've been carrying this patch on a fork (AG-Studio-Apps/SwiftTerm @ v1.13.0-meshterm.1) for our iOS app meshTerm. Happy to switch back to upstream the moment this lands. If you'd prefer a different shape (e.g. `open` access on `selection` itself, or a different name), I'll happily adjust.

Filed alongside (and in the same spirit as) #530.