### PR TITLE
Fix LocalProcess retain cycle causing terminal memory leak

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -184,7 +184,8 @@ public class LocalProcess {
                 print ("[SEND-\(copy)] Queuing data to client: \(data) ")
             }
 
-            DispatchIO.write(toFileDescriptor: childfd, data: ddata, runningHandlerOn: DispatchQueue.global(qos: .userInitiated), handler:  { dd, errno in
+            DispatchIO.write(toFileDescriptor: childfd, data: ddata, runningHandlerOn: DispatchQueue.global(qos: .userInitiated), handler:  { [weak self] dd, errno in
+                guard let self else { return }
                 self.total += copyCount
                 if self.debugIO {
                     print ("[SEND-\(copy)] completed bytes=\(self.total)")
@@ -239,7 +240,9 @@ public class LocalProcess {
         guard let data else {
             // Re-schedule the read on transient errors to keep the chain alive
             if !done, running {
-                io?.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+                io?.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                    self?.childProcessRead(done: done, data: data, errno: errno)
+                }
             }
             return
         }
@@ -280,7 +283,9 @@ public class LocalProcess {
                 self.delegate?.dataReceived(slice: b[...])
             }
         }
-        io?.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+        io?.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+            self?.childProcessRead(done: done, data: data, errno: errno)
+        }
     }
 
 #if os(macOS)
@@ -292,6 +297,15 @@ public class LocalProcess {
         childMonitor?.cancel()
         childMonitor = nil
 #endif
+        // With [weak self] in the read/write handlers, deinit can fire even
+        // when the consumer never called terminate() explicitly. Close the
+        // DispatchIO so its cleanup handler releases the file descriptor —
+        // otherwise the FD (and the DispatchIO itself) would leak. We
+        // intentionally don't send SIGTERM here; terminate() remains the
+        // explicit API for killing the shell. deinit only guarantees that
+        // our own I/O resources don't outlive us.
+        io?.close()
+        io = nil
     }
 
     func processTerminated ()
@@ -368,8 +382,10 @@ public class LocalProcess {
             }
             io.setLimit(lowWater: 1)
             io.setLimit(highWater: readSize)
-            io.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
-            
+            io.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                self?.childProcessRead(done: done, data: data, errno: errno)
+            }
+
             // Start subprocess with swift-subprocess asynchronously
             Task {
                 do {
@@ -467,7 +483,9 @@ public class LocalProcess {
             }
             io.setLimit(lowWater: 1)
             io.setLimit(highWater: readSize)
-            io.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+            io.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                self?.childProcessRead(done: done, data: data, errno: errno)
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`LocalProcess` uses `childProcessRead` as a method reference in `io.read(ioHandler:)`, which Swift implicitly captures as a strong reference to `self`. Because the read loop re-arms itself on every successful read, there is always a pending `DispatchIO` operation pinning `self` — making it impossible for `LocalProcess` to deallocate through ARC alone.

The same issue exists in `DispatchIO.write`'s completion handler, which captures `self` strongly for the debug counter.

Consumers that call `terminate()` explicitly are unaffected (it closes the `DispatchIO`, breaking the cycle). But consumers that drop their reference to the terminal view — the natural ARC pattern in SwiftUI hosts — leak the entire `LocalProcess`, its `DispatchIO`, the file descriptor, and (through the owning `LocalProcessTerminalView`) all terminal buffer storage. In practice this means every discarded terminal leaks its full scrollback history indefinitely.

Discovered in Maestri via `heap`/`vmmap` profiling after unloading workspaces: ~500k orphaned `BufferLine` objects, ~50k leaked `dispatch_queue_t` instances, and ~10 GB of `MALLOC_LARGE` regions that were never freed — all traced back to zombie `LocalProcess` instances held alive by pending `DispatchIO` read operations.

Note that the existing code already uses `[weak self]` in `enqueueReceivedData` (line 129) and `childMonitor` (line 452), so the intent was always ARC-correct ownership — the `io.read` sites just slipped through because method references look innocuous.

## Fix

- Replace all `ioHandler: childProcessRead` call sites (4 total) with closure wrappers using `[weak self]`. When self is deallocated, the read loop silently stops.
- Apply `[weak self]` to the `DispatchIO.write` completion handler.
- Close `io` in `deinit` so that dropped instances release their file descriptors even when `terminate()` was never called. `terminate()` remains the explicit API for killing the shell — `deinit` only guarantees I/O resource cleanup.

## Tests

Verified in Maestri: stress-tested with 50+ terminals, unloaded all workspaces, confirmed via `vmmap -summary` that `MALLOC_LARGE` regions and physical footprint drop back to baseline. Previously they were retained indefinitely.