### PR TITLE
Fix stale synchronized-output test that fails deterministically

### DIFF
--- a/Tests/SwiftTermTests/SynchronizedOutputTests.swift
+++ b/Tests/SwiftTermTests/SynchronizedOutputTests.swift
@@ -38,7 +38,14 @@ final class SynchronizedOutputTests {
         ).replacingOccurrences(of: "\u{0}", with: " ")
     }
 
-    @Test func testSynchronizedOutputBlocksDisplayUntilReset() {
+    /// Synchronized output (DEC mode 2026) no longer snapshots the buffer in
+    /// the core: `displayBuffer === buffer` and the live buffer is mutated
+    /// immediately. Display blocking is enforced at the view layer instead
+    /// (`AppleTerminalView.updateDisplay` early-returns while the flag is set,
+    /// covered by the view-level tests below). This test pins the core
+    /// contract: the active flag toggles on `?2026h`/`?2026l`, and the live
+    /// buffer always reflects the most recent content.
+    @Test func testSynchronizedOutputTracksLiveBufferAndTogglesFlag() {
         let terminal = Terminal(
             delegate: TestDelegate(),
             options: TerminalOptions(cols: 20, rows: 5, scrollback: 0)
@@ -47,14 +54,19 @@ final class SynchronizedOutputTests {
 
         terminal.feed(text: "\(esc)[2J\(esc)[HOLD")
         #expect(topLineText(from: terminal.displayBuffer).hasPrefix("OLD"))
+        #expect(!terminal.synchronizedOutputActive)
 
         terminal.feed(text: "\(esc)[?2026h")
-        terminal.feed(text: "\(esc)[2J\(esc)[HNEW")
+        #expect(terminal.synchronizedOutputActive)
 
-        #expect(topLineText(from: terminal.displayBuffer).hasPrefix("OLD"))
+        terminal.feed(text: "\(esc)[2J\(esc)[HNEW")
+        // Core does not freeze the buffer during sync; the new content is live
+        // immediately and displayBuffer mirrors it.
         #expect(topLineText(from: terminal.buffer).hasPrefix("NEW"))
+        #expect(topLineText(from: terminal.displayBuffer).hasPrefix("NEW"))
 
         terminal.feed(text: "\(esc)[?2026l")
+        #expect(!terminal.synchronizedOutputActive)
         #expect(topLineText(from: terminal.displayBuffer).hasPrefix("NEW"))
     }
 


### PR DESCRIPTION
## Problem

`SynchronizedOutputTests.testSynchronizedOutputBlocksDisplayUntilReset` fails on every CI run (and locally), e.g. [run 27973775699](https://github.com/migueldeicaza/SwiftTerm/actions/runs/27973775699) on `main`:

```
✘ testSynchronizedOutputBlocksDisplayUntilReset() recorded an issue at SynchronizedOutputTests.swift:54:9:
   Expectation failed: (topLineText(from: terminal.displayBuffer) → "NEW").hasPrefix("OLD")
```

## Root cause

The test is stale, not flaky. Commit 9446f60 (*"Simplifies the DEC 2026 buffering support, which was causing updates to not flush to the screen on time"*) removed the frozen `synchronizedOutputBuffer` snapshot — `displayBuffer` now simply returns `buffer`, and display blocking moved to the view layer (`AppleTerminalView.updateDisplay` early-returns while `synchronizedOutputActive` is set).

That commit never updated this test, which still asserts the old snapshot behaviour (`displayBuffer` frozen to "OLD" during sync). Since `displayBuffer === buffer` now, the assertion can never hold once the buffer is mutated to "NEW", so it fails 100% of the time.

## Fix

Rewrite the test (test-only change, no behaviour change) to pin the **current** core contract:

- `synchronizedOutputActive` toggles correctly on `?2026h` / `?2026l`
- the live buffer always reflects the most recent content during sync

The view-layer blocking behaviour remains covered by the existing `#if os(macOS)` tests in the same file.

All 5 tests in `SynchronizedOutputTests` pass locally after this change.