### PR TITLE
fix(iOS): mark TerminalView non-opaque to stop scrollback rendering corruption

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1179,6 +1179,16 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         setupOptions(width: bounds.width, height: bounds.height)
         layer.backgroundColor = nativeBackgroundColor.cgColor
         nativeBackgroundColor = UIColor.clear
+        // The terminal background is provided by `layer.backgroundColor`, and
+        // `draw(_:)` paints glyph cells with a transparent backdrop so that the
+        // layer colour shows through the gaps. That only works if the view is
+        // non-opaque: an opaque view gets an alpha-less graphics context where
+        // the transparent fill is a no-op, leaving uninitialised backing-store
+        // garbage in every default-background region. When the scroll view blits
+        // and re-exposes strips during scrolling, that garbage becomes visible as
+        // flickering/striped corruption. Marking the view non-opaque makes the
+        // transparent compositing behave as intended.
+        isOpaque = false
     }
     
     var _nativeFg, _nativeBg: TTColor!


### PR DESCRIPTION
### Problem

On iOS, scrollback renders as flickering, striped garbage over default-background regions once the user scrolls (see #566).

| Before (1.13.0 / `main`) | After (this PR) |
|---|---|
| ![before – striped garbage](https://raw.githubusercontent.com/ferponse/SwiftTerm/media/before.png) | ![after – clean](https://raw.githubusercontent.com/ferponse/SwiftTerm/media/after.png) |

### Cause

`TerminalView` (a `UIScrollView`) draws its background via `layer.backgroundColor` and fills glyph cells transparently in `draw(_:)` (`setupOptions()` sets `nativeBackgroundColor = .clear`), relying on the layer colour showing through the gaps.

That requires a **non-opaque** view, but `isOpaque` was never cleared, so the view's CoreGraphics context had no alpha channel: the `UIColor.clear` fill in `draw(_:)` became a no-op and every default-background region was left as uninitialised backing-store memory. It is masked on full repaints and exposed by the scroll view's blit / redraw-only-the-exposed-strip behaviour during scrolling.

### Fix

Set `isOpaque = false` in `setupOptions()`. One line; it only enables the transparent compositing the existing code already assumes.

### Testing

Reproduced and verified on the iPhone 16 / iOS 18.2 simulator using the bundled `iOSTerminal` demo fed with synthetic coloured scrollback. A ready-to-run reproduction is on [`repro/ios-scroll-corruption`](https://github.com/ferponse/SwiftTerm/tree/repro/ios-scroll-corruption):

- **Before:** full-screen striped corruption over default-background regions (matches #566).
- **After:** clean background at rest and while scrolling in both directions; coloured cells and text unaffected.

Fixes #566.
