### PR TITLE
iOS: expose public showStandardContextMenu wrapper

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1339,6 +1339,23 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         selection?.selectNone()
     }
 
+    /// Programmatically presents SwiftTerm's standard Copy / Paste /
+    /// Select All context menu at the given point in the terminal's
+    /// coordinate space. Mirrors the path the built-in long-press
+    /// gesture takes — becomes first responder, computes the menu
+    /// region around the tap point, then calls the existing internal
+    /// `showContextMenu(forRegion:pos:)` presenter.
+    ///
+    /// Useful when a host app replaces the built-in long-press gesture
+    /// with custom behaviour (e.g. a cursor-drag mode) but still wants
+    /// the existing menu as a fallback for release-without-movement.
+    public func showStandardContextMenu(at point: CGPoint) {
+        _ = becomeFirstResponder()
+        let region = makeContextMenuRegionForTap(point: point)
+        let hit = calculateTapHit(point: point)
+        showContextMenu(forRegion: region, pos: hit.grid)
+    }
+
     var lineAscent: CGFloat = 0
     var lineDescent: CGFloat = 0
     var lineLeading: CGFloat = 0


### PR DESCRIPTION
## Summary

Adds one public method on `iOSTerminalView`:

```swift
public func showStandardContextMenu(at point: CGPoint)
```

It wraps the existing internal `showContextMenu(forRegion:pos:)` with a `CGPoint`-taking entry point — the same path the built-in long-press gesture already takes (becomes first responder, computes the menu region via `makeContextMenuRegionForTap(point:)`, resolves the tap to a grid position via `calculateTapHit(point:)`, then calls `showContextMenu`).

No behaviour change. The existing long-press gesture still works exactly as before; this just makes the same menu reachable programmatically.

## Motivation

I want to replace the built-in long-press-shows-menu gesture in my host app with a Termius-style "long-press arms cursor mode, drag moves the cursor" gesture. To stay backwards-compatible with users who expect the menu, I fall back to it when the long-press ends without movement — i.e. the menu should still appear, just delayed by ~one gesture's worth of decision-time.

Without this exposure, host apps either reimplement the standard menu (UIEditMenuInteraction or UIMenuController) or lose access to whatever SwiftTerm provides today (current state: standard `UIResponderStandardEditActions`).

Sibling to #549 (`hasActiveSelection`) and #550 (`setSelectionRange` / `clearSelection`) — the same shape of patch: narrow public-surface exposure of an internal-but-otherwise-public-API entry point, no behaviour change.

## Test plan

- [x] `swift build` succeeds on the iOS target
- [x] Calling `showStandardContextMenu(at:)` on a `TerminalView` instance presents the same menu the built-in long-press gesture shows
- [x] The built-in long-press gesture continues to work unchanged
- [x] First-responder state is taken correctly (verified via subsequent Copy from the menu invoking the standard action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)