### PR TITLE
iOS: make TerminalView.deleteBackward open for subclass overriding

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -2180,7 +2180,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
     }
     
-    public func deleteBackward() {
+    open func deleteBackward() {
         uitiLog("deleteBackward() \(textInputStateDescription())")
 
         // after backward deletion, marked range is always cleared, and length of selected range is always zero


### PR DESCRIPTION
## What

Widen `TerminalView.deleteBackward()` from `public` to `open` on iOS.

## Why

`insertText(_:)` is already `open`, which lets a subclass observe inserted
text — for example to drive an autocomplete / command-prediction model from
what the user types. Its companion `UIKeyInput` method, `deleteBackward()`
(the method the soft keyboard's delete key routes through), is only `public`,
so a subclass in a *different module* cannot override it. That asymmetry means
a subclass can see insertions but not deletions, leaving any
keystroke-derived model stale as the user backspaces.

This one-word change makes `deleteBackward()` overridable for symmetry with
`insertText`. It's a pure access-level widening — no behavioural change, and
existing callers are unaffected.

Encountered while building a terminal app (meshTerm) on SwiftTerm where a
prediction overlay needed to track the in-flight input line across both
insertions and deletions.