### PR TITLE
Center full-width (CJK) glyphs within their cell instead of left-pinning them

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -83,6 +83,31 @@ struct ViewLineInfo {
     var boxDrawings: [BoxDrawingRenderItem]
 }
 
+/// How to place a single glyph within its `columnWidth`-cell slot.
+///
+/// Full-width (CJK) and other substituted glyphs would otherwise be pinned to
+/// the left edge of their slot, which dumps the slack between the glyph's
+/// advance and the slot width onto the right of every cell — the phantom gap
+/// reported for CJK text. ``GlyphSlotFit`` centers the glyph's advance box in
+/// the slot so the slack is split evenly instead, matching Terminal.app and the
+/// centering Ghostty applies to wide glyphs (its glyph constraint with
+/// `align: .center`). As a safety net it also constrains a glyph whose ink
+/// overflows its slot — too wide for the columns, or too tall for the cell —
+/// scaling it down to fit and re-centering it vertically. That fit-to-cell guard
+/// is in the spirit of Ghostty's `size` constraint; it is not Ghostty's
+/// cap-height CJK down-scaling (#8709), which corrects an up-scaling we never do.
+/// `dx`/`dy` are point offsets applied to the glyph origin; `scale` is a uniform
+/// downscale (`<= 1`).
+struct GlyphSlotFit {
+    var dx: CGFloat = 0
+    var dy: CGFloat = 0
+    var scale: CGFloat = 1
+
+    static let identity = GlyphSlotFit()
+
+    var isIdentity: Bool { dx == 0 && dy == 0 && scale == 1 }
+}
+
 extension TerminalView {
     typealias CellDimension = CGSize
 
@@ -251,7 +276,54 @@ extension TerminalView {
         let snappedHeight = ceil(cellHeight * scale) / scale
         return CellDimension(width: max(1, snappedWidth), height: max(min(snappedHeight, 8192), 1))
     }
-    
+
+    /// Computes how to center `glyph` within its `columnWidth`-cell slot (and
+    /// scale it down if its ink overflows). Returns ``GlyphSlotFit/identity`` for
+    /// ordinary single-cell glyphs, so Latin text in a monospace font is rendered
+    /// exactly as before and the hot path stays untouched. Shared by the
+    /// CoreGraphics and Metal glyph renderers so they stay pixel-consistent.
+    func glyphSlotFit (font: CTFont, glyph: CGGlyph, columnWidth: Int) -> GlyphSlotFit
+    {
+        // Only wide cells need adjusting: a single-width glyph in a monospace
+        // font already fills its cell, so we skip the metric lookups entirely.
+        guard columnWidth >= 2, cellDimension != nil else { return .identity }
+
+        let cellWidth = cellDimension.width
+        let cellHeight = cellDimension.height
+        let slotWidth = CGFloat(columnWidth) * cellWidth
+
+        var g = glyph
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(font, .horizontal, &g, &advance, 1)
+        guard advance.width > 0 else { return .identity }
+
+        var ink = CGRect.zero
+        CTFontGetBoundingRectsForGlyphs(font, .horizontal, &g, &ink, 1)
+
+        // Scale down only when the ink would spill outside its slot (rare; this
+        // protects oversized substitute glyphs). Never enlarge.
+        var scale: CGFloat = 1
+        if ink.width > slotWidth || ink.height > cellHeight, ink.width > 0, ink.height > 0 {
+            scale = max(0.1, min(min(slotWidth / ink.width, cellHeight / ink.height), 1))
+        }
+
+        // Center the (scaled) advance box horizontally in the slot. Centering by
+        // advance rather than ink keeps glyphs that are intentionally off-center
+        // within their em square — e.g. the CJK comma `、` — in their place.
+        let dx = (slotWidth - advance.width * scale) / 2
+
+        // Preserve the natural Latin baseline unless the glyph was scaled, in
+        // which case center its ink vertically so it doesn't sit too low/high.
+        var dy: CGFloat = 0
+        if scale < 1, ink.height > 0 {
+            let baselineFromBottom = ceil(CTFontGetDescent(fontSet.normal) + CTFontGetLeading(fontSet.normal))
+            let inkCenterFromBaseline = (ink.origin.y + ink.height / 2) * scale
+            dy = (cellHeight / 2 - baselineFromBottom) - inkCenterFromBaseline
+        }
+
+        return GlyphSlotFit(dx: dx, dy: dy, scale: scale)
+    }
+
     func mapColor (color: Attribute.Color, isFg: Bool, isBold: Bool, useBrightColors: Bool = true) -> TTColor
     {
         switch color {
@@ -1454,9 +1526,43 @@ extension TerminalView {
                         color.setFill()
                     }
 
-                    CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
+                    // Center full-width (CJK) and substituted glyphs within their
+                    // multi-cell slot instead of pinning them to the cell's left
+                    // edge. `positions` stays grid-aligned for the decorations
+                    // below; only `glyphPositions` is shifted/scaled.
+                    let ctRunFont = runFont as CTFont
+                    var glyphPositions = positions
+                    var scaledFits: [GlyphSlotFit]? = nil
+                    if prepared.segment.columnWidth >= 2 {
+                        var computed = [GlyphSlotFit](repeating: .identity, count: runGlyphsCount)
+                        var anyScaled = false
+                        for i in 0..<runGlyphsCount {
+                            let fit = glyphSlotFit(font: ctRunFont, glyph: runGlyphs[i], columnWidth: prepared.segment.columnWidth)
+                            computed[i] = fit
+                            glyphPositions[i].x += fit.dx
+                            glyphPositions[i].y += fit.dy
+                            if fit.scale != 1 { anyScaled = true }
+                        }
+                        if anyScaled { scaledFits = computed }
+                    }
 
-                    // Draw other attributes
+                    if let scaledFits {
+                        // Rare path: at least one glyph overflowed its slot and is
+                        // drawn individually at a reduced point size.
+                        for i in 0..<runGlyphsCount {
+                            let s = scaledFits[i].scale
+                            let drawFont: CTFont = s == 1
+                                ? ctRunFont
+                                : CTFontCreateCopyWithAttributes(ctRunFont, CTFontGetSize(ctRunFont) * s, nil, nil)
+                            var g = runGlyphs[i]
+                            var p = glyphPositions[i]
+                            CTFontDrawGlyphs(drawFont, &g, &p, 1, context)
+                        }
+                    } else {
+                        CTFontDrawGlyphs(runFont, runGlyphs, &glyphPositions, glyphPositions.count, context)
+                    }
+
+                    // Draw other attributes (decorations stay grid-aligned)
                     drawRunAttributes(runAttributes, glyphPositions: positions, in: context)
 
                     processedGlyphs += runGlyphsCount
@@ -1758,8 +1864,13 @@ extension TerminalView {
         let offset = (cellDimension.height * (CGFloat(buffer.y-(buffer.yDisp-buffer.yBase)+1)))
         let lineOrigin = CGPoint(x: 0, y: frame.height - offset)
         #endif
+        let charUnderCursor = buffer.lines [vy][buffer.x]
+        // Span the caret across the full character so a block cursor covers a
+        // full-width (CJK) glyph instead of only its left half.
+        let cursorColumnWidth = max(1, Int(charUnderCursor.width))
         caretView.frame.origin = CGPoint(x: lineOrigin.x + (cellDimension.width * doublePosition * CGFloat(buffer.x)), y: lineOrigin.y)
-        caretView.setText (ch: buffer.lines [vy][buffer.x])
+        caretView.frame.size.width = cellDimension.width * doublePosition * CGFloat(cursorColumnWidth)
+        caretView.setText (ch: charUnderCursor)
     }
     
     // Does not use a default argument and merge, because it is called back

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -52,14 +52,20 @@ extension CaretView {
             let runGlyphsCount = CTRunGetGlyphCount(run)
             let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
             let runFont = runAttributes[.font] as! TTFont
+            let ctRunFont = runFont as CTFont
 
             let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
                 CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
                 count = runGlyphsCount
             }
 
-            var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
-                CGPoint(x: 0, y: yOffset)
+            // Center full-width (CJK) glyphs within the caret the same way as the
+            // surrounding text so the character doesn't shift under the cursor.
+            // The caret bounds span `glyphColumnWidth` cells (set when sizing it),
+            // so the centered glyph isn't clipped.
+            var positions = runGlyphs.map { glyph -> CGPoint in
+                let fit = terminal.glyphSlotFit(font: ctRunFont, glyph: glyph, columnWidth: glyphColumnWidth)
+                return CGPoint(x: fit.dx, y: yOffset + fit.dy)
             }
             CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
         }

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -60,14 +60,25 @@ extension CaretView {
             }
 
             // Center full-width (CJK) glyphs within the caret the same way as the
-            // surrounding text so the character doesn't shift under the cursor.
-            // The caret bounds span `glyphColumnWidth` cells (set when sizing it),
-            // so the centered glyph isn't clipped.
-            var positions = runGlyphs.map { glyph -> CGPoint in
-                let fit = terminal.glyphSlotFit(font: ctRunFont, glyph: glyph, columnWidth: glyphColumnWidth)
-                return CGPoint(x: fit.dx, y: yOffset + fit.dy)
+            // surrounding text so the character doesn't shift under the cursor,
+            // and scale an oversized glyph down to match (drawTerminalContents
+            // does the same via CTFontCreateCopyWithAttributes). The caret bounds
+            // span `glyphColumnWidth` cells, so the centered glyph isn't clipped.
+            let fits = runGlyphs.map { terminal.glyphSlotFit(font: ctRunFont, glyph: $0, columnWidth: glyphColumnWidth) }
+            var positions = fits.map { CGPoint(x: $0.dx, y: yOffset + $0.dy) }
+            if fits.contains(where: { $0.scale != 1 }) {
+                for i in 0..<runGlyphsCount {
+                    let s = fits[i].scale
+                    let drawFont: CTFont = s == 1
+                        ? ctRunFont
+                        : CTFontCreateCopyWithAttributes(ctRunFont, CTFontGetSize(ctRunFont) * s, nil, nil)
+                    var g = runGlyphs[i]
+                    var p = positions[i]
+                    CTFontDrawGlyphs(drawFont, &g, &p, 1, context)
+                }
+            } else {
+                CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
             }
-            CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
         }
         context.restoreGState()
     }

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -1179,15 +1179,25 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                         }
                         let ctPos = glyphRun.positions[i]
                         let glyphColumn = startColumn + ((drawnGlyphsInRun + i) * shaped.segment.columnWidth)
-                        let basePos = CGPoint(x: lineOrigin.x + (cellWidth * CGFloat(glyphColumn)),
-                                              y: lineOrigin.y + yOffset + ctPos.y)
-                        let pxX = basePos.x * scale + entry.bearing.x
-                        let pxY = basePos.y * scale + entry.bearing.y
+                        // Center full-width (CJK) and substituted glyphs within
+                        // their multi-cell slot instead of pinning them to the
+                        // cell's left edge, mirroring the CoreGraphics path. The
+                        // decoration loops below keep using the grid column, so
+                        // underlines/strikethroughs stay cell-aligned.
+                        let fit = shaped.segment.columnWidth >= 2
+                            ? terminalView.glyphSlotFit(font: glyphRun.font,
+                                                        glyph: glyph,
+                                                        columnWidth: shaped.segment.columnWidth)
+                            : GlyphSlotFit.identity
+                        let basePos = CGPoint(x: lineOrigin.x + (cellWidth * CGFloat(glyphColumn)) + fit.dx,
+                                              y: lineOrigin.y + yOffset + ctPos.y + fit.dy)
+                        let pxX = basePos.x * scale + entry.bearing.x * fit.scale
+                        let pxY = basePos.y * scale + entry.bearing.y * fit.scale
 
                         let x0 = pxX
                         let y0 = pxY
-                        let x1 = pxX + entry.size.width
-                        let y1 = pxY + entry.size.height
+                        let x1 = pxX + entry.size.width * fit.scale
+                        let y1 = pxY + entry.size.height * fit.scale
                         let (tx0, ty0, tx1, ty1) = transformRect(x0: x0, y0: y0, x1: x1, y1: y1)
 
                         let atlasSize = entry.atlasKind == .color ? colorAtlas.size : grayscaleAtlas.size
@@ -2090,10 +2100,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let cellWidthPx = cellWidth * scale
         let cellHeightPx = cellHeight * scale
         let doublePosition: CGFloat = buffer.lines[cursorRow].renderMode == .single ? 1.0 : 2.0
+        // Span the cursor across the full character so a block/underline cursor
+        // covers a full-width (CJK) glyph instead of only its left half, matching
+        // the CoreGraphics caret.
+        let cursorColumnWidth = CGFloat(max(1, Int(buffer.lines[cursorRow][buffer.x].width)))
 
         let x0 = lineOriginPx.x + CGFloat(buffer.x) * cellWidthPx * doublePosition
         let y0 = lineOriginPx.y
-        let x1 = x0 + cellWidthPx
+        let x1 = x0 + cellWidthPx * doublePosition * cursorColumnWidth
         let y1 = y0 + cellHeightPx
 
         #if os(macOS)
@@ -2196,14 +2210,17 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     continue
                 }
                 let ctPos = coreTextPositions[i]
-                let basePos = CGPoint(x: lineOrigin.x + cellWidth * doublePosition * CGFloat(buffer.x),
-                                      y: lineOrigin.y + yOffset + ctPos.y)
-                let pxX = basePos.x * scale + entry.bearing.x
-                let pxY = basePos.y * scale + entry.bearing.y
+                // Center the glyph under the cursor the same way as normal text so
+                // a full-width (CJK) character doesn't shift when the caret lands on it.
+                let fit = terminalView.glyphSlotFit(font: ctFont, glyph: glyph, columnWidth: max(1, Int(charData.width)))
+                let basePos = CGPoint(x: lineOrigin.x + cellWidth * doublePosition * CGFloat(buffer.x) + fit.dx * doublePosition,
+                                      y: lineOrigin.y + yOffset + ctPos.y + fit.dy)
+                let pxX = basePos.x * scale + entry.bearing.x * fit.scale
+                let pxY = basePos.y * scale + entry.bearing.y * fit.scale
                 let x0 = Float(pxX)
                 let y0 = Float(pxY)
-                let x1 = x0 + Float(entry.size.width)
-                let y1 = y0 + Float(entry.size.height)
+                let x1 = x0 + Float(entry.size.width * fit.scale)
+                let y1 = y0 + Float(entry.size.height * fit.scale)
 
                 let atlasSize = entry.atlasKind == .color ? colorAtlas.size : grayscaleAtlas.size
                 let u0 = Float(entry.region.x) / Float(atlasSize)

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -18,6 +18,9 @@ import CoreText
 class CaretView: NSView, CALayerDelegate {
     weak var terminal: TerminalView?
     var ctline: CTLine?
+    /// Cell width of the character currently under the caret (2 for full-width
+    /// CJK). Used to center its glyph within the caret, matching the text.
+    var glyphColumnWidth: Int = 1
     var bgColor: CGColor
     var tracksFocus = true
     
@@ -45,6 +48,7 @@ class CaretView: NSView, CALayerDelegate {
     }
     
     func setText (ch: CharData) {
+        glyphColumnWidth = max(1, Int(ch.width))
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
             string: UnicodeUtil.textPresentationAdjusted (character),

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -16,6 +16,9 @@ import CoreGraphics
 class CaretView: UIView {
     weak var terminal: TerminalView?
     var ctline: CTLine?
+    /// Cell width of the character currently under the caret (2 for full-width
+    /// CJK). Used to center its glyph within the caret, matching the text.
+    var glyphColumnWidth: Int = 1
     var bgColor: CGColor
     var tracksFocus = true
     
@@ -78,6 +81,7 @@ class CaretView: UIView {
     }
     
     func setText (ch: CharData) {
+        glyphColumnWidth = max(1, Int(ch.width))
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
             string: UnicodeUtil.textPresentationAdjusted (character),


### PR DESCRIPTION
## Problem

Full-width (CJK) and other substituted glyphs are pinned to the left edge of their N-cell slot. The renderer discards CoreText's x advance and places every glyph at `column * cellDimension.width` on the cell grid, then draws it at natural size. For a single-width Latin glyph in a monospace font that's exact. But a full-width CJK glyph spans 2 cells, and with a typical Latin-metric base font the slot is wider than the glyph:

- SF Mono's advance is ≈ 0.62 em, so a 2-cell slot is ≈ 1.24 em.
- The substituted CJK glyph (Hiragino, PingFang, …) advances ≈ 1.0 em.

The ≈ 0.24 em of slack is dumped entirely on the **right** of every character, so each glyph sits hard against the left of its slot with a gap after it. It reads as if a space were inserted after every CJK character: Japanese/Chinese/Korean output looks "spaced out" and is markedly harder to read. Western text is unaffected.

This is structural, not letter-spacing: the gap is `N*cellWidth - glyphAdvance` for any Latin-metric base font. Terminal.app and Ghostty avoid the artifact by centering the glyph in its slot (Ghostty's glyph constraint, `align: .center`); the slack is identical but split symmetrically, which reads as natural CJK tracking. SwiftTerm pins left, which breaks the rhythm.

Reported by a Japanese user; reproduced with the default SF Mono on both the CoreGraphics and Metal renderers.

## Fix

Add `glyphSlotFit(font:glyph:columnWidth:)` on `TerminalView`, shared by the CoreGraphics (`drawTerminalContents`) and Metal glyph paths so they stay pixel-consistent. For a glyph in a slot of `columnWidth >= 2` it centers the glyph's advance box in the slot (`dx = (slotWidth - advance) / 2`); for the rare glyph whose ink overflows its slot it also scales it down to fit and re-centers it vertically. It returns identity for single-width cells, so it's a no-op for Latin and the hot path is untouched (the helper isn't even called for `columnWidth == 1`).

- Centering is by **advance, not ink**, so glyphs intentionally off-center in their em square (e.g. the CJK comma `、`) keep their designed position.
- Background fill, selection, and underline/strikethrough keep using the grid column; only the glyph ink moves within its own cell, so cursor/selection alignment is unchanged.
- The block caret is widened to span the full character and its glyph is centered the same way, so a block cursor covers the whole full-width character instead of just its left half, and the glyph doesn't jump when the caret lands on it. (Also fixes the pre-existing 1-cell caret on full-width characters.)

## Tests

Manually verified on both renderers:

- CJK (`日本語の表示、テスト。「カナ」 ABC 123`) now centers in its cells with no one-sided gap; mixed CJK+Latin stays grid-aligned; punctuation (`、。「」`) is balanced.
- Latin/ASCII is byte-for-byte unchanged (the helper short-circuits on single-width cells).
- Block cursor over CJK covers the whole character with no jump on blink/move; underline and selection stay cell-aligned.
- Cross-checked against a strict 1:2 font (Sarasa Mono): the offset is ≈ 0 (the glyph already fills the slot), confirming the helper only redistributes slack and stays out of the way when there's none.

Before:
<img width="694" height="132" alt="SCR-20260621-sgrw" src="https://github.com/user-attachments/assets/4de680f0-32aa-41a4-b4cb-d8b661ac3c54" />

After:
<img width="1099" height="180" alt="SCR-20260621-sgta" src="https://github.com/user-attachments/assets/a4b66743-a0b3-4430-97df-5eb1635ecc77" />

