### PR TITLE
Mac: word-mode drag selection drops the seed word when dragging backwards

### DIFF
--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -69,7 +69,16 @@ class SelectionService: CustomDebugStringConvertible {
     /**
      * Used to track the pivot point when selection in iOS-style selection
      */
-    public var pivot: Position? 
+    public var pivot: Position?
+
+    /**
+     * When `selectWordOrExpression` seeds a selection (a double-click), the
+     * selected range is recorded here so that a subsequent word-mode drag can
+     * pivot around the whole seed word.  Without this, dragging *backwards*
+     * past the seed word would leave `start` pinned at the seed word's start
+     * and the seed word would be dropped from the selection.
+     */
+    var wordSelectionAnchor: (start: Position, end: Position)?
 
     /**
      * Returns the selection ending point in buffer coordinates
@@ -92,6 +101,7 @@ class SelectionService: CustomDebugStringConvertible {
     {
         setSoftStart(row: row, col: col)
         selectionMode = .character
+        wordSelectionAnchor = nil
         setActiveAndNotify()
     }
         
@@ -121,6 +131,7 @@ class SelectionService: CustomDebugStringConvertible {
         end = start
         selectingRows = false
         selectionMode = .character
+        wordSelectionAnchor = nil
         setActiveAndNotify()
     }
     
@@ -270,14 +281,35 @@ class SelectionService: CustomDebugStringConvertible {
      * The position is in buffer coordinates
      */
     public func dragExtend (bufferPosition: Position) {
+        // When the selection was seeded by a double-click (word mode), pivot the
+        // drag around the whole seed word.  This keeps the seed word in the
+        // selection when the drag goes *backwards* (to the left/up) past it, and
+        // snaps both ends to word boundaries in either direction.
+        if selectionMode == .word, let anchor = wordSelectionAnchor {
+            let buffer = terminal.displayBuffer
+            if Position.compare(bufferPosition, anchor.start) == .before {
+                start = extendToWordBoundary(position: bufferPosition, in: buffer, direction: -1)
+                end = anchor.end
+            } else if Position.compare(bufferPosition, anchor.end) == .after {
+                start = anchor.start
+                end = extendToWordBoundary(position: bufferPosition, in: buffer, direction: 1)
+            } else {
+                // Still inside the seed word: keep the whole word selected.
+                start = anchor.start
+                end = anchor.end
+            }
+            setActiveAndNotify()
+            return
+        }
+
         var adjustedEnd = bufferPosition
-        
+
         // If we're in word selection mode, extend to word boundaries
         if selectionMode == .word {
             let direction = Position.compare(bufferPosition, start) == .before ? -1 : 1
             adjustedEnd = extendToWordBoundary(position: bufferPosition, in: terminal.displayBuffer, direction: direction)
         }
-        
+
         end = adjustedEnd
         setActiveAndNotify()
     }
@@ -312,6 +344,7 @@ class SelectionService: CustomDebugStringConvertible {
         end = Position(col: terminal.cols-1, row: row)
         selectingRows = true
         selectionMode = .row
+        wordSelectionAnchor = nil
         setActiveAndNotify()
     }
 
@@ -519,9 +552,10 @@ class SelectionService: CustomDebugStringConvertible {
             end = position
         }
         selectionMode = .word
+        wordSelectionAnchor = (start, end)
         setActiveAndNotify()
     }
-    
+
     /**
      * Clears the selection
      */
@@ -530,6 +564,7 @@ class SelectionService: CustomDebugStringConvertible {
         if active {
             active = false
             selectionMode = .character
+            wordSelectionAnchor = nil
         }
     }
     

--- a/Tests/SwiftTermTests/SelectionTests.swift
+++ b/Tests/SwiftTermTests/SelectionTests.swift
@@ -330,4 +330,37 @@ final class SelectionTests: TerminalDelegate {
         #expect(selection.start.col == 3)
         #expect(selection.end.col == 3)
     }
+
+    /// After a double-click word selection, dragging *backwards* (to the left)
+    /// must keep the seed word in the selection. Regression test: previously the
+    /// drag pinned `start` to the seed word's start and dropped the seed word,
+    /// so dragging from "bbb" onto "aaa" selected only "aaa ".
+    @Test func testWordDragExtendBackwardIncludesSeedWord() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 20, rows: 1))
+        let selection = SelectionService(terminal: terminal)
+        terminal.feed(text: "aaa bbb ccc")
+
+        // Double-click "bbb"
+        selection.selectWordOrExpression(at: Position(col: 5, row: 0), in: terminal.buffer)
+        #expect(selection.getSelectedText() == "bbb")
+
+        // Drag left into "aaa"
+        selection.dragExtend(row: 0, col: 1)
+        #expect(selection.getSelectedText() == "aaa bbb")
+    }
+
+    /// After a double-click word selection, dragging forwards extends the
+    /// selection by whole words (this already worked and must keep working).
+    @Test func testWordDragExtendForwardExtendsByWords() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 20, rows: 1))
+        let selection = SelectionService(terminal: terminal)
+        terminal.feed(text: "aaa bbb ccc")
+
+        // Double-click "bbb"
+        selection.selectWordOrExpression(at: Position(col: 5, row: 0), in: terminal.buffer)
+
+        // Drag right into "ccc"
+        selection.dragExtend(row: 0, col: 9)
+        #expect(selection.getSelectedText() == "bbb ccc")
+    }
 }


### PR DESCRIPTION
## Problem

On macOS, when a word is selected by **double-click** and the user then **drags backwards** (to the left, or up onto an earlier line), the double-clicked "seed" word is excluded from the selection.

### Steps to reproduce
With `aaa bbb ccc` on screen:

1. Double-click **`bbb`** → `bbb` is selected ✅
2. Drag left onto `aaa`

**Actual:** selection is `"aaa "` (seed word `bbb` dropped)
**Expected:** selection is `"aaa bbb"`

Dragging *forwards* (double-click `bbb`, drag onto `ccc`) already works and yields `"bbb ccc"`.

## Cause

Word-mode `dragExtend` only moves `end` and keeps `start` pinned at the seed word's start. On a backwards drag the resulting `start…end` range runs from the drag point up to the seed word's *start*, so the seed word is never included. This is in the word-extension selection added in #39.

## Fix

Record the double-clicked word range (`wordSelectionAnchor`) in `selectWordOrExpression`, and pivot the word-mode drag around it:

- drag goes **before** the word → extend `start` backward to a word boundary, keep the word's far `end`
- drag goes **after** the word → keep the word's `start`, extend `end` forward to a word boundary
- still **inside** the word → keep the whole word selected

Forward word-by-word extension is unchanged. The anchor is cleared whenever a non-word selection begins (`startSelection`, `select(row:)`, `selectNone`).

## Tests

Adds two regression tests to `SelectionTests`:

- `testWordDragExtendBackwardIncludesSeedWord` — drag left keeps the seed word (fails on `main`: gets `"aaa "`)
- `testWordDragExtendForwardExtendsByWords` — drag right still extends by words

All existing `SelectionTests` pass (`swift test --filter SelectionTests`, 23 tests).