### PR TITLE
Clear the dirty region in the CoreGraphics renderer (fixes restricted-region scroll artifacts)

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1284,6 +1284,16 @@ extension TerminalView {
         }
         var placeholderImageCache: [UInt32: TTImage] = [:]
 
+        #if os(macOS)
+        // Clear the invalidated region before painting. We fill only cells that carry
+        // an explicit background; default-background cells rely on transparent backing-
+        // store pixels showing the layer's background color. AppKit clears the backing
+        // store only on a full-view redraw, so a partial repaint (a restricted DECSTBM
+        // scroll region, line insert/delete) otherwise keeps stale glyphs/backgrounds.
+        // Clear to transparent — not fill — so a translucent background is preserved.
+        context.clear(dirtyRect)
+        #endif
+
         for row in firstRow...lastRow {
             if row < 0 {
                 continue
@@ -1773,6 +1783,14 @@ extension TerminalView {
             let oh = region.height
             let oy = region.origin.y
             region = CGRect (x: 0, y: 0, width: frame.width, height: oh + oy)
+        } else {
+            // Region ends mid-screen (a restricted DECSTBM region): extend the
+            // invalidation down by one cell so the sub-cell remainder just below the
+            // band's bottom row (descenders / tall unicode) is cleared too. Previously
+            // only rowEnd == rows-1 got this, leaving a one-row ghost below the region.
+            let extra = cellDimension.height
+            let newY = max (0, region.origin.y - extra)
+            region = CGRect (x: 0, y: newY, width: frame.width, height: region.maxY - newY)
         }
 #if canImport(MetalKit)
         if metalView != nil {

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -2523,6 +2523,11 @@ open class Terminal {
         }
         // this.maxRange();
         updateRange (startLine: buffer.y, endLine: buffer.scrollBottom)
+        // A restricted region leaves stale pixels / a bottom-edge ghost outside
+        // [y, scrollBottom] on the CG renderer (as in scroll()); the range above
+        // already covers full-screen, so widen to the whole viewport only when the
+        // region is restricted.
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: true)
     }
     
     //
@@ -4750,7 +4755,7 @@ open class Terminal {
             }
         }
         // this.maxRange();
-        updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
     }
 
     //
@@ -4786,7 +4791,7 @@ open class Terminal {
             }
         }
         // this.maxRange();
-        updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
     }
 
     //
@@ -4863,6 +4868,11 @@ open class Terminal {
         
         // this.maxRange();
         updateRange (startLine: buffer.y, endLine: buffer.scrollBottom)
+        // A restricted region leaves stale pixels / a bottom-edge ghost outside
+        // [y, scrollBottom] on the CG renderer (as in scroll()); the range above
+        // already covers full-screen, so widen to the whole viewport only when the
+        // region is restricted.
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: true)
     }
 
     //
@@ -5260,6 +5270,16 @@ open class Terminal {
     
     var blankLine: BufferLine = BufferLine(cols: 0)
     
+    /// Flag the scrolled region dirty. The CoreGraphics renderer now clears any
+    /// dirtied region before painting (see AppleTerminalView), so flagging just
+    /// [top, bottom] fixes the stale rows / bottom ghost — no whole-viewport repaint
+    /// needed. Full-screen + scrollback (`canBlit`) keeps the cheap path.
+    private func refreshScrolledRegion(top: Int, bottom: Int, canBlit: Bool) {
+        if top != 0 || bottom != rows - 1 || !canBlit {
+            updateRange(startLine: top, endLine: bottom)
+        }
+    }
+
     public func scroll (isWrapped: Bool = false)
     {
         let buffer = self.buffer
@@ -5385,9 +5405,7 @@ open class Terminal {
         updateRange (scrollTop, scrolling: true)
         updateRange (scrollBottom, scrolling: true)
 
-        if !hasScrollback {
-            updateRange(startLine: scrollTop, endLine: scrollBottom)
-        }
+        refreshScrolledRegion(top: scrollTop, bottom: scrollBottom, canBlit: hasScrollback)
 
         if buffer.hasAnyImages {
             updateKittyRelativePlacementsForCurrentBuffer()
@@ -5826,7 +5844,7 @@ open class Terminal {
                     }
                     buffer.lines [topRow] = buffer.getBlankLine (attribute: eraseAttr ())
                 }
-                updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)
+                refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
             }
         } else if buffer.y > 0 {
             buffer.y -= 1


### PR DESCRIPTION
### Problem
Scrolling or editing inside a restricted DECSTBM scroll region (a fixed header and/or footer, as in `nano`, `vim`, `less`, `htop`) leaves stale rows and a sub-cell "ghost" on the region's last row on the **CoreGraphics renderer** (Metal disabled). The Metal path masks it by clearing the whole target each frame.

Reproducible: open `nano` on a file with lines wider than the window and hold PageDown/PageUp; or do `vim` line edits in a fixed-footer layout.

### Root cause — the renderer, not the scroll primitives
The scroll/edit primitives report a correct dirty range. The CG renderer:

1. **never clears the dirty region's background** before painting — `drawTerminalContents` fills background per-cell-run only, and **only for cells that carry an explicit background**; default-background cells rely on transparent backing-store pixels showing the layer's `backgroundColor`. AppKit clears the backing store only on a full-view redraw, so a partial repaint (a restricted region, IL/DL) keeps stale glyphs/backgrounds.
2. **only invalidates the sub-cell bottom remainder when `rowEnd == rows-1`** — a restricted region ends at `scrollBottom < rows-1`, so the sliver below it is never repainted → the ghost.

(There is no pixel blit; unchanged pixels persist via AppKit's dirty-rect coalescing over the layer backing store.)

### Fix — macOS CG path only; Metal unaffected
In `AppleTerminalView`:

1. `context.clear(dirtyRect)` before the per-row paint — clears the invalidated region to transparent (a clear, **not** a fill, so a translucent background is preserved), giving the per-cell paint a clean slate.
2. Extend a mid-screen region's invalidated `region` down by one cell, so the bottom remainder is cleared too (previously only `rowEnd == rows-1` got this).

This fixes **every** row-mutating primitive (`scroll`, `reverseIndex`, `cmdScrollUp/Down`, `cmdInsertLines/DeleteLines`) at the source. With the renderer clearing any dirtied region, the primitives only need to flag the rows they changed — so `refreshScrolledRegion` flags just `[scrollTop, scrollBottom]` (keeping the full-screen + scrollback cheap path) instead of inflating to the whole viewport.

The Metal renderer is untouched: it already `loadAction = .clear`s the whole target each frame, and the `region` extension only feeds the non-Metal `setNeedsDisplay`.

### Testing
Verified in `nano` / `vim` / `less` / `htop` on the CG renderer — no stale rows or bottom ghost while paging or editing — with a translucent background intact, and normal full-screen output scrolling unaffected (cheap path preserved). The package builds cleanly.

---
*This supersedes an earlier per-primitive workaround on this branch (which inflated each scroll op's dirty range to the whole viewport) with the renderer-level root fix.*
