### PR TITLE
Render local input responses immediately

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -355,7 +355,6 @@ extension TerminalView {
 
     public func synchronizedOutputChanged (source: Terminal, active: Bool)
     {
-        SyncDebug.log("delegate active=\(active)")
         if !active {
             updateScroller()
             queuePendingDisplay()
@@ -1613,12 +1612,10 @@ extension TerminalView {
     {
         defer { pendingDisplay = false }
         if terminal.synchronizedOutputActive {
-            SyncDebug.log("paint-blocked sync=true")
             return
         }
         updateCursorPosition()
         guard let (rowStart, rowEnd) = terminal.getUpdateRange () else {
-            SyncDebug.log("paint-norange (cursor-only)")
             if notifyUpdateChanges {
                 let buffer = terminal.displayBuffer
                 let y = buffer.yDisp+buffer.y
@@ -1646,7 +1643,6 @@ extension TerminalView {
             terminalDelegate?.rangeChanged (source: self, startY: rowStart, endY: rowEnd)
         }
 
-        SyncDebug.log("paint rows=\(rowStart)-\(rowEnd)")
         terminal.clearUpdateRange ()
 
         #if os(macOS)
@@ -1775,7 +1771,6 @@ extension TerminalView {
     func queuePendingDisplay ()
     {
         if terminal.synchronizedOutputActive {
-            SyncDebug.log("queue-blocked sync=true")
             return
         }
         // throttle
@@ -1784,12 +1779,10 @@ extension TerminalView {
             // let fps30 = 16670000*2
             let fpsDelay = fps60
             pendingDisplay = true
-            SyncDebug.log("queue-scheduled (+16.67ms)")
             DispatchQueue.main.asyncAfter(
                 deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay)),
                 execute: updateDisplay)
         } else {
-            SyncDebug.log("queue-noop (already pending)")
         }
     }
 
@@ -1987,7 +1980,6 @@ extension TerminalView {
     
     func feedFinish ()
     {
-        SyncDebug.log("feedFinish sync=\(terminal.synchronizedOutputActive)")
         suspendDisplayUpdates ()
         if shouldDisplayImmediatelyAfterUserInput() {
             displayImmediately()

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1989,9 +1989,31 @@ extension TerminalView {
     {
         SyncDebug.log("feedFinish sync=\(terminal.synchronizedOutputActive)")
         suspendDisplayUpdates ()
+        if shouldDisplayImmediatelyAfterUserInput() {
+            displayImmediately()
+            return
+        }
         queuePendingDisplay()
     }
-    
+
+    private func shouldDisplayImmediatelyAfterUserInput() -> Bool {
+        guard !terminal.synchronizedOutputActive else { return false }
+        guard lastUserInputUptimeNs > 0 else { return false }
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now >= lastUserInputUptimeNs else { return false }
+        return now - lastUserInputUptimeNs <= interactiveInputDisplayWindowNs
+    }
+
+    private func displayImmediately() {
+        guard !Thread.isMainThread else {
+            updateDisplay()
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.updateDisplay()
+        }
+    }
+
     /// Sends data to the terminal emulator for interpretation, this can be invoked from a background thread
     public func feed (byteArray: ArraySlice<UInt8>)
     {
@@ -2037,6 +2059,7 @@ extension TerminalView {
      */
     public func send(data: ArraySlice<UInt8>)
     {
+        lastUserInputUptimeNs = DispatchTime.now().uptimeNanoseconds
         ensureCaretIsVisible ()
         #if os(iOS) || os(visionOS)
         if TerminalView.textInputDebugEnabled {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -116,6 +116,10 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     private var findBarOptions: SearchOptions = SearchOptions()
     var debug: TerminalDebugView?
     var pendingDisplay: Bool = false
+    /// Output received shortly after local input is likely echo or prompt redraw;
+    /// render it without the 16.67ms frame-rate throttle so typing feels responsive.
+    var lastUserInputUptimeNs: UInt64 = 0
+    let interactiveInputDisplayWindowNs: UInt64 = 150_000_000
 #if canImport(MetalKit)
     var metalView: MTKView?
     var metalRenderer: MetalTerminalRenderer?

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -5548,7 +5548,6 @@ open class Terminal {
     private func beginSynchronizedOutput ()
     {
         let wasActive = synchronizedOutputActive
-        SyncDebug.log("BSU wasActive=\(wasActive)")
         synchronizedOutputActive = true
         scheduleSynchronizedOutputTimeout()
         if !wasActive {
@@ -5559,10 +5558,8 @@ open class Terminal {
     private func endSynchronizedOutput ()
     {
         guard synchronizedOutputActive else {
-            SyncDebug.log("ESU ignored (not active)")
             return
         }
-        SyncDebug.log("ESU")
         synchronizedOutputActive = false
         synchronizedOutputTimeoutItem?.cancel()
         synchronizedOutputTimeoutItem = nil
@@ -5577,7 +5574,6 @@ open class Terminal {
             guard let self, self.synchronizedOutputActive else {
                 return
             }
-            SyncDebug.log("safety-timer-fired (missing ESU)")
             self.endSynchronizedOutput()
         }
         synchronizedOutputTimeoutItem = workItem

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -191,6 +191,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var search: SearchService!
     var debug: UIView?
     var pendingDisplay: Bool = false
+    /// Output received shortly after local input is likely echo or prompt redraw;
+    /// render it without the 16.67ms frame-rate throttle so typing feels responsive.
+    var lastUserInputUptimeNs: UInt64 = 0
+    let interactiveInputDisplayWindowNs: UInt64 = 150_000_000
 #if canImport(MetalKit)
     var metalView: MTKView?
     var metalRenderer: MetalTerminalRenderer?


### PR DESCRIPTION
Reopened version of #542 on top of the recent sync-output rework.

## Problem

After `9446f60`, the remaining typing-lag source is the 16.67ms throttle in `queuePendingDisplay`. When output bursts coincide with keystrokes, `pendingDisplay` stays armed and subsequent keystrokes get coalesced into the next 60Hz tick. Perceptible as occasional "skipped" characters that appear together a frame later.

In practice this surfaces most when the host is under load — we see it consistently when many terminals are running concurrently in Maestri.

## Fix

Input-immediate bypass only, no settle-window machinery. If output arrives within 150ms of a keystroke and we're not in a sync block, paint synchronously instead of via `asyncAfter(+16.67ms)`. Complementary to the sync-output simplification on main.

## Tests

Confirmed in Maestri against the same workloads that motivated the first PR.