### PR TITLE
Fix terminal content hidden under the scroller after a font change

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -146,7 +146,11 @@ extension TerminalView {
         resetCaches()
         self.cellDimension = computeFontDimensions ()
         if (frame.width > 0) && (frame.height > 0) {
-            let newCols = Int(frame.width / cellDimension.width)
+            // Use getEffectiveWidth so the scroller's reserved width is taken
+            // into account, matching processSizeChange(). Computing columns from
+            // the raw frame width here would over-count by the scroller width,
+            // so zooming the font in and back out would drift the column count.
+            let newCols = Int(getEffectiveWidth(size: frame.size) / cellDimension.width)
             let newRows = Int(frame.height / cellDimension.height)
             resize(cols: newCols, rows: newRows)
         }

--- a/Tests/SwiftTermTests/FontResizeColumnsTests.swift
+++ b/Tests/SwiftTermTests/FontResizeColumnsTests.swift
@@ -1,0 +1,51 @@
+//
+//  FontResizeColumnsTests.swift
+//  SwiftTerm
+//
+//  Regression tests ensuring that after a font change the terminal content
+//  stays clear of the scroller, i.e. the recomputed geometry reserves the
+//  scroller width just like the live window-resize path does.
+//
+
+#if os(macOS)
+import Foundation
+import Testing
+import AppKit
+@testable import SwiftTerm
+
+final class FontResizeColumnsTests {
+    /// The core invariant: after a font change the rendered columns must fit
+    /// within the area that is not covered by the scroller. If `resetFont`
+    /// sized the terminal from the raw frame width, the right-most columns
+    /// would be drawn underneath the scroller and become hidden.
+    @Test func testFontChangeKeepsContentClearOfScroller() {
+        let frame = CGRect(x: 0, y: 0, width: 400, height: 200)
+        let view = TerminalView(frame: frame)
+        view.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        let renderedWidth = CGFloat(view.getTerminal().cols) * view.cellDimension.width
+        let usableWidth = view.getEffectiveWidth(size: frame.size)
+
+        // Content must not extend into the reserved scroller strip.
+        #expect(renderedWidth <= usableWidth)
+        // Sanity: the scroller actually reserves space in this configuration,
+        // so the test is exercising a non-trivial case.
+        #expect(usableWidth < frame.width)
+    }
+
+    /// The font-change path (`resetFont`) and the live-resize path
+    /// (`processSizeChange`) must agree on the column count for a given frame,
+    /// so zooming the font in and back out never drifts the column count.
+    @Test func testFontChangeColumnsMatchResizePath() {
+        let frame = CGRect(x: 0, y: 0, width: 400, height: 200)
+        let view = TerminalView(frame: frame)
+        view.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        let colsAfterFontChange = view.getTerminal().cols
+        view.processSizeChange(newSize: frame.size)
+        let colsAfterResize = view.getTerminal().cols
+
+        #expect(colsAfterFontChange == colsAfterResize)
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

After changing the font size (zoom in/out), the right-most columns of the
terminal are drawn **underneath the scroller** and become hidden. Zooming
the font in and back out also leaves the reported column count off by a
couple of columns from what a window resize produces.

## Root cause

The column/row count is computed in two places, and they disagree about
the scroller:

- The live window-resize path, `processSizeChange(newSize:)`, uses
  `getEffectiveWidth(size:)`, which subtracts the reserved scroller width.
- `resetFont()` (invoked when the font changes) computed the columns from
  the **raw** `frame.width`:

  ```swift
  let newCols = Int(frame.width / cellDimension.width)
  ```

So after a font change the terminal claims more columns than actually fit
in the visible (non-scroller) area, and the overflowing right-most columns
are rendered beneath the scroller.

## Fix

Compute the columns from `getEffectiveWidth(size:)` in `resetFont()` too,
matching `processSizeChange`. The function already exists and is used on
both macOS and iOS, so this keeps the two paths consistent and guarantees
content stays clear of the scroller.

## Tests

Added `FontResizeColumnsTests` (macOS) which:

- asserts the rendered width (`cols * cellDimension.width`) stays within
  `getEffectiveWidth(size:)` after a font change — i.e. content is not
  covered by the scroller;
- asserts the font-change path and the live-resize path report the same
  column count for the same frame.

Both tests fail on `main` (e.g. `renderedWidth 397.5 > usableWidth 383.0`,
and `53 != 51` columns) and pass with this change. The rest of the suite
is unaffected (the single pre-existing `testSynchronizedOutputBlocksDisplayUntilReset`
failure also reproduces on a clean `main` and is unrelated).