### PR TITLE
Buffer.resize: iterate lines.count, not lines.maxLength (O(scrollback capacity) -> O(content))

### DIFF
--- a/Sources/SwiftTerm/Buffer.swift
+++ b/Sources/SwiftTerm/Buffer.swift
@@ -425,7 +425,12 @@ public final class Buffer {
             // Deal with columns increasing (reducing needs to happen after reflow)
             
             if cols < newCols {
-                for i in 0..<lines.maxLength {
+                // Iterate only the lines that exist: touching every capacity slot
+                // materializes a BufferLine per empty slot (the CircularList subscript
+                // calls makeEmpty), making resize O(scrollback capacity). Empty slots
+                // are created on demand at the buffer's current cols, so they never
+                // need resizing here.
+                for i in 0..<lines.count {
                     lines [i].resize (cols: newCols, fillData: CharData.Null)
                 }
 
@@ -507,7 +512,8 @@ public final class Buffer {
             reflow (newCols, newRows)
             // Trim the end of the line off if cols shrunk
             if cols > newCols {
-                for i in 0..<lines.maxLength {
+                // lines.count, not lines.maxLength (see the widen loop above).
+                for i in 0..<lines.count {
                     lines [i].resize (cols: newCols, fillData: CharData.Null)
                 }
             }
@@ -515,7 +521,11 @@ public final class Buffer {
         
         // DEBUG: Post-condition
         if lines.count > 0 {
-            for i in 0..<lines.maxLength {
+            // lines.count, not lines.maxLength: checking every capacity slot would
+            // materialize blank lines for the whole scrollback on every resize and,
+            // worse, they would be created at the old `cols` (updated below) and
+            // trip the abort() when widening.
+            for i in 0..<lines.count {
                 let line = lines [i]
                 if line.count < newCols {
                     print ("stop here newCols=\(newCols) but the element has: \(line.count)")


### PR DESCRIPTION
## Problem

Three loops in `Buffer.resize` iterate `lines.maxLength` — the scrollback **capacity** — instead of `lines.count`, the number of lines actually in the buffer. `CircularList`'s subscript materializes a `BufferLine` for every empty slot it touches (the getter calls `makeEmpty`), so each loop walks and allocates the entire scrollback capacity even for a nearly empty buffer.

With a large scrollback this makes every column-count change expensive. At `changeScrollback(50_000)`, a single resize costs **30–70 ms of main-thread time per terminal** (~200× the cost at the default 500-line scrollback), measured headless on an M-series Mac. In an app with several visible terminals, every window resize, divider drag, or layout switch multiplies that — it shows up as typing lag and slow view switching. Patched, the same resize is **~0.3 ms**.

## Fix

Iterate `0..<lines.count` in the three sites. This is safe:

- The two column-resize loops (widen at the top of `resize`, narrow after `reflow`) only need to touch lines that exist. Empty slots are materialized on demand by `makeEmpty` → `getBlankLine`, which uses the buffer's *current* `cols` and therefore already produces lines at the new width.
- The `DEBUG: Post-condition` loop would otherwise materialize blank lines for the whole capacity on every resize — and worse, they'd be created at the **old** `cols` value (`cols` is updated after the check), which trips the `abort()` when widening.

## Measurements

Headless `Terminal` with `changeScrollback(50_000)` and 1,000 lines of content, resizing between 80/120/200 columns:

| resize | before | after |
|---|---|---|
| 80 → 120 cols | ~50 ms | 0.70 ms |
| 120 → 80 cols | ~40 ms | 0.32 ms |
| 80 → 200 cols | ~60 ms | 0.90 ms |
| 200 → 80 cols | ~45 ms | 0.36 ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
