### PR TITLE
Add public searchMatchSummary for search-UI match counters

### DIFF
--- a/Sources/SwiftTerm/TerminalViewSearch.swift
+++ b/Sources/SwiftTerm/TerminalViewSearch.swift
@@ -51,6 +51,22 @@ extension TerminalView {
         return false
     }
 
+
+    /// Position of the current match among all matches for `term`: a 1-based
+    /// `index` (0 when there is no current match) and the `total` match count
+    /// (capped at `limit`). Drives a "2/14" style counter in a search UI.
+    public func searchMatchSummary (_ term: String, options: SearchOptions = SearchOptions(), limit: Int = 1000) -> (index: Int, total: Int) {
+        guard let search = search else {
+            return (0, 0)
+        }
+        let all = search.findAll(term: term, options: options, limit: limit)
+        guard let last = search.lastResult,
+              let i = all.firstIndex(where: { $0.row == last.row && $0.col == last.col }) else {
+            return (0, all.count)
+        }
+        return (i + 1, all.count)
+    }
+
     /// Clears the current search state and selection.
     public func clearSearch () {
         search?.reset()


### PR DESCRIPTION
## Summary

Adds a small public API on `TerminalView` to support match counters in search UIs:

```swift
public func searchMatchSummary (_ term: String, options: SearchOptions = SearchOptions(), limit: Int = 1000) -> (index: Int, total: Int)
```

- `index` is the 1-based position of the current match (the one selected by `findNext`/`findPrevious`) among all matches, or 0 when there is no current match.
- `total` is the overall match count, capped at `limit`.

This lets a client render the familiar "2/14" counter next to the find next/previous controls. `findNext`, `findPrevious`, and `clearSearch` are already public, but the underlying `SearchService.findAll`/`lastResult` are internal, so a counter can't be built from outside the package today.

## Implementation

A thin wrapper in `TerminalViewSearch.swift` over the existing `SearchService.findAll` port: it locates `search.lastResult` within the `findAll` results by (row, col). No changes to the search engine itself.

## Testing

- `swift build` clean on macOS.
- Exercised on iOS in a terminal app: counter tracks findNext/findPrevious correctly, including wrap-around at both buffer ends, and reports (0, 0)/(0, n) for empty/no-current-match states.