### PR TITLE
Center glyphs vertically when lineSpacing > 1

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -681,9 +681,55 @@ struct SnapshotRenderContext {
         identity = UInt64(bitPattern: Int64(identityHasher.finalize()))
     }
 
+    /// ``CellGeometry/baselineOffset(normalFont:cellHeight:)`` for the fonts and
+    /// cell geometry captured in this frame. Both renderers read it from here so
+    /// a frame's text, caret, and scaled glyphs share one baseline.
+    var baselineOffset: CGFloat {
+        CellGeometry.baselineOffset(normalFont: fonts.normal,
+                                    cellHeight: cellDimension.height)
+    }
+
     func glyphSlotFit (font: CTFont, glyph: CGGlyph, columnWidth: Int) -> GlyphSlotFit {
         GlyphSlotFit.calculate(font: font, glyph: glyph, columnWidth: columnWidth,
                                cellDimension: cellDimension, normalFont: fonts.normal)
+    }
+}
+
+/// Text geometry derived from a cell's size. Not isolated to the main actor:
+/// the snapshot renderers do this arithmetic on their own threads, from the
+/// fonts and cell dimensions captured for the frame.
+enum CellGeometry {
+    /// Distance from the bottom of a cell to the glyph baseline.
+    ///
+    /// ``TerminalView/lineSpacing`` makes the cell taller than the font's
+    /// natural line (ascent + descent + leading) in `computeFontDimensions`,
+    /// but the baseline used to stay pinned at `descent + leading` from the
+    /// cell's bottom, so every bit of the added height piled up above the text
+    /// and rows looked bottom-heavy at the larger values (1.4-1.6). This
+    /// splits the extra evenly above and below the glyph instead — the
+    /// half-leading model iTerm2 and WezTerm use — so text stays vertically
+    /// centered in its cell.
+    ///
+    /// The classic `ceil(descent + leading)` term is kept intact and the
+    /// glyph's share of the extra is added as a whole number of points on top,
+    /// rather than rounding the sum: that keeps the baseline on the same pixel
+    /// grid the old offset landed on, and it makes the default exact rather
+    /// than approximate. A cell within two points of the font's natural height
+    /// — which pixel-grid snapping alone can produce at `lineSpacing == 1` on
+    /// a fractional backing scale — yields the classic offset unchanged, so
+    /// nobody who leaves `lineSpacing` alone sees a single pixel move.
+    ///
+    /// Every renderer — CoreGraphics, Metal, the caret views — and the glyph
+    /// slot fitter must derive baselines from this one function. The local
+    /// copies of the formula it replaces are how those paths drifted out of
+    /// sync in the first place.
+    static func baselineOffset (normalFont: CTFont, cellHeight: CGFloat) -> CGFloat
+    {
+        let descent = CTFontGetDescent (normalFont)
+        let leading = CTFontGetLeading (normalFont)
+        let naturalHeight = ceil (CTFontGetAscent (normalFont) + descent + leading)
+        let extra = max (0, cellHeight - naturalHeight)
+        return ceil (descent + leading) + floor (extra / 2)
     }
 }
 
@@ -737,8 +783,8 @@ struct GlyphSlotFit {
         guard columnWidth >= 2 else { return .identity }
 
         let metrics = GlyphMetrics.measure(font: font, glyph: glyph)
-        let baselineFromBottom = ceil(CTFontGetDescent(normalFont) +
-                                      CTFontGetLeading(normalFont))
+        let baselineFromBottom = CellGeometry.baselineOffset(normalFont: normalFont,
+                                                             cellHeight: cellDimension.height)
         return calculate(metrics: metrics,
                          columnWidth: columnWidth,
                          cellDimension: cellDimension,
@@ -1265,6 +1311,9 @@ extension TerminalView {
 
     /// Multiplier for vertical line spacing. 1.0 = default (ascent + descent + leading).
     /// Set to 1.1 for 110% vertical spacing (matches iTerm2's vertical spacing setting).
+    /// The extra height is split evenly above and below each glyph (see
+    /// ``CellGeometry/baselineOffset(normalFont:cellHeight:)``), so text stays vertically
+    /// centered within its cell.
     /// Triggers a font reset and terminal resize when changed.
     @objc open var lineSpacing: CGFloat {
         get { _lineSpacing }
@@ -1636,6 +1685,14 @@ extension TerminalView {
         return CellDimension(width: max(1, snappedWidth), height: max(min(snappedHeight, 8192), 1))
     }
 
+    /// ``CellGeometry/baselineOffset(normalFont:cellHeight:)`` for this view's
+    /// current font and cell geometry.
+    var baselineOffset: CGFloat {
+        let currentCellDimension: CellDimension? = cellDimension
+        return CellGeometry.baselineOffset (normalFont: fontSet.normal,
+                                            cellHeight: currentCellDimension?.height ?? 0)
+    }
+
     /// Computes how to center `glyph` within its `columnWidth`-cell slot (and
     /// scale it down if its ink overflows). Returns ``GlyphSlotFit/identity`` for
     /// ordinary single-cell glyphs, so Latin text in a monospace font is rendered
@@ -1661,8 +1718,8 @@ extension TerminalView {
         guard let currentCellDimension else { return .identity }
         let normalFont = fontSet.normal
         let metrics = GlyphMetrics.measure(font: font, glyph: glyph)
-        let baselineFromBottom = ceil(CTFontGetDescent(normalFont) +
-                                      CTFontGetLeading(normalFont))
+        let baselineFromBottom = CellGeometry.baselineOffset(
+            normalFont: normalFont, cellHeight: currentCellDimension.height)
         return GlyphSlotFit.calculate(metrics: metrics,
                                       policy: policy,
                                       columnWidth: columnWidth,
@@ -2817,9 +2874,7 @@ extension TerminalView {
 
         guard let viewState = captureFrameViewState() else { return }
         renderOwner.withSnapshotForDrawing(viewState: viewState) { snapshot, renderContext in
-        let lineDescent = CTFontGetDescent(fontSet.normal)
-        let lineLeading = CTFontGetLeading(fontSet.normal)
-        let yOffset = ceil(lineDescent+lineLeading)
+        let yOffset = renderContext.baselineOffset
         #if os(macOS)
         let renderBufferOffset = snapshot.yDisp
         #else

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -41,9 +41,11 @@ extension CaretView {
         context.fill([region])
 
         let normalFont = renderNormalFont ?? terminal.fontSet.normal
-        let lineDescent = CTFontGetDescent(normalFont)
-        let lineLeading = CTFontGetLeading(normalFont)
-        let yOffset = ceil(lineDescent+lineLeading)
+        // Must be the offset the text renderers use, or the glyph drawn inside
+        // the caret lands on a different baseline than the row under it.
+        let terminalCell: TerminalView.CellDimension? = terminal.cellDimension
+        let yOffset = CellGeometry.baselineOffset(
+            normalFont: normalFont, cellHeight: terminalCell?.height ?? bounds.height)
         
         guard style == .steadyBlock || style  == .blinkBlock else {
             return

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -1421,9 +1421,7 @@ final class MetalTerminalRenderer {
         let scale = context.renderingScale
         let cellWidth = context.cellDimension.width
         let cellHeight = context.cellDimension.height
-        let lineDescent = CTFontGetDescent(context.fonts.normal)
-        let lineLeading = CTFontGetLeading(context.fonts.normal)
-        let yOffset = ceil(lineDescent + lineLeading)
+        let yOffset = context.baselineOffset
         let viewWidthPx = context.viewBounds.width * scale
 
         let rowInfo = visibleRowRange(snapshot: snapshot)
@@ -1604,8 +1602,6 @@ final class MetalTerminalRenderer {
                                              scale: scale,
                                              cellWidth: cellWidth,
                                              cellHeight: cellHeight,
-                                             lineDescent: lineDescent,
-                                             lineLeading: lineLeading,
                                              yDisp: visibleDisp,
                                              firstRow: firstRow,
                                              lastRow: lastRow)
@@ -3331,8 +3327,6 @@ final class MetalTerminalRenderer {
                                      scale: CGFloat,
                                      cellWidth: CGFloat,
                                      cellHeight: CGFloat,
-                                     lineDescent: CGFloat,
-                                     lineLeading: CGFloat,
                                      yDisp: Int,
                                      firstRow: Int,
                                      lastRow: Int) -> (colorVertices: [ColorVertex],
@@ -3480,7 +3474,7 @@ final class MetalTerminalRenderer {
         guard let runs = CTLineGetGlyphRuns(ctline) as? [CTRun] else {
             return (colorVertices, [], [])
         }
-        let yOffset = ceil(lineDescent + lineLeading)
+        let yOffset = context.baselineOffset
         let textColorSIMD = colorToSIMD(caretTextColor)
 
         for run in runs {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -3568,8 +3568,8 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         let definition = NSAttributedString(
             string: wordAndScreenRow.word.text,
             attributes: [.font: fontSet.normal])
-        let baselineOffset = ceil(
-            CTFontGetDescent(fontSet.normal) + CTFontGetLeading(fontSet.normal))
+        // The popover anchors on the word's baseline, which lineSpacing moves.
+        let baselineOffset = self.baselineOffset
         let baseline = NSPoint(
             x: CGFloat(wordAndScreenRow.word.start.col) * cellDimension.width,
             y: frame.height - CGFloat(wordAndScreenRow.screenRow + 1) * cellDimension.height

--- a/Tests/SwiftTermTests/CellBaselineTests.swift
+++ b/Tests/SwiftTermTests/CellBaselineTests.swift
@@ -1,0 +1,110 @@
+#if os(macOS)
+import AppKit
+import CoreText
+import Testing
+@testable import SwiftTerm
+
+/// `CellGeometry.baselineOffset` is the single definition of where a glyph's
+/// baseline sits inside its cell. Every renderer reads it, so these tests pin
+/// the two properties the renderers depend on: it does not move at
+/// `lineSpacing == 1`, and above 1 it centers the natural line in the cell.
+@MainActor
+final class CellBaselineTests {
+    private static let fonts: [(name: String, size: CGFloat)] = [
+        ("Monaco", 10), ("Monaco", 12), ("Monaco", 13.5), ("Monaco", 24),
+        ("Menlo", 11), ("Menlo", 14), ("SF Mono", 12), ("Courier", 13),
+    ]
+
+    private func classicOffset (_ font: NSFont) -> CGFloat {
+        ceil(CTFontGetDescent(font) + CTFontGetLeading(font))
+    }
+
+    /// The offset every renderer used before line spacing was distributed. Any
+    /// change here at the default spacing is a visible regression for every
+    /// user who never touches `lineSpacing`.
+    @Test func defaultSpacingKeepsTheClassicBaseline() throws {
+        for spec in Self.fonts {
+            guard let font = NSFont(name: spec.name, size: spec.size) else { continue }
+            let view = TerminalView(frame: .zero, font: font)
+            #expect(view.lineSpacing == 1)
+            #expect(view.baselineOffset == classicOffset(font),
+                    "\(spec.name) \(spec.size)pt moved at lineSpacing == 1")
+        }
+    }
+
+    /// A cell a point or two taller than the font's natural line — which
+    /// pixel-grid snapping alone can produce on a fractional backing scale —
+    /// must not shift the baseline either: there is no whole point to give the
+    /// glyph, and half-point baselines are what blur text.
+    @Test func extraUnderTwoPointsDoesNotMoveTheBaseline() throws {
+        let font = try #require(NSFont(name: "Monaco", size: 12))
+        let natural = ceil(CTFontGetAscent(font) + CTFontGetDescent(font) + CTFontGetLeading(font))
+        for extra in [-4.0, 0.0, 0.01, 0.5, 0.999, 1.0, 1.5, 1.999] as [CGFloat] {
+            #expect(CellGeometry.baselineOffset(normalFont: font, cellHeight: natural + extra)
+                    == classicOffset(font),
+                    "extra of \(extra)pt should be left where it is")
+        }
+        // Two whole points is the first split worth making: one each side.
+        #expect(CellGeometry.baselineOffset(normalFont: font, cellHeight: natural + 2)
+                == classicOffset(font) + 1)
+    }
+
+    /// The baseline rises by whole points only, and never past the point where
+    /// the ascender would be pushed out of the cell.
+    @Test func baselineRisesInWholePointsAndStaysInTheCell() throws {
+        let font = try #require(NSFont(name: "Monaco", size: 12))
+        let natural = ceil(CTFontGetAscent(font) + CTFontGetDescent(font) + CTFontGetLeading(font))
+        var previous = classicOffset(font)
+        for extra in stride(from: CGFloat(0), through: 40, by: 0.5) {
+            let offset = CellGeometry.baselineOffset(normalFont: font, cellHeight: natural + extra)
+            #expect(offset == offset.rounded(), "baseline landed off the pixel grid at \(extra)")
+            #expect(offset >= previous, "baseline moved backwards at \(extra)")
+            #expect(offset + CTFontGetAscent(font) <= natural + extra,
+                    "ascender pushed out of the cell at \(extra)")
+            previous = offset
+        }
+    }
+
+    /// Above 1 the extra height is split evenly, so the font's natural line
+    /// ends up centered in the taller cell rather than pinned to its top.
+    @Test func extraSpacingIsSplitEvenlyAboveAndBelow() throws {
+        let font = try #require(NSFont(name: "Monaco", size: 12))
+        let natural = ceil(CTFontGetAscent(font) + CTFontGetDescent(font) + CTFontGetLeading(font))
+
+        for spacing in [1.2, 1.4, 1.6, 2.0] as [CGFloat] {
+            let view = TerminalView(frame: .zero, font: font)
+            view.lineSpacing = spacing
+            let cellHeight = view.cellDimension.height
+            let extra = cellHeight - natural
+            try #require(extra >= 1, "lineSpacing \(spacing) should add real height")
+
+            let offset = view.baselineOffset
+            // Space under the descender vs. over the ascender: the whole point
+            // of the change is that these are within a rounding step, instead
+            // of all of the slack sitting above the text.
+            let below = offset - CTFontGetDescent(font) - CTFontGetLeading(font)
+            let above = cellHeight - offset - CTFontGetAscent(font)
+            #expect(abs(above - below) <= 1,
+                    "lineSpacing \(spacing): \(below)pt below vs \(above)pt above")
+            #expect(offset > classicOffset(font))
+            #expect(offset < cellHeight - CTFontGetAscent(font) + 1)
+        }
+    }
+
+    /// The caret, the CoreGraphics path, and the Metal path all position text
+    /// from the frame's snapshot context. If that disagrees with the view the
+    /// glyph inside the block cursor sits on a different baseline than the row
+    /// it covers — the divergence this consolidation removes.
+    @Test func snapshotContextAgreesWithTheView() throws {
+        let font = try #require(NSFont(name: "Monaco", size: 13))
+        for spacing in [1.0, 1.3, 1.6] as [CGFloat] {
+            let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 300), font: font)
+            view.lineSpacing = spacing
+            #expect(CellGeometry.baselineOffset(normalFont: view.fontSet.normal,
+                                                cellHeight: view.cellDimension.height)
+                    == view.baselineOffset,
+                    "lineSpacing \(spacing): snapshot geometry diverged from the view")
+        }
+    }
+}
+#endif

--- a/Tests/SwiftTermTests/GlyphMetricsParityTests.swift
+++ b/Tests/SwiftTermTests/GlyphMetricsParityTests.swift
@@ -64,8 +64,8 @@ struct GlyphMetricsParityTests {
             metrics: metrics,
             columnWidth: columnWidth,
             cellDimension: cellDimension,
-            baselineFromBottom: ceil(CTFontGetDescent(normalFont) +
-                                     CTFontGetLeading(normalFont)),
+            baselineFromBottom: CellGeometry.baselineOffset(normalFont: normalFont,
+                                                            cellHeight: cellDimension.height),
             renderingScale: renderingScale)
     }
 


### PR DESCRIPTION
## What

When `lineSpacing > 1`, vertically center the glyph within the (now taller) cell, splitting the extra space above and below — instead of leaving it all above the text.

Rebased onto current `main` (`cb3c863`), after the `new-io` work landed. Single commit.

## Why

`lineSpacing` scales the cell height in `computeFontDimensions()`:

```swift
let cellHeight = ceil((lineAscent + lineDescent + lineLeading) * _lineSpacing)
```

but every renderer positioned the baseline with the un-scaled offset:

```swift
let yOffset = ceil(lineDescent + lineLeading)
```

Since the row is drawn from the bottom up, the glyph baseline stays pinned to the bottom of the cell and **all** the added spacing ends up above the text. At larger values (e.g. 1.4–1.6) the lines look bottom-heavy. Splitting the extra evenly matches how iTerm2 and WezTerm distribute their line spacing (and the CSS half-leading model).

## Change

One definition, `CellGeometry.baselineOffset`, that every path reads:

```swift
/// Text geometry derived from a cell's size. Not isolated to the main actor:
/// the snapshot renderers do this arithmetic on their own threads, from the
/// fonts and cell dimensions captured for the frame.
enum CellGeometry {
    static func baselineOffset (normalFont: CTFont, cellHeight: CGFloat) -> CGFloat
    {
        let descent = CTFontGetDescent (normalFont)
        let leading = CTFontGetLeading (normalFont)
        let naturalHeight = ceil (CTFontGetAscent (normalFont) + descent + leading)
        let extra = max (0, cellHeight - naturalHeight)
        return ceil (descent + leading) + floor (extra / 2)
    }
}
```

It is a plain non-isolated namespace rather than a `TerminalView` member because the snapshot renderers do this arithmetic off the main actor — hanging it on the (now `@MainActor`) view fails strict-concurrency checking with `sending 'normalFont' risks causing data races`. `SnapshotRenderContext.baselineOffset` and `TerminalView.baselineOffset` are thin accessors over it, so a frame's text, caret, and scaled glyphs are guaranteed to share one baseline.

Every place that computed its own `ceil(descent + leading)` now reads it. There were **eight**, up from four when this PR was first opened:

| site | |
|---|---|
| `drawTerminalContents` | via `SnapshotRenderContext.baselineOffset` |
| `CaretView.drawCursor` | so the glyph inside the caret stays on the row's baseline |
| `MetalTerminalRenderer.buildDrawDataPass` | |
| `MetalTerminalRenderer.buildCursorDrawData` | `lineDescent`/`lineLeading` parameters dropped — it already receives the `SnapshotRenderContext` they were derived from |
| `GlyphSlotFit.calculate` | its `baselineFromBottom` must agree with the draw-time offset or scaled wide glyphs stop being centered on it |
| `TerminalView.glyphSlotFit(font:glyph:columnWidth:policy:)` | new since the last revision |
| `quickLook`'s definition popover | new since the last revision; it anchors on the word's baseline, so its position was already wrong under `lineSpacing > 1` |
| `GlyphMetricsParityTests`' `scaledFit` helper | see below |

### On rounding

The classic `ceil(descent + leading)` term is kept intact and the glyph's share of the extra is added as a whole number of points on top, rather than rounding the sum (`ceil(descent + leading + extra/2)`, which is what the previous revision did).

Two reasons. It keeps the baseline on the same pixel grid the old offset landed on. And it makes `lineSpacing == 1` *exact* rather than approximate: `cellHeight` is snapped to the pixel grid, so on a fractional backing scale it can sit a point or two above the font's natural height even at the default, and rounding the sum would then quietly move the baseline for someone who never touched `lineSpacing`.

The parity test below is what caught this: with Menlo 16pt (natural line 19pt) and its synthetic 20pt cell, `extra` is exactly 1.0 and `ceil(3.77 + 0.5)` pushed the baseline up a full point.

### The test that had its own copy

`GlyphMetricsParityTests.scaledFit` hardcoded `ceil(CTFontGetDescent(normalFont) + CTFontGetLeading(normalFont))` as its `baselineFromBottom`, while the reference side called `GlyphSlotFit.calculate(font:...)`. Once the two disagreed the test failed by 41pt on the 100×100 synthetic cell. Both sides now derive the baseline from `CellGeometry`, which is what the test set out to compare in the first place — the scaled pixel-space path against the point-space reference, not two different baselines.

## Verification

`swift build` clean, **990 tests pass** (Xcode 26 / Swift 6.3, macOS).

New `CellBaselineTests` pins both halves of the invariant:

- **No regression at the default.** `baselineOffset` is equal to the old `ceil(descent + leading)` across eight font/size combinations (Monaco, Menlo, SF Mono, Courier; 10–24pt, including a fractional 13.5pt), and for any cell within two points of the natural line height.
- **Whole-point, bounded, monotonic.** Sweeping `extra` from 0 to 40pt in 0.5pt steps, the offset always lands on an integer point, never decreases, and never pushes the ascender out of the cell.
- **Actually centered.** At `lineSpacing` 1.2 / 1.4 / 1.6 / 2.0, the space under the descender and the space over the ascender agree to within one rounding step.
- **Renderers agree.** The snapshot geometry the Metal and CoreGraphics paths use matches the view's at 1.0 / 1.3 / 1.6 — the caret-vs-text divergence class from the first review, now asserted rather than eyeballed.

Also verified previously, and unchanged by the rebase: at `lineSpacing == 1.6` the caret-drawn glyph sits on the same baseline as the surrounding text, and DECDHL double-height rows join cleanly at 1.5 (both halves shift by the same pre-scale offset and the scale pivots sit on the shared row boundary).
