### PR TITLE
Add selectedTextForegroundColor to recolor selected text

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -645,6 +645,9 @@ extension TerminalView {
             if isSelected {
                 var mutable = attributes
                 mutable[.selectionBackgroundColor] = selectedTextBackgroundColor
+                if let selectedTextForegroundColor {
+                    mutable[.foregroundColor] = selectedTextForegroundColor
+                }
                 currentAttributes = mutable
             } else {
                 currentAttributes = attributes

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -476,6 +476,19 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
     }
 
+    var _selectedTextForegroundColor: NSColor? = nil
+    /// The color used to render the text of the selection. When `nil` (the default),
+    /// selected text keeps its original foreground color and only the selection
+    /// background is drawn.
+    public var selectedTextForegroundColor: NSColor? {
+        get {
+            return _selectedTextForegroundColor
+        }
+        set {
+            _selectedTextForegroundColor = newValue
+        }
+    }
+
     func backingScaleFactor () -> CGFloat
     {
         window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1258,6 +1258,19 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             _selectedTextBackgroundColor = newValue
         }
     }
+
+    var _selectedTextForegroundColor: UIColor? = nil
+    /// The color used to render the text of the selection. When `nil` (the default),
+    /// selected text keeps its original foreground color and only the selection
+    /// background is drawn.
+    public var selectedTextForegroundColor: UIColor? {
+        get {
+            return _selectedTextForegroundColor
+        }
+        set {
+            _selectedTextForegroundColor = newValue
+        }
+    }
     
     var _selectionHandleColor: UIColor = UIColor.systemBlue
     /// The color used to render the selection handles


### PR DESCRIPTION
## Summary

Adds an optional `selectedTextForegroundColor` property to the macOS (`TerminalView`/`MacTerminalView`) and iOS terminal views.

When set, selected text is rendered in this color in addition to the existing `selectedTextBackgroundColor`. When `nil` (the default), behavior is unchanged — selected text keeps its original foreground color and only the selection background is drawn, so this is fully backward compatible and opt-in.

## Motivation

Several terminal color schemes define a distinct *selection foreground* alongside the selection background (for example GitHub Dark uses near-black text on a yellow selection). Today only the background can be customized, so selected text can become hard to read against a saturated selection background. This adds parity with terminals/themes that expect a selection foreground.

## Changes

- `Mac/MacTerminalView.swift`: add `selectedTextForegroundColor: NSColor?` (default `nil`).
- `iOS/iOSTerminalView.swift`: add `selectedTextForegroundColor: UIColor?` (default `nil`).
- `Apple/AppleTerminalView.swift`: in `buildAttributedString`, when a cell is selected, override the foreground attribute with `selectedTextForegroundColor` if it is set (the existing draw path already honors `.foregroundColor`).

## Testing

- `swift build --target SwiftTerm` succeeds.
- Verified in an embedding app: setting `selectedTextForegroundColor` renders legible dark text on a light selection background; leaving it `nil` preserves existing behavior.