### PR TITLE
iOS: expose public setSelectionRange / clearSelection on iOSTerminalView

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1307,6 +1307,24 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         return selection?.active ?? false
     }
 
+    /// Programmatically sets the selection range to the given buffer
+    /// positions. Useful for callers that want to highlight a region
+    /// without going through a drag gesture — e.g. a search overlay
+    /// that wants match cells to light up with the same visual
+    /// treatment as a user-driven selection. Coordinates are
+    /// buffer-relative `Position` values. The view's internal
+    /// selection rendering picks up the change automatically.
+    public func setSelectionRange(start: Position, end: Position) {
+        selection?.setSelection(start: start, end: end)
+    }
+
+    /// Clears any active selection. Companion to `setSelectionRange`
+    /// for callers that don't have a UIResponder hook into the menu
+    /// system (where `selectNone` would otherwise come from).
+    public func clearSelection() {
+        selection?.selectNone()
+    }
+
     var lineAscent: CGFloat = 0
     var lineDescent: CGFloat = 0
     var lineLeading: CGFloat = 0


### PR DESCRIPTION
## Summary

Adds two public methods on `iOSTerminalView` so callers outside the
SwiftTerm module can programmatically drive the existing selection
mechanism:

```swift
public func setSelectionRange(start: Position, end: Position)
public func clearSelection()
```

Both delegate to the internal `SelectionService` that already handles
selection rendering — the on-screen highlight, the scroll-into-view
behaviour, and the standard iOS selection-tint visual. They don't
change behaviour; they expose existing functionality that was
unreachable from a cross-module subclass (the `selection` property
itself has internal access).

## Motivation

I'm building an in-terminal search bar (`⌘F`-style) over SwiftTerm on
iOS. Walking the buffer via the existing public APIs
(`getScrollInvariantLine` / `BufferLine.translateToString`) is
straightforward, and scrolling to a match via the public
`scrollTo(row:)` works too. What's missing is a way to visually
highlight which cells matched — and the natural answer ("just use the
selection mechanism that SwiftTerm already renders for drag-selects")
turns out to be unreachable from a subclass in a separate module.

Sibling to #549 (recently merged): the same shape of patch — a
narrow public-surface exposure of internal-but-otherwise-public-API
state, no behaviour change.

## Test plan

- [x] `swift build` on iOS target succeeds
- [x] Calling `setSelectionRange(start:end:)` on a `TerminalView`
  instance shows the same blue tint as a drag-select would, and
  scrolls the matched row into view
- [x] `clearSelection()` removes the highlight cleanly
- [x] Existing drag-select gesture behaviour unchanged (the new
  methods just funnel into the same `SelectionService` entry points
  the gesture handler already calls)