### PR TITLE
Implements the request to not have the view autoscroll to the bottom …

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1919,11 +1919,10 @@ extension TerminalView {
     
     public func scroll (toPosition: Double)
     {
-        userScrolling = true
         let displayBuffer = terminal.displayBuffer
         let oldPosition = displayBuffer.yDisp
         
-        let maxScrollback = displayBuffer.lines.count - displayBuffer.rows
+        let maxScrollback = max(0, displayBuffer.lines.count - displayBuffer.rows)
         var newScrollPosition = Int (Double (maxScrollback) * toPosition)
         
         if newScrollPosition < 0 {
@@ -1935,25 +1934,48 @@ extension TerminalView {
 
         if newScrollPosition != oldPosition {
             scrollTo(row: newScrollPosition)
+        } else {
+            updateUserScrollingState(for: newScrollPosition, in: displayBuffer)
         }
-        userScrolling = false
+    }
+
+    private func updateUserScrollingState(for row: Int, in displayBuffer: Buffer) {
+        let maxScrollback = max(0, displayBuffer.lines.count - displayBuffer.rows)
+        let isUserScrolling = row < maxScrollback
+        userScrolling = isUserScrolling
+        terminal.userScrolling = isUserScrolling
     }
     
     public func scrollTo (row: Int, notifyAccessibility: Bool = true)
     {
         let displayBuffer = terminal.displayBuffer
-        if row != displayBuffer.yDisp {
-            terminal.setViewYDisp (row)
-            
+        let maxScrollback = max(0, displayBuffer.lines.count - displayBuffer.rows)
+        let targetRow = max(0, min(row, maxScrollback))
+#if os(iOS) || os(visionOS)
+        resetManualScrollOffsetWithinRow()
+#endif
+        updateUserScrollingState(for: targetRow, in: displayBuffer)
+
+        if targetRow != displayBuffer.yDisp {
+            terminal.setViewYDisp (targetRow)
+
             // tell the terminal we want to refresh all the rows
             terminal.refresh (startRow: 0, endRow: terminal.rows)
-            
+
             // do the display update
             updateDisplay (notifyAccessibility: notifyAccessibility)
             //selectionView.notifyScrolled(source: terminal)
             terminalDelegate?.scrolled (source: self, position: scrollPosition)
             updateScroller()
             setNeedsDisplay(frame)
+        } else {
+#if os(iOS) || os(visionOS)
+            // The row did not change, but we just cleared any sub-row manual
+            // scroll offset above; resync contentOffset so a later output-driven
+            // updateScroller does not snap the view up by that stale fractional
+            // amount.
+            updateScroller()
+#endif
         }
     }
     

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1344,6 +1344,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var lineLeading: CGFloat = 0
     
     open func bufferActivated(source: Terminal) {
+        resetManualScrollTracking()
         updateScroller ()
     }
     
@@ -1436,8 +1437,27 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         let displayBuffer = terminal.displayBuffer
         contentSize = CGSize (width: CGFloat (displayBuffer.cols) * cellDimension.width,
                               height: CGFloat (displayBuffer.lines.count) * cellDimension.height)
-        //contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
-        contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
+        // Let the gesture own contentOffset while the finger is physically down
+        // (isTracking), and while frozen history coasts under momentum —
+        // re-asserting it there fights the drag and blocks the user from reaching
+        // the bottom. But when following the bottom (userScrolling == false) we
+        // must keep pinning to the bottom even during deceleration: otherwise
+        // streaming output grows the content faster than the coasting offset, the
+        // tail pulls away, and the view falls behind the live output.
+        //
+        // NOTE: isTracking (finger down), not isDragging — on device isDragging
+        // stays true through the whole momentum coast, so it cannot distinguish
+        // an active drag from post-lift deceleration. contentSize is still
+        // updated above so the newly appended rows remain reachable.
+        if isTracking || (userScrolling && isDecelerating) {
+            return
+        }
+        let rowOffset = CGFloat (displayBuffer.yDisp) * cellDimension.height
+        let desiredY = userScrolling ? rowOffset + manualScrollOffsetWithinRow : rowOffset
+        // Clamp to the scroll view's real maximum so following the bottom rests
+        // flush against the last line instead of over-scrolling past it.
+        let offsetY = min(desiredY, maxContentOffsetY())
+        setContentOffsetFromTerminal(CGPoint (x: 0, y: offsetY))
         //Xscroller.doubleValue = scrollPosition
         //Xscroller.knobProportion = scrollThumbsize
     }
@@ -1462,6 +1482,106 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 #endif
     
     var userScrolling = false
+    private var updatingContentOffsetFromTerminal = false
+    private var manualScrollOffsetWithinRow: CGFloat = 0
+
+    private var contentOffsetTolerance: CGFloat {
+        1 / max(backingScaleFactor(), 1)
+    }
+
+    private func maxDisplayRow(in displayBuffer: Buffer) -> Int {
+        max(0, displayBuffer.lines.count - displayBuffer.rows)
+    }
+
+    /// The largest resting `contentOffset.y` the scroll view can actually reach.
+    /// This is smaller than `maxDisplayRow * cellHeight` by the partial-row
+    /// remainder whenever the viewport height is not an exact multiple of the
+    /// cell height, so it — not the row offset — is the true "bottom" of the
+    /// content for both follow-mode positioning and at-bottom detection. The
+    /// `adjustedContentInset.bottom` term matches UIScrollView's own clamp: with
+    /// a bottom inset (accessory view, safe area, keyboard) the resting maximum
+    /// shifts, and ignoring it left the user unable to ever reach the bottom to
+    /// disengage the freeze — even by overscrolling.
+    private func maxContentOffsetY() -> CGFloat {
+        max(0, contentSize.height - bounds.height + adjustedContentInset.bottom)
+    }
+
+    private func setContentOffsetFromTerminal(_ newContentOffset: CGPoint) {
+        if abs(contentOffset.x - newContentOffset.x) <= contentOffsetTolerance &&
+            abs(contentOffset.y - newContentOffset.y) <= contentOffsetTolerance {
+            return
+        }
+
+        updatingContentOffsetFromTerminal = true
+        contentOffset = newContentOffset
+        updatingContentOffsetFromTerminal = false
+    }
+
+    private func setManualScrolling(_ enabled: Bool) {
+        userScrolling = enabled
+        terminal.userScrolling = enabled
+        if !enabled {
+            manualScrollOffsetWithinRow = 0
+        }
+    }
+
+    func resetManualScrollOffsetWithinRow() {
+        manualScrollOffsetWithinRow = 0
+    }
+
+    private func resetManualScrollTracking() {
+        setManualScrolling(false)
+
+        let displayBuffer = terminal.displayBuffer
+        terminal.setViewYDisp(maxDisplayRow(in: displayBuffer))
+        let bottomOffset = min(CGFloat(displayBuffer.yDisp) * cellDimension.height, maxContentOffsetY())
+        setContentOffsetFromTerminal(CGPoint(x: 0, y: bottomOffset))
+    }
+
+    private func syncYDispFromContentOffset() {
+        guard terminal != nil, !updatingContentOffsetFromTerminal, cellDimension.height > 0 else {
+            return
+        }
+
+        let displayBuffer = terminal.displayBuffer
+        let maxRow = maxDisplayRow(in: displayBuffer)
+        let maxContentOffset = maxContentOffsetY()
+        let offsetY = min(max(contentOffset.y, 0), maxContentOffset)
+
+        // A drag that lands within half a row of the bottom (or overscrolls past
+        // it) re-engages auto-follow. A sub-pixel tolerance was too tight —
+        // fractional cell heights and contentInset rounding left the user a hair
+        // short of the exact maximum, so the freeze never disengaged.
+        let atBottomThreshold = max(contentOffsetTolerance, cellDimension.height / 2)
+        if offsetY >= maxContentOffset - atBottomThreshold {
+            if displayBuffer.yDisp != maxRow {
+                terminal.setViewYDisp(maxRow)
+            }
+            setManualScrolling(false)
+            return
+        }
+
+        // Freeze auto-follow only while the finger is physically down
+        // (isTracking). Excluding the momentum coast is essential: after the
+        // finger lifts, deceleration keeps firing sync while streaming output
+        // extends the content and the bottom recedes ahead of the coasting
+        // offset — treating that "not at the bottom yet" reading as a manual
+        // scroll would re-freeze a view the user just flung to the bottom. This
+        // must key off isTracking, not isDragging: on device isDragging stays
+        // true through the entire coast, so it fails to exclude momentum. It also
+        // covers layout/system-driven offset changes (startup sizing, rotation,
+        // keyboard insets, buffer shrink), which are never a manual scroll.
+        guard isTracking else {
+            return
+        }
+
+        let row = max(0, min(maxRow, Int(floor((offsetY + contentOffsetTolerance) / cellDimension.height))))
+        manualScrollOffsetWithinRow = offsetY - CGFloat(row) * cellDimension.height
+        if displayBuffer.yDisp != row {
+            terminal.setViewYDisp(row)
+        }
+        setManualScrolling(true)
+    }
 
     func getCurrentGraphicsContext () -> CGContext?
     {
@@ -1542,6 +1662,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 
     open override var contentOffset: CGPoint {
         didSet {
+            syncYDispFromContentOffset()
 #if canImport(MetalKit)
             if useMetalRenderer, metalView != nil {
                 requestMetalDisplay()
@@ -2181,7 +2302,13 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         // Suppress during sync blocks and inter-block gaps.
         guard !terminal.synchronizedOutputActive && !inSyncSequence else { return }
         let displayBuffer = terminal.displayBuffer
-        contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
+        let realCaret = displayBuffer.y + displayBuffer.yBase
+        let viewportEnd = displayBuffer.yDisp + displayBuffer.rows
+
+        if userScrolling || terminal.userScrolling || realCaret >= viewportEnd || realCaret < displayBuffer.yDisp {
+            resetManualScrollTracking()
+            updateScroller()
+        }
     }
     
     public func deleteBackward() {

--- a/TerminalApp/iOSTerminal.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TerminalApp/iOSTerminal.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,33 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "hdrhistogram-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift.git",
-      "state" : {
-        "revision" : "de0b9b8a27956b9bfc9b4dce7d1c38ad7c579f19",
-        "version" : "0.1.4"
-      }
-    },
-    {
-      "identity" : "package-benchmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-benchmark",
-      "state" : {
-        "revision" : "a1075611342d4b164bf6e977edb02a3db4434afd",
-        "version" : "1.29.11"
-      }
-    },
-    {
-      "identity" : "package-jemalloc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-jemalloc.git",
-      "state" : {
-        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
@@ -109,30 +82,12 @@
       }
     },
     {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "texttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/TextTable.git",
-      "state" : {
-        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
-        "version" : "0.0.2"
       }
     }
   ],

--- a/Tests/SwiftTermTests/SelectionTests.swift
+++ b/Tests/SwiftTermTests/SelectionTests.swift
@@ -77,6 +77,25 @@ final class SelectionTests: TerminalDelegate {
         #expect(view.calculateMouseHit(at: CGPoint(x: 0, y: 10)).grid.row == 1)
     }
 
+    @Test func testScrollToMarksTerminalAsUserScrolling() {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 400, height: 100)))
+
+        for i in 0..<30 {
+            view.terminal.feed(text: "line \(i)\r\n")
+        }
+
+        let bottom = view.terminal.displayBuffer.yDisp
+        let target = max(0, bottom - 3)
+        view.scrollTo(row: target)
+
+        #expect(view.terminal.userScrolling)
+        view.terminal.feed(text: "incoming\r\n")
+        #expect(view.terminal.displayBuffer.yDisp == target)
+
+        view.scrollTo(row: view.terminal.displayBuffer.yBase)
+        #expect(!view.terminal.userScrolling)
+    }
+
     @Test func testZeroSizedResizeDoesNotChangeTerminalDimensions() {
         let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 320, height: 160)))
         let originalCols = view.terminal.cols


### PR DESCRIPTION
…of the screen on output if the user drags the view up.

The fix is to make iOS scrolling use the terminal model’s existing viewport state instead of forcing the UIKit scroll view to the bottom on every output update.

Previously, iOSTerminalView.updateScroller() always did:

  contentOffset.y = (displayBuffer.lines.count - displayBuffer.rows) * cellHeight

So any incoming data snapped the view back to the bottom, even if the user had scrolled up.

The new behavior keeps two things synchronized:

  - UIScrollView.contentOffset.y
  - terminal.displayBuffer.yDisp

When the user scrolls, the view computes the top visible terminal row from contentOffset.y.  While new output arrives, Terminal.scroll() sees terminal.userScrolling == true and does not advance yDisp to the bottom. The visible text stays stable.

The iOS view now also derives its contentOffset from displayBuffer.yDisp during scroller updates, instead of deriving it from “bottom of buffer” unconditionally. A fractional intra-row offset is preserved so tiny scroll movements still count; the user does not need to scroll a full row before the freeze behavior starts.

Important details:

- It uses panGestureRecognizer.addTarget(...), not UIScrollView.delegate, so embedders do not lose delegate semantics.

- Manual scrolling is cleared when the view reaches the bottom again.

- Manual scrolling is also cleared on buffer switches, so alternate-screen transitions snap to the right place.

- Keyboard input calls ensureCaretIsVisible(), which clears manual scrolling and returns to the active prompt/output.

- Shared scrollTo(row:) now updates terminal.userScrolling, so PageUp/PageDown and programmatic scrolling behave consistently with touch scrolling.

In short: iOS now treats yDisp as the source of truth for the terminal
  viewport, and contentOffset as the UIKit representation of that
  viewport. Incoming output no longer overwrites the user’s scroll
  position unless the user returns to the bottom or sends keyboard
  input.