### PR TITLE
iOS: report taps as left-click (button 0) instead of middle-click (button 1)

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -657,7 +657,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     func encodeFlags (release: Bool) -> Int
     {
         let encodedFlags = terminal.encodeButton(
-            button: 1,
+            // Outpost patch: taps/drags are the primary (left) button. Upstream
+            // hard-codes 1 (middle), so every tap arrives as a middle-click —
+            // vim pastes, and left-click targets in TUIs never fire. 0 = left.
+            button: 0,
             release: release,
             shift: false,
             meta: false,


### PR DESCRIPTION
While building an iOS SSH client on SwiftTerm I hit a case where tapping in mouse-aware TUIs never triggered left-click actions — buttons did nothing, and in vim with `:set mouse=a` a tap *pasted* instead of moving the cursor.

It traces to `encodeFlags` in `iOSTerminalView`, which hard-codes the mouse button as `1` (middle) for every tap and drag, so the remote app always sees a middle-click. Switching it to `0` (left) makes a tap behave as a normal left-click, which is what apps expect. Drags run through the same encoder, so this fixes click-drag too.

Tested against htop, lazygit, and a ratatui-based app — clicking behaves correctly now.