### PR TITLE
Fix default-text-presentation symbols rendering as color emoji on iOS (U+2733 & friends)

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -729,6 +729,11 @@ extension TerminalView {
             } else {
                 // Common path: just accumulate into the batch
                 pendingText.append(character)
+                if UnicodeUtil.prefersTextPresentation(character) {
+                    // Steer font fallback away from Apple Color Emoji for
+                    // default-text-presentation symbols (see prefersTextPresentation).
+                    pendingText.append("\u{FE0E}")
+                }
                 previousPlaceholder = nil
                 previousPlaceholderAttribute = nil
             }

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -2162,7 +2162,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let attributes = terminalView.getAttributedValue(charData.attribute,
                                                          usingFg: terminalView.caretColor,
                                                          andBg: caretTextColor) ?? [.font: terminalView.fontSet.normal]
-        let attributedString = NSAttributedString(string: String(charData.getCharacter()), attributes: attributes)
+        let attributedString = NSAttributedString(string: UnicodeUtil.textPresentationAdjusted(charData.getCharacter()), attributes: attributes)
         let ctline = CTLineCreateWithAttributedString(attributedString)
         guard let runs = CTLineGetGlyphRuns(ctline) as? [CTRun] else {
             return (colorVertices, [], [])

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -47,7 +47,7 @@ class CaretView: NSView, CALayerDelegate {
     func setText (ch: CharData) {
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
-            string: String (character),
+            string: UnicodeUtil.textPresentationAdjusted (character),
             attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor ?? terminal?.nativeForegroundColor ?? NSColor.black))
         ctline = CTLineCreateWithAttributedString(res)
 

--- a/Sources/SwiftTerm/Utilities.swift
+++ b/Sources/SwiftTerm/Utilities.swift
@@ -306,6 +306,40 @@ struct UnicodeUtil {
         return bisearch(rune: rune.value, table: UnicodeWidthData.emojiVs16Base, max: UnicodeWidthData.emojiVs16Base.count - 1) != 0
     }
 
+    /**
+     * True for a lone symbol whose Unicode default presentation is text (Emoji=Yes,
+     * Emoji_Presentation=No) and that carries no explicit variation selector.
+     *
+     * Renderers append U+FE0E (text variation selector) to such characters before shaping:
+     * when the base font lacks a glyph, Core Text's font fallback on iOS resolves them to
+     * Apple Color Emoji (e.g. U+2733 under SF Mono), rendering a full-color emoji where the
+     * terminal should show a monochrome, foreground-tinted glyph. An explicit VS15 steers
+     * the cascade to a text-presentation font instead, matching the Unicode default.
+     *
+     * Clusters that already carry a variation selector (VS15 or VS16) or any combining
+     * scalar are left untouched — the stream made an explicit choice.
+     */
+    static func prefersTextPresentation (_ ch: Character) -> Bool
+    {
+        let scalars = ch.unicodeScalars
+        guard scalars.count == 1, let scalar = scalars.first else {
+            return false
+        }
+        // ASCII-range emoji bases (#, *, 0-9) always have text glyphs in the base font.
+        guard scalar.value > 0xFF else {
+            return false
+        }
+        let properties = scalar.properties
+        return properties.isEmoji && !properties.isEmojiPresentation
+    }
+
+    /// The character as a shaping-ready string, with U+FE0E appended when
+    /// `prefersTextPresentation` applies.
+    static func textPresentationAdjusted (_ ch: Character) -> String
+    {
+        return prefersTextPresentation(ch) ? String(ch) + "\u{FE0E}" : String(ch)
+    }
+
     private static func isEastAsianWide (_ value: UInt32) -> Bool
     {
         if UnicodeWidthData.eastAsianWide.isEmpty {

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -80,7 +80,7 @@ class CaretView: UIView {
     func setText (ch: CharData) {
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
-            string: String (character),
+            string: UnicodeUtil.textPresentationAdjusted (character),
             attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor ?? terminal?.nativeForegroundColor ?? TTColor.black))
         ctline = CTLineCreateWithAttributedString(res)
         setNeedsDisplay(bounds)


### PR DESCRIPTION
## Problem

Symbols that are emoji-*capable* but whose Unicode default presentation is **text** (`Emoji=Yes`, `Emoji_Presentation=No` — e.g. U+2733 ✳, U+26A0 ⚠, U+2714 ✔) render as large full-color emoji on iOS instead of monochrome, foreground-tinted glyphs.

The most visible real-world case: Claude Code's spinner/banner character U+2733 shows up as a big green emoji in any SwiftTerm-based iOS terminal, while desktop terminals (Terminal.app, Ghostty, iTerm2…) show the expected white asterisk.

### Root cause

SwiftTerm shapes cells through Core Text with the configured terminal font (default: SF Mono via `UIFont.monospacedSystemFont`). SF Mono has no glyph for U+2733, so Core Text's cascade fallback picks a font — and on iOS it picks Apple Color Emoji even though the codepoint's default presentation is text. Probed on an iOS 26 simulator with `CTFontCreateForString` over the default font:

| Input | Fallback font chosen by iOS |
|---|---|
| `U+2733` (plain) | **.AppleColorEmojiUI** ← the bug |
| `U+2733 U+FE0F` (VS16) | .AppleColorEmojiUI (correct) |
| `U+2733 U+FE0E` (VS15) | Menlo-Regular (monochrome) |
| `U+2722 / U+2736 / U+273B / U+273D` | Menlo-Regular |

macOS resolves plain U+2733 to a monochrome font (Zapf Dingbats), which is why the bug is iOS-specific in practice — but the fix below is correct and harmless on both platforms.

This is the same policy Ghostty implements in its own font resolver: with no explicit variation selector adjacent to the codepoint, presentation defaults to the UCD value (`src/font/CodepointResolver.zig`, `is_emoji_presentation`), and VS15/VS16 override it (`src/font/shaper/run.zig`). SwiftTerm delegates fallback to Core Text, so the equivalent is steering the cascade with an explicit selector.

## Fix

At shaping time, append U+FE0E (text variation selector) to lone symbols whose default presentation is text:

- `UnicodeUtil.prefersTextPresentation` / `textPresentationAdjusted`: true only for single-scalar clusters above U+00FF with `isEmoji && !isEmojiPresentation`. Clusters already carrying VS15/VS16 (or any combining scalar) are untouched, so **explicit emoji presentation from the stream is preserved**.
- Applied in `buildAttributedString` (shared by the CoreGraphics and Metal render paths) and in the three caret paths (`MacCaretView`, `iOSCaretView`, Metal cursor).

This is display-only: the terminal buffer, cell widths, and what `getCharacter`/selection return are unchanged. The VS merges into the same grapheme cluster and Core Text emits a single glyph for it, so the one-glyph-per-cell column mapping in both renderers is unaffected. When the base font does have the glyph (©, ®, ™ in SF Mono), the selector is a no-op.

## Verification

On an iPad simulator, fed through a `TerminalView`:

- plain `✳ ✢ ✶ ✻ ✽ ⚠ ✔` → monochrome, tinted with the cell's foreground color
- `✳️` / `⚠️` (explicit VS16) → still color emoji, double-width as before
- `😀` (default emoji presentation) → unchanged
- caret over the glyph → monochrome as well

`swift test`: 425/426 pass; the one failure (`SynchronizedOutputTests.testSynchronizedOutputBlocksDisplayUntilReset`) also fails on a clean checkout of `main` and is unrelated.
