### PR TITLE
Fix Option-composed characters dropped under the kitty keyboard protocol

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1376,6 +1376,28 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
                 pendingKittyKeyEvent = nil
                 kittyIsComposing = false
                 let text = str as String
+
+                // Option acting as a compose/AltGr layer (e.g. on the Czech
+                // layout Option+2 produces "@" while the bare key is "ě"). When
+                // optionAsMetaKey is off, Option is not Meta, so the keypress
+                // simply produced a normal character. Encoding it as a kitty
+                // CSI-u event keys off charactersIgnoringModifiers (the
+                // base-layout glyph, "ě") and only carries the composed "@" as
+                // associated text, so apps that negotiate reportAlternates or
+                // reportAllKeys without reportText (e.g. OpenCode) receive the
+                // base key and the composed glyph is lost. Send the composed
+                // text directly instead, matching how kitty/Ghostty handle
+                // AltGr layers.
+                if let pendingEvent,
+                   !optionAsMetaKey,
+                   pendingEvent.event.modifierFlags.contains(.option),
+                   !pendingEvent.event.modifierFlags.contains(.control),
+                   !pendingEvent.event.modifierFlags.contains(.command),
+                   isPlainPrintableText(text) {
+                    send(txt: text)
+                    return
+                }
+
                 let kittyEvent: KittyKeyEvent
                 if text.unicodeScalars.count == 1,
                    let pendingEvent,
@@ -1399,6 +1421,19 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         // needsDisplay = true
     }
     
+    /// Whether `text` is a non-empty run of printable scalars (no C0/C1 control
+    /// characters). Used to decide when Option-composed input can be sent as
+    /// literal UTF-8 rather than encoded as a kitty key event.
+    private func isPlainPrintableText(_ text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+        for scalar in text.unicodeScalars {
+            if scalar.value < 0x20 || (scalar.value >= 0x7f && scalar.value <= 0x9f) {
+                return false
+            }
+        }
+        return true
+    }
+
     // NSTextInputClient protocol implementation
     open func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         switch string {

--- a/Tests/SwiftTermTests/KittyOptionComposeTests.swift
+++ b/Tests/SwiftTermTests/KittyOptionComposeTests.swift
@@ -1,0 +1,79 @@
+//
+//  KittyOptionComposeTests.swift
+//
+//  Regression coverage for Option-as-compose / AltGr input under the kitty
+//  keyboard protocol. On layouts where a printable character is produced via
+//  Option (e.g. Czech Option+2 = "@", German AltGr+Q = "@"), the composed
+//  character must reach the PTY even when the application negotiates
+//  reportAllKeys/reportAlternates without reportText. Previously the kitty
+//  encoder keyed off the base-layout codepoint and dropped the composed glyph.
+//
+#if os(macOS)
+import AppKit
+import Testing
+@testable import SwiftTerm
+
+final class KittyOptionComposeTests {
+
+    /// Captures bytes the view sends to the PTY.
+    private final class CapturingDelegate: TerminalViewDelegate {
+        var sent: [UInt8] = []
+        func send(source: TerminalView, data: ArraySlice<UInt8>) { sent.append(contentsOf: data) }
+        func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+        func setTerminalTitle(source: TerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        func scrolled(source: TerminalView, position: Double) {}
+        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+        func bell(source: TerminalView) {}
+        func clipboardCopy(source: TerminalView, content: Data) {}
+        func clipboardRead(source: TerminalView) -> Data? { nil }
+        func iTermContent(source: TerminalView, content: ArraySlice<UInt8>) {}
+        func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+    }
+
+    private func optionKeyEvent(characters: String,
+                                charactersIgnoringModifiers: String,
+                                keyCode: UInt16) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .option,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode)!
+    }
+
+    /// Czech Option+2 produces "@" while the bare key produces "ě". With the
+    /// kitty protocol active (disambiguate + reportAlternates + reportAllKeys,
+    /// the Bubble Tea default that OpenCode uses) and Option not acting as Meta,
+    /// the PTY must receive the composed "@", not the base-layout key.
+    @Test func testOptionComposedCharacterSendsComposedText() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let delegate = CapturingDelegate()
+        view.terminalDelegate = delegate
+        view.optionAsMetaKey = false
+
+        // Push kitty flags 11 = disambiguate(1) + reportAlternates(2) + reportAllKeys(8).
+        view.getTerminal().feed(text: "\u{1b}[>11u")
+
+        // kVK_ANSI_2 == 19. Bare key on the Czech layout yields "ě"; Option composes "@".
+        let event = optionKeyEvent(characters: "@", charactersIgnoringModifiers: "ě", keyCode: 19)
+        view.keyDown(with: event)
+
+        // keyDown sets the pending key event and forwards to interpretKeyEvents.
+        // In a headless test interpretKeyEvents is a no-op, so we drive the text
+        // commit ourselves. If a given environment *does* commit synchronously,
+        // keyDown already produced the output and we assert on that instead, so
+        // the test fails only when the composed character is actually wrong.
+        if delegate.sent.isEmpty {
+            view.insertText("@", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        #expect(delegate.sent == Array("@".utf8))
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

When the kitty keyboard protocol is active and a printable character is produced via Option acting as a compose/AltGr layer, the composed character can be silently dropped and the base-layout key is sent instead.

The clearest repro is a non-US layout where the composed glyph sits on a key whose unmodified character differs from US. On the **Czech** layout the number-row "2" key produces `ě` when pressed bare and `@` with Option. Typing **Option+2** in an app that enabled the protocol with `reportAlternates` (but not `reportText`) inserts `ě` instead of `@`.

The cause is in `insertText`. An Option-composed commit is turned into a kitty key event via `kittyTextEvent`, which keys the event off `charactersIgnoringModifiers` (the base-layout glyph, `ě`) and carries the actual `@` only as associated `text`. The encoder then:

- with `reportAlternates`, sees a non-nil base-layout alternate and bails out of the plain-text fast path in `KittyKeyboardEncoder.encode`, emitting a CSI-u sequence keyed on `ě`;
- only includes the associated `@` text when `reportText` (flag 16) is negotiated.

So any app that turns on `reportAlternates`/`reportAllKeys` without `reportText` receives the base key and never sees the composed character. OpenCode (Bubble Tea) is one such app, which is what surfaced this. US-layout Option characters (`Option+8` = `•`, etc.) are unaffected because their base glyph matches US, so the alternate is nil and they take the plain-text path. Apps that don't enable the protocol at all (e.g. Claude Code's default mode) are also unaffected, which is why this only reproduced in some terminals/apps.

## Fix

When `optionAsMetaKey` is off and Option produced a plain printable character with no Control/Command modifier, send the composed text directly as UTF-8 instead of routing it through the kitty encoder. This mirrors the existing non-report-all plain-text fast path and matches how kitty and Ghostty treat AltGr layers: the character the user typed is what reaches the program. It is gated on `!optionAsMetaKey`, so it is a no-op when Option-as-Meta is enabled (the default).

## Tests

Added `KittyOptionComposeTests.swift`, a view-level test that drives the Czech `Option+2` case (`charactersIgnoringModifiers = "ě"`, composed `@`) with the kitty alternates/all-keys flags pushed and `optionAsMetaKey` off, and asserts the PTY receives `@`. Without the fix the same input emits the base-layout CSI-u sequence instead.

Also verified live: switching to the Czech input source and typing `Option+2` in OpenCode produced `ě` before the fix and `@` after.
