### PR TITLE
Bidirectional text (Arabic/Hebrew) rendering: UAX #9 reordering, Arabic shaping, terminal-wg escapes

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -66,9 +66,21 @@ struct ViewLineSegment {
     let columnWidth: Int
     let characterCount: Int
     let attributedString: NSAttributedString
-    
+    /// Maps every UTF-16 unit of attributedString to the ordinal of the cell
+    /// it belongs to, so glyphs can be positioned by cell (combining marks
+    /// share their base's cell instead of shifting the column grid).
+    let utf16ToCellOrdinal: [Int]
+
     var columnSpan: Int {
         return max(0, characterCount * columnWidth)
+    }
+
+    @inline(__always)
+    func cellOrdinal(forUTF16 index: Int) -> Int {
+        if index >= 0 && index < utf16ToCellOrdinal.count {
+            return utf16ToCellOrdinal[index]
+        }
+        return max(0, utf16ToCellOrdinal.last ?? 0)
     }
 }
 
@@ -109,6 +121,26 @@ struct GlyphSlotFit {
 }
 
 extension TerminalView {
+
+    /// The paragraph direction actually used for rendering: the
+    /// user-selected `bidiParagraphDirection` unless it is `.auto`, in which
+    /// case the escape-driven terminal-wg state applies — BDSM explicit mode
+    /// (`CSI 8 l`) turns BiDi off, autodetection (`DECSET 2501`) selects
+    /// per-row detection, and otherwise the SPD direction (`CSI Ps SP S`)
+    /// forces LTR or RTL paragraphs.
+    public var effectiveBidiDirection: BidiParagraphDirection {
+        if bidiParagraphDirection != .auto {
+            return bidiParagraphDirection
+        }
+        if !terminal.bidiSupportEnabled {
+            return .off
+        }
+        if terminal.bidiAutodetectDirection {
+            return .auto
+        }
+        return terminal.bidiRTLPreference ? .rightToLeft : .leftToRight
+    }
+
     typealias CellDimension = CGSize
 
 #if os(macOS)
@@ -658,6 +690,8 @@ extension TerminalView {
         let columnWidth: Int
         private var attributedString = NSMutableAttributedString()
         private var characterCount: Int = 0
+        private var utf16ToCellOrdinal: [Int] = []
+        private var cellCount: Int = 0
         
         init(column: Int, columnWidth: Int) {
             self.column = column
@@ -668,16 +702,25 @@ extension TerminalView {
             characterCount == 0
         }
         
-        mutating func append(text: String, attributes: [NSAttributedString.Key: Any]) {
+        /// Appends a batch of text; `cellUTF16Lengths` holds one entry per
+        /// terminal cell in the batch (its text length in UTF-16 units).
+        mutating func append(text: String, attributes: [NSAttributedString.Key: Any],
+                             cellUTF16Lengths: [Int]) {
             attributedString.append(NSAttributedString(string: text, attributes: attributes))
             characterCount += 1
+            for length in cellUTF16Lengths {
+                for _ in 0..<max(1, length) {
+                    utf16ToCellOrdinal.append(cellCount)
+                }
+                cellCount += 1
+            }
         }
         
         func buildIfNeeded() -> ViewLineSegment? {
             guard !isEmpty else {
                 return nil
             }
-            return ViewLineSegment(column: column, columnWidth: columnWidth, characterCount: characterCount, attributedString: attributedString)
+            return ViewLineSegment(column: column, columnWidth: columnWidth, characterCount: characterCount, attributedString: attributedString, utf16ToCellOrdinal: utf16ToCellOrdinal)
         }
     }
     
@@ -690,6 +733,33 @@ extension TerminalView {
         let selectionColumns = selectedColumnsRange(row: row, cols: cols)
         var col = 0
         var builder: ViewLineSegmentBuilder?
+
+        // BiDi: rows containing RTL content are walked in visual order with
+        // per-cell display substitutions (shaped Arabic forms, mirrored
+        // brackets); the layout is nil for plain LTR rows, which use the
+        // logical path below unchanged. Soft-wrapped lines pass their edge
+        // characters as joining context so shaping survives the wrap seam.
+        var precedingScalar: UInt32? = nil
+        var followingScalar: UInt32? = nil
+        let bidiDirection = effectiveBidiDirection
+        if bidiDirection != .off {
+            let lines = terminal.displayBuffer.lines
+            if line.isWrapped, row > 0, row - 1 < lines.count {
+                precedingScalar = TerminalBidi.trailingScalar(of: lines[row - 1], cols: cols,
+                                                              terminal: terminal)
+            }
+            if row + 1 < lines.count, lines[row + 1].isWrapped {
+                followingScalar = TerminalBidi.leadingScalar(of: lines[row + 1], cols: cols,
+                                                             terminal: terminal)
+            }
+        }
+        let bidiLayout = TerminalBidi.layout(line: line, cols: cols, terminal: terminal,
+                                             direction: bidiDirection, font: fontSet.normal,
+                                             precedingScalar: precedingScalar,
+                                             followingScalar: followingScalar)
+        let bidiWritingDirectionKey = NSAttributedString.Key(kCTWritingDirectionAttributeName as String)
+        var visualCol = 0
+        var visualIndex = 0
         var kittyPlaceholders: [KittyPlaceholderCell] = []
         var previousPlaceholder: KittyPlaceholderCell?
         var previousPlaceholderAttribute: Attribute?
@@ -698,6 +768,7 @@ extension TerminalView {
         
         // Batching state: accumulate consecutive characters with the same attributes
         var pendingText = ""
+        var pendingCellLengths: [Int] = []
         var pendingAttrs: [NSAttributedString.Key: Any]? = nil
         var lastAttr: Attribute? = nil
         var lastHasUrl = false
@@ -705,12 +776,24 @@ extension TerminalView {
 
         func flushPending() {
             if !pendingText.isEmpty, let attrs = pendingAttrs {
-                builder?.append(text: pendingText, attributes: attrs)
+                builder?.append(text: pendingText, attributes: attrs,
+                                cellUTF16Lengths: pendingCellLengths)
                 pendingText = ""
+                pendingCellLengths = []
             }
         }
 
-        while col < cols {
+        while true {
+            var displayOverride: Character? = nil
+            if let bidiLayout {
+                guard visualIndex < bidiLayout.visualCells.count else { break }
+                let visualCell = bidiLayout.visualCells[visualIndex]
+                visualIndex += 1
+                col = visualCell.logicalCol
+                displayOverride = visualCell.display
+            } else if col >= cols {
+                break
+            }
             let ch: CharData = line[col]
             let width = max(1, Int(ch.width))
             let attr = ch.attribute
@@ -723,7 +806,10 @@ extension TerminalView {
                 builder = nil
                 previousPlaceholder = nil
                 previousPlaceholderAttribute = nil
-                col += width
+                if bidiLayout == nil {
+                    col += width
+                }
+                visualCol += width
                 continue
             }
 
@@ -732,7 +818,7 @@ extension TerminalView {
                 if let finished = builder?.buildIfNeeded() {
                     segments.append(finished)
                 }
-                builder = ViewLineSegmentBuilder(column: col, columnWidth: width)
+                builder = ViewLineSegmentBuilder(column: visualCol, columnWidth: width)
             }
 
             let isSelected = isColumnSelected(selectionColumns, column: col, width: width)
@@ -745,7 +831,7 @@ extension TerminalView {
                 lastIsSelected = isSelected
             }
 
-            let currentAttributes: [NSAttributedString.Key: Any]
+            var currentAttributes = attributes
             if isSelected {
                 var mutable = attributes
                 mutable[.selectionBackgroundColor] = selectedTextBackgroundColor
@@ -760,9 +846,16 @@ extension TerminalView {
             } else {
                 currentAttributes = attributes
             }
+            if bidiLayout != nil {
+                // The cell sequence is already in visual order and contextually
+                // shaped; force an LTR-override run (embedding 0 | override 2)
+                // so CoreText neither reorders nor re-shapes it, keeping the
+                // one-glyph-per-cell mapping the renderer relies on.
+                currentAttributes[bidiWritingDirectionKey] = [NSNumber(value: 2)]
+            }
             pendingAttrs = currentAttributes
 
-            let character = ch.code == 0 ? " " : terminal.getCharacter(for: ch)
+            let character: Character = displayOverride ?? (ch.code == 0 ? " " : terminal.getCharacter(for: ch))
 
             // Renders box drawing characters independently of the font
             // U+2500...U+257F
@@ -771,11 +864,11 @@ extension TerminalView {
                ch.code <= BoxDrawingRenderer.upperBoundary {
                 flushPending()
                 let fgColor = (currentAttributes[.foregroundColor] as? TTColor) ?? nativeForegroundColor
-                boxDrawings.append(BoxDrawingRenderItem(column: col,
+                boxDrawings.append(BoxDrawingRenderItem(column: visualCol,
                                                         columnWidth: width,
                                                         codePoint: UInt32(ch.code),
                                                         foregroundColor: fgColor))
-                builder?.append(text: " ", attributes: currentAttributes)
+                builder?.append(text: " ", attributes: currentAttributes, cellUTF16Lengths: [1])
                 previousPlaceholder = nil
                 previousPlaceholderAttribute = nil
             // Renders block elements independently of the font
@@ -785,38 +878,62 @@ extension TerminalView {
                       let rects = BlockElementMapping.rects(for: UInt32(ch.code)) {
                 flushPending()
                 let fgColor = (currentAttributes[.foregroundColor] as? TTColor) ?? nativeForegroundColor
-                blockElements.append(BlockElementRenderItem(column: col,
+                blockElements.append(BlockElementRenderItem(column: visualCol,
                                                             columnWidth: width,
                                                             codePoint: UInt32(ch.code),
                                                             rects: rects,
                                                             foregroundColor: fgColor))
-                builder?.append(text: " ", attributes: currentAttributes)
+                builder?.append(text: " ", attributes: currentAttributes, cellUTF16Lengths: [1])
                 previousPlaceholder = nil
                 previousPlaceholderAttribute = nil
             } else if let placeholder = KittyPlaceholderDecoder.decode(character: character,
                                                                        attribute: attr,
                                                                        row: row,
-                                                                       col: col,
+                                                                       col: visualCol,
                                                                        previous: previousPlaceholder,
                                                                        previousAttribute: previousPlaceholderAttribute) {
                 flushPending()
                 kittyPlaceholders.append(placeholder)
-                builder?.append(text: " ", attributes: currentAttributes)
+                builder?.append(text: " ", attributes: currentAttributes, cellUTF16Lengths: [1])
                 previousPlaceholder = placeholder
                 previousPlaceholderAttribute = attr
+            } else if bidiLayout != nil && TerminalBidi.needsCellIsolation(character) {
+                // In BiDi rows, Arabic-script cells and cells holding combining
+                // sequences or emoji are isolated into their own column-anchored
+                // segment so that font-side ligation or extra mark glyphs cannot
+                // shift the columns of the cells that follow them.
+                flushPending()
+                if let finished = builder?.buildIfNeeded() {
+                    segments.append(finished)
+                }
+                builder = ViewLineSegmentBuilder(column: visualCol, columnWidth: width)
+                builder?.append(text: String(character), attributes: currentAttributes,
+                                cellUTF16Lengths: [character.utf16.count])
+                if let finished = builder?.buildIfNeeded() {
+                    segments.append(finished)
+                }
+                builder = nil
+                previousPlaceholder = nil
+                previousPlaceholderAttribute = nil
             } else {
                 // Common path: just accumulate into the batch
                 pendingText.append(character)
+                var cellUTF16Length = character.utf16.count
                 if UnicodeUtil.prefersTextPresentation(character) {
                     // Steer font fallback away from Apple Color Emoji for
                     // default-text-presentation symbols (see prefersTextPresentation).
                     pendingText.append("\u{FE0E}")
+                    cellUTF16Length += 1
                 }
+                pendingCellLengths.append(cellUTF16Length)
                 previousPlaceholder = nil
                 previousPlaceholderAttribute = nil
             }
 
-            col += width
+            if bidiLayout == nil {
+                col += width
+            }
+            visualCol += width
         }
         flushPending()
         
@@ -1409,15 +1526,25 @@ extension TerminalView {
             context.setLineWidth(0)
 
             for prepared in preparedSegments {
-                var processedGlyphs = 0
                 for run in prepared.runs {
                     let runGlyphsCount = CTRunGetGlyphCount(run)
                     if runGlyphsCount == 0 {
                         continue
                     }
                     let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
-                    let startColumn = prepared.segment.column + (processedGlyphs * prepared.segment.columnWidth)
-                    let endColumn = startColumn + (runGlyphsCount * prepared.segment.columnWidth)
+                    // Span the columns of the cells this run's characters came
+                    // from: combining marks add glyphs but not columns.
+                    var runIndices = [CFIndex](repeating: 0, count: runGlyphsCount)
+                    CTRunGetStringIndices(run, CFRange(), &runIndices)
+                    var minOrdinal = Int.max
+                    var maxOrdinal = Int.min
+                    for index in runIndices {
+                        let ordinal = prepared.segment.cellOrdinal(forUTF16: index)
+                        minOrdinal = min(minOrdinal, ordinal)
+                        maxOrdinal = max(maxOrdinal, ordinal)
+                    }
+                    let startColumn = prepared.segment.column + (minOrdinal * prepared.segment.columnWidth)
+                    let endColumn = prepared.segment.column + ((maxOrdinal + 1) * prepared.segment.columnWidth)
                     var backgroundColor: TTColor?
                     if runAttributes.keys.contains(.selectionBackgroundColor) {
                         backgroundColor = runAttributes[.selectionBackgroundColor] as? TTColor
@@ -1471,7 +1598,6 @@ extension TerminalView {
                             #endif
                         }
                     }
-                    processedGlyphs += runGlyphsCount
                 }
             }
 
@@ -1508,7 +1634,6 @@ extension TerminalView {
 
             // Glyph drawing loop — reuses cached CTLines
             for prepared in preparedSegments {
-                var processedGlyphs = 0
                 for run in prepared.runs {
                     let runGlyphsCount = CTRunGetGlyphCount(run)
                     if runGlyphsCount == 0 {
@@ -1516,7 +1641,6 @@ extension TerminalView {
                     }
                     let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
                     let runFont = runAttributes[.font] as! TTFont
-                    let startColumn = prepared.segment.column + (processedGlyphs * prepared.segment.columnWidth)
 
                     let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
                         CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
@@ -1525,13 +1649,26 @@ extension TerminalView {
 
                     var coreTextPositions = [CGPoint](repeating: .zero, count: runGlyphsCount)
                     CTRunGetPositions(run, CFRange(), &coreTextPositions)
+                    var runIndices = [CFIndex](repeating: 0, count: runGlyphsCount)
+                    CTRunGetStringIndices(run, CFRange(), &runIndices)
 
+                    // Position each glyph at its source cell's column; glyphs
+                    // sharing a cell (base + combining marks) keep their
+                    // CoreText offsets relative to the cluster's first glyph,
+                    // so marks overlay the base instead of shifting columns.
+                    var clusterAnchors: [Int: CGFloat] = [:]
                     var positions = [CGPoint](repeating: .zero, count: runGlyphsCount)
                     for i in 0..<runGlyphsCount {
                         let ctPosition = coreTextPositions[i]
-                        let glyphColumn = startColumn + (i * prepared.segment.columnWidth)
+                        let ordinal = prepared.segment.cellOrdinal(forUTF16: runIndices[i])
+                        let anchor = clusterAnchors[ordinal]
+                        let intraCluster = anchor.map { ctPosition.x - $0 } ?? 0
+                        if anchor == nil {
+                            clusterAnchors[ordinal] = ctPosition.x
+                        }
+                        let glyphColumn = prepared.segment.column + (ordinal * prepared.segment.columnWidth)
                         positions[i] = CGPoint(
-                            x: lineOrigin.x + CGFloat(glyphColumn) * cellDimension.width,
+                            x: lineOrigin.x + CGFloat(glyphColumn) * cellDimension.width + intraCluster,
                             y: lineOrigin.y + yOffset + ctPosition.y)
                     }
 
@@ -1580,8 +1717,6 @@ extension TerminalView {
 
                     // Draw other attributes (decorations stay grid-aligned)
                     drawRunAttributes(runAttributes, glyphPositions: positions, in: context)
-
-                    processedGlyphs += runGlyphsCount
                 }
             }
 
@@ -1889,7 +2024,18 @@ extension TerminalView {
         // Span the caret across the full character so a block cursor covers a
         // full-width (CJK) glyph instead of only its left half.
         let cursorColumnWidth = max(1, Int(charUnderCursor.width))
-        caretView.frame.origin = CGPoint(x: lineOrigin.x + (cellDimension.width * doublePosition * CGFloat(buffer.x)), y: lineOrigin.y)
+        // In BiDi rows the caret is drawn at the visual column of the logical
+        // cursor position.
+        var caretCol = buffer.x
+        if effectiveBidiDirection != .off, vy >= 0, vy < buffer.lines.count,
+           let bidiLayout = TerminalBidi.layout(line: buffer.lines[vy], cols: terminal.cols,
+                                                terminal: terminal,
+                                                direction: effectiveBidiDirection,
+                                                font: fontSet.normal),
+           caretCol >= 0, caretCol < bidiLayout.logicalToVisualCol.count {
+            caretCol = bidiLayout.logicalToVisualCol[caretCol]
+        }
+        caretView.frame.origin = CGPoint(x: lineOrigin.x + (cellDimension.width * doublePosition * CGFloat(caretCol)), y: lineOrigin.y)
         caretView.frame.size.width = cellDimension.width * doublePosition * CGFloat(cursorColumnWidth)
         caretView.setText (ch: charUnderCursor)
     }

--- a/Sources/SwiftTerm/Apple/TerminalBidi.swift
+++ b/Sources/SwiftTerm/Apple/TerminalBidi.swift
@@ -1,0 +1,565 @@
+//
+//  TerminalBidi.swift
+//  SwiftTerm
+//
+//  Cell-level bidirectional text support (Arabic/Hebrew) for the terminal view,
+//  following the "implicit BiDi" model recommended by the terminal-wg BiDi
+//  specification (the model used by mlterm): the buffer stays in logical order,
+//  and at render time each row is given a visual permutation of its cells plus
+//  per-cell display substitutions (Arabic contextual forms, mirrored brackets).
+//
+//  Ordering is delegated to CoreText's UAX #9 implementation: a "probe" line is
+//  built with exactly one UTF-16 unit per cell, where Arabic letters are replaced
+//  by U+0621 (non-joining, Bidi_Class AL) so that no ligatures or contextual
+//  shaping can merge glyphs, guaranteeing a 1:1 glyph-to-cell mapping. The visual
+//  order of cells is then recovered from the glyph positions of the CTLine.
+//
+#if os(macOS) || os(iOS) || os(visionOS) || os(macCatalyst)
+import Foundation
+import CoreText
+import CoreGraphics
+
+/// Controls how the terminal determines the paragraph direction of each row
+/// when rendering bidirectional text (Arabic, Hebrew).
+public enum BidiParagraphDirection {
+    /// BiDi processing disabled: cells are rendered strictly left-to-right
+    /// in logical order (legacy terminal behavior).
+    case off
+    /// The direction of each row is detected from its first strong
+    /// directional character (UAX #9 rules P2/P3). Rows with no strong
+    /// character are treated as left-to-right.
+    case auto
+    /// Every row is treated as a left-to-right paragraph.
+    case leftToRight
+    /// Every row is treated as a right-to-left paragraph: RTL text hugs the
+    /// right edge and neutrals flow right-to-left.
+    case rightToLeft
+}
+
+/// A cell in visual order, produced by `TerminalBidi.layout`.
+struct BidiCell {
+    /// The buffer (logical) column this cell came from.
+    let logicalCol: Int
+    /// Number of columns the cell occupies.
+    let width: Int
+    /// When non-nil, render this instead of the buffer character
+    /// (contextually shaped Arabic form, lam-alef ligature, or mirrored bracket).
+    let display: Character?
+}
+
+/// The visual layout of one terminal row after BiDi processing.
+struct BidiRowLayout {
+    /// Cells in visual (left-to-right screen) order.
+    let visualCells: [BidiCell]
+    /// Maps a logical column to the visual column where it is displayed.
+    let logicalToVisualCol: [Int]
+    /// Maps a visual column back to the logical buffer column.
+    let visualToLogicalCol: [Int]
+}
+
+enum TerminalBidi {
+
+    // MARK: - Row scanning
+
+    /// Fast check: does this scalar require BiDi processing?
+    /// Covers Hebrew through Arabic Extended-A contiguously, the presentation
+    /// form blocks, and the RTL directional formatting characters.
+    @inline(__always)
+    static func isRTLTrigger(_ v: UInt32) -> Bool {
+        if v < 0x0590 { return false }
+        switch v {
+        case 0x0590...0x08FF,           // Hebrew ... Arabic Extended-A
+             0xFB1D...0xFDFF,           // Hebrew/Arabic presentation forms A
+             0xFE70...0xFEFC,           // Arabic presentation forms B
+             0x200F, 0x202B, 0x202E,    // RLM, RLE, RLO
+             0x2067:                    // RLI
+            return true
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Arabic joining classification (subset of ArabicShaping.txt)
+
+    enum Joining {
+        case none         // U: non-joining
+        case transparent  // T: combining marks, skipped when finding neighbors
+        case causing      // C: tatweel, ZWJ
+        case right        // R: joins only with the preceding letter
+        case dual         // D: joins on both sides
+    }
+
+    static func joining(of v: UInt32) -> Joining {
+        switch v {
+        case 0x0640, 0x200D:
+            return .causing
+        case 0x0610...0x061A, 0x064B...0x065F, 0x0670,
+             0x06D6...0x06DC, 0x06DF...0x06E4, 0x06E7, 0x06E8,
+             0x06EA...0x06ED, 0x08D3...0x08FF:
+            return .transparent
+        case 0x0622, 0x0623, 0x0624, 0x0625, 0x0627, 0x0629,
+             0x062F, 0x0630, 0x0631, 0x0632, 0x0648, 0x0649,
+             0x0671,                                  // alef wasla
+             0x0688, 0x0691, 0x0698, 0x06BA, 0x06D2, 0x06D5: // ڈ ڑ ژ ں ے ە
+            return .right
+        case 0x0626, 0x0628, 0x062A...0x062E, 0x0633...0x063A,
+             0x0641...0x0647, 0x064A,
+             0x0679, 0x067E, 0x0686, 0x06A9, 0x06AF, 0x06BE, 0x06CC: // ٹ پ چ ک گ ھ ی
+            return .dual
+        default:
+            return .none
+        }
+    }
+
+    /// Contextual presentation forms: base scalar -> (isolated, final, initial, medial).
+    /// Initial/medial are nil for right-joining letters.
+    /// Standard Arabic uses Presentation Forms-B (U+FE70...U+FEFC); the common
+    /// Persian/Urdu letters use Presentation Forms-A.
+    static let forms: [UInt32: (iso: UInt32, fin: UInt32, ini: UInt32?, med: UInt32?)] = [
+        0x0621: (0xFE80, 0xFE80, nil, nil),          // ء
+        0x0622: (0xFE81, 0xFE82, nil, nil),          // آ
+        0x0623: (0xFE83, 0xFE84, nil, nil),          // أ
+        0x0624: (0xFE85, 0xFE86, nil, nil),          // ؤ
+        0x0625: (0xFE87, 0xFE88, nil, nil),          // إ
+        0x0626: (0xFE89, 0xFE8A, 0xFE8B, 0xFE8C),    // ئ
+        0x0627: (0xFE8D, 0xFE8E, nil, nil),          // ا
+        0x0628: (0xFE8F, 0xFE90, 0xFE91, 0xFE92),    // ب
+        0x0629: (0xFE93, 0xFE94, nil, nil),          // ة
+        0x062A: (0xFE95, 0xFE96, 0xFE97, 0xFE98),    // ت
+        0x062B: (0xFE99, 0xFE9A, 0xFE9B, 0xFE9C),    // ث
+        0x062C: (0xFE9D, 0xFE9E, 0xFE9F, 0xFEA0),    // ج
+        0x062D: (0xFEA1, 0xFEA2, 0xFEA3, 0xFEA4),    // ح
+        0x062E: (0xFEA5, 0xFEA6, 0xFEA7, 0xFEA8),    // خ
+        0x062F: (0xFEA9, 0xFEAA, nil, nil),          // د
+        0x0630: (0xFEAB, 0xFEAC, nil, nil),          // ذ
+        0x0631: (0xFEAD, 0xFEAE, nil, nil),          // ر
+        0x0632: (0xFEAF, 0xFEB0, nil, nil),          // ز
+        0x0633: (0xFEB1, 0xFEB2, 0xFEB3, 0xFEB4),    // س
+        0x0634: (0xFEB5, 0xFEB6, 0xFEB7, 0xFEB8),    // ش
+        0x0635: (0xFEB9, 0xFEBA, 0xFEBB, 0xFEBC),    // ص
+        0x0636: (0xFEBD, 0xFEBE, 0xFEBF, 0xFEC0),    // ض
+        0x0637: (0xFEC1, 0xFEC2, 0xFEC3, 0xFEC4),    // ط
+        0x0638: (0xFEC5, 0xFEC6, 0xFEC7, 0xFEC8),    // ظ
+        0x0639: (0xFEC9, 0xFECA, 0xFECB, 0xFECC),    // ع
+        0x063A: (0xFECD, 0xFECE, 0xFECF, 0xFED0),    // غ
+        0x0641: (0xFED1, 0xFED2, 0xFED3, 0xFED4),    // ف
+        0x0642: (0xFED5, 0xFED6, 0xFED7, 0xFED8),    // ق
+        0x0643: (0xFED9, 0xFEDA, 0xFEDB, 0xFEDC),    // ك
+        0x0644: (0xFEDD, 0xFEDE, 0xFEDF, 0xFEE0),    // ل
+        0x0645: (0xFEE1, 0xFEE2, 0xFEE3, 0xFEE4),    // م
+        0x0646: (0xFEE5, 0xFEE6, 0xFEE7, 0xFEE8),    // ن
+        0x0647: (0xFEE9, 0xFEEA, 0xFEEB, 0xFEEC),    // ه
+        0x0648: (0xFEED, 0xFEEE, nil, nil),          // و
+        0x0649: (0xFEEF, 0xFEF0, nil, nil),          // ى
+        0x064A: (0xFEF1, 0xFEF2, 0xFEF3, 0xFEF4),    // ي
+        // Persian / Urdu (Presentation Forms-A)
+        0x0679: (0xFB66, 0xFB67, 0xFB68, 0xFB69),    // ٹ
+        0x067E: (0xFB56, 0xFB57, 0xFB58, 0xFB59),    // پ
+        0x0686: (0xFB7A, 0xFB7B, 0xFB7C, 0xFB7D),    // چ
+        0x0688: (0xFB88, 0xFB89, nil, nil),          // ڈ
+        0x0691: (0xFB8C, 0xFB8D, nil, nil),          // ڑ
+        0x0698: (0xFB8A, 0xFB8B, nil, nil),          // ژ
+        0x06A9: (0xFB8E, 0xFB8F, 0xFB90, 0xFB91),    // ک
+        0x06AF: (0xFB92, 0xFB93, 0xFB94, 0xFB95),    // گ
+        0x06BA: (0xFB9E, 0xFB9F, nil, nil),          // ں
+        0x06BE: (0xFBAA, 0xFBAB, 0xFBAC, 0xFBAD),    // ھ
+        0x06CC: (0xFBFC, 0xFBFD, 0xFBFE, 0xFBFF),    // ی
+        0x06D2: (0xFBAE, 0xFBAF, nil, nil),          // ے
+    ]
+
+    /// Lam-alef ligatures: alef variant -> (isolated, final) ligature form.
+    static let lamAlef: [UInt32: (iso: UInt32, fin: UInt32)] = [
+        0x0622: (0xFEF5, 0xFEF6),   // لآ
+        0x0623: (0xFEF7, 0xFEF8),   // لأ
+        0x0625: (0xFEF9, 0xFEFA),   // لإ
+        0x0627: (0xFEFB, 0xFEFC),   // لا
+    ]
+
+    /// Common mirrored pairs (UAX #9 rule L4) applied to cells resolved RTL.
+    static let mirror: [Character: Character] = [
+        "(": ")", ")": "(", "[": "]", "]": "[", "{": "}", "}": "{",
+        "<": ">", ">": "<", "«": "»", "»": "«", "‹": "›", "›": "‹",
+        "⟨": "⟩", "⟩": "⟨", "≤": "≥", "≥": "≤",
+    ]
+
+    /// Horizontally asymmetric box drawing characters, mirrored on RTL-level
+    /// cells when DECSET 2500 (terminal-wg box mirroring) is active.
+    static let boxMirror: [Character: Character] = [
+        "┌": "┐", "┐": "┌", "└": "┘", "┘": "└", "├": "┤", "┤": "├",
+        "┏": "┓", "┓": "┏", "┗": "┛", "┛": "┗", "┣": "┫", "┫": "┣",
+        "╔": "╗", "╗": "╔", "╚": "╝", "╝": "╚", "╠": "╣", "╣": "╠",
+        "╭": "╮", "╮": "╭", "╰": "╯", "╯": "╰",
+        "╒": "╕", "╕": "╒", "╘": "╛", "╛": "╘", "╓": "╖", "╖": "╓",
+        "╙": "╜", "╜": "╙", "╞": "╡", "╡": "╞", "╟": "╢", "╢": "╟",
+        "╴": "╶", "╶": "╴", "╸": "╺", "╺": "╸",
+    ]
+
+    /// True for cells that must be rendered as their own column-anchored
+    /// segment in BiDi rows: Arabic-script cells (a font may apply required
+    /// ligatures across adjacent presentation forms — e.g. compressing الله —
+    /// merging glyphs and shifting the column mapping of the rest of the
+    /// segment) and any multi-scalar cell (combining marks, emoji).
+    @inline(__always)
+    static func needsCellIsolation(_ text: Character) -> Bool {
+        if text.unicodeScalars.count > 1 { return true }
+        guard let v = text.unicodeScalars.first?.value else { return false }
+        switch v {
+        case 0x0600...0x06FF, 0x0750...0x077F, 0x08A0...0x08FF,
+             0xFB50...0xFDFF, 0xFE70...0xFEFC:
+            return true
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Cell extraction
+
+    struct Cell {
+        let logicalCol: Int
+        let width: Int
+        let text: Character
+    }
+
+    /// Extracts the renderable cells of a row (skipping wide-character
+    /// continuation columns), noting whether any cell contains a character
+    /// that triggers BiDi processing.
+    static func extractCells(line: BufferLine, cols: Int, terminal: Terminal) -> (cells: [Cell], hasRTL: Bool) {
+        var cells: [Cell] = []
+        cells.reserveCapacity(cols)
+        var hasRTL = false
+        var col = 0
+        let count = min(cols, line.count)
+        while col < count {
+            let ch = line[col]
+            let width = max(1, Int(ch.width))
+            let character: Character = ch.code == 0 ? " " : terminal.getCharacter(for: ch)
+            if !hasRTL {
+                for scalar in character.unicodeScalars where isRTLTrigger(scalar.value) {
+                    hasRTL = true
+                    break
+                }
+            }
+            cells.append(Cell(logicalCol: col, width: width, text: character))
+            col += width
+        }
+        return (cells, hasRTL)
+    }
+
+    // MARK: - Visual ordering via CoreText (UAX #9)
+
+    /// True for scalars that can shape or ligate under Arabic script rules and
+    /// must therefore be substituted in the probe line.
+    @inline(__always)
+    static func isJoiningCapable(_ v: UInt32) -> Bool {
+        switch v {
+        case 0x0620...0x064A, 0x066E...0x066F, 0x0671...0x06D5,
+             0x06EE, 0x06EF, 0x06FA...0x06FF, 0x0750...0x077F,
+             0x08A0...0x08D2, 0x200D:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Builds the probe scalar for a cell: one BMP, non-joining, non-combining
+    /// UTF-16 unit with the same Bidi_Class as the cell's first scalar.
+    static func probeScalar(for text: Character) -> unichar {
+        guard let first = text.unicodeScalars.first else { return 0x20 }
+        let v = first.value
+        if first.properties.canonicalCombiningClass != .notReordered
+            || first.properties.generalCategory == .nonspacingMark
+            || first.properties.generalCategory == .enclosingMark {
+            return 0x00B7  // lone combining mark: neutral placeholder (ON)
+        }
+        if isJoiningCapable(v) {
+            return 0x0621  // hamza: Bidi_Class AL, Joining_Type U
+        }
+        if v > 0xFFFF {
+            return 0x00B7  // astral (emoji etc.): neutral placeholder (ON)
+        }
+        return unichar(v)
+    }
+
+    /// Computes the visual order of cells and which cells resolved to an RTL
+    /// embedding level, using CoreText's UAX #9 implementation.
+    static func computeVisualOrder(cells: [Cell], direction: BidiParagraphDirection, font: AnyObject)
+        -> (order: [Int], rtl: [Bool])?
+    {
+        let n = cells.count
+        if n == 0 { return nil }
+
+        var units = [unichar](repeating: 0, count: n)
+        for (i, cell) in cells.enumerated() {
+            units[i] = probeScalar(for: cell.text)
+        }
+        let probe = NSString(characters: &units, length: n)
+
+        var writingDirection: CTWritingDirection
+        switch direction {
+        case .rightToLeft: writingDirection = .rightToLeft
+        case .leftToRight: writingDirection = .leftToRight
+        default: writingDirection = .natural
+        }
+        let style: CTParagraphStyle = withUnsafeMutableBytes(of: &writingDirection) { ptr in
+            var setting = CTParagraphStyleSetting(
+                spec: .baseWritingDirection,
+                valueSize: MemoryLayout<CTWritingDirection>.size,
+                value: ptr.baseAddress!)
+            return CTParagraphStyleCreate(&setting, 1)
+        }
+        let ligature = 0 as CFNumber
+        let attributes: [NSAttributedString.Key: Any] = [
+            NSAttributedString.Key(kCTFontAttributeName as String): font,
+            NSAttributedString.Key(kCTParagraphStyleAttributeName as String): style,
+            NSAttributedString.Key(kCTLigatureAttributeName as String): ligature,
+        ]
+        let attributed = NSAttributedString(string: probe as String, attributes: attributes)
+        let ctLine = CTLineCreateWithAttributedString(attributed)
+        guard let runs = CTLineGetGlyphRuns(ctLine) as? [CTRun], !runs.isEmpty else {
+            return nil
+        }
+
+        var entries: [(x: CGFloat, idx: Int)] = []
+        entries.reserveCapacity(n)
+        var rtl = [Bool](repeating: false, count: n)
+        for run in runs {
+            let glyphCount = CTRunGetGlyphCount(run)
+            if glyphCount == 0 { continue }
+            let isRTLRun = CTRunGetStatus(run).contains(.rightToLeft)
+            var indices = [CFIndex](repeating: 0, count: glyphCount)
+            CTRunGetStringIndices(run, CFRange(), &indices)
+            var positions = [CGPoint](repeating: .zero, count: glyphCount)
+            CTRunGetPositions(run, CFRange(), &positions)
+            for i in 0..<glyphCount {
+                let idx = indices[i]
+                guard idx >= 0 && idx < n else { continue }
+                entries.append((positions[i].x, idx))
+                if isRTLRun {
+                    rtl[idx] = true
+                }
+            }
+        }
+        entries.sort { $0.x < $1.x }
+
+        var order: [Int] = []
+        order.reserveCapacity(n)
+        var seen = Set<Int>()
+        for entry in entries where seen.insert(entry.idx).inserted {
+            order.append(entry.idx)
+        }
+        // Repair pass: any cell whose probe produced no glyph (e.g. a control
+        // or formatting character) is reinserted next to its logical neighbor.
+        if order.count < n {
+            for k in 0..<n where !seen.contains(k) {
+                if let p = order.firstIndex(of: k - 1) {
+                    order.insert(k, at: rtl[k - 1] ? p : p + 1)
+                } else if let p = order.firstIndex(of: k + 1) {
+                    order.insert(k, at: rtl[k + 1] ? p + 1 : p)
+                } else {
+                    order.append(k)
+                }
+                seen.insert(k)
+            }
+        }
+        guard order.count == n else { return nil }
+        return (order, rtl)
+    }
+
+    // MARK: - Arabic contextual shaping (cell level)
+
+    /// Computes per-cell display substitutions for Arabic contextual forms and
+    /// lam-alef ligatures. Operates on cells in logical order so that color or
+    /// attribute changes never break joining. Combining marks stored beyond
+    /// the base scalar of a cell (harakat) are preserved after the
+    /// substituted presentation form; the renderer's per-cluster column
+    /// mapping keeps them overlaid on their base cell.
+    ///
+    /// `precedingScalar`/`followingScalar` supply joining context from the
+    /// adjacent rows of a soft-wrapped logical line, so words split by
+    /// wrapping keep their connected forms at the seam.
+    static func shapeArabic(cells: [Cell],
+                            precedingScalar: UInt32? = nil,
+                            followingScalar: UInt32? = nil) -> [Character?] {
+        let n = cells.count
+        var result = [Character?](repeating: nil, count: n)
+
+        func baseScalar(_ i: Int) -> UInt32 {
+            cells[i].text.unicodeScalars.first?.value ?? 0x20
+        }
+        // The joining neighbor on a given side, skipping transparent cells;
+        // past the row edge, the wrapped-neighbor context applies.
+        func neighbor(from i: Int, step: Int) -> Joining {
+            var j = i + step
+            while j >= 0 && j < n {
+                let kind = joining(of: baseScalar(j))
+                if kind != .transparent { return kind }
+                j += step
+            }
+            if step < 0, let precedingScalar {
+                return joining(of: precedingScalar)
+            }
+            if step > 0, let followingScalar {
+                return joining(of: followingScalar)
+            }
+            return .none
+        }
+
+        var i = 0
+        while i < n {
+            let v = baseScalar(i)
+            let kind = joining(of: v)
+            guard kind == .dual || kind == .right else {
+                // Non-joining letters with a presentation form (hamza) still
+                // get their explicit isolated form for rendering consistency.
+                if kind == .none, let form = forms[v] {
+                    var text = String(UnicodeScalar(form.iso)!)
+                    for scalar in cells[i].text.unicodeScalars.dropFirst() {
+                        text.unicodeScalars.append(scalar)
+                    }
+                    result[i] = Character(text)
+                }
+                i += 1
+                continue
+            }
+            let prevConnects: Bool = {
+                let p = neighbor(from: i, step: -1)
+                return p == .dual || p == .causing
+            }()
+
+            // Retains any combining marks (harakat) stored after the base
+            // scalar of a cell.
+            func withMarks(_ shaped: UInt32, from cell: Cell) -> Character {
+                var text = String(UnicodeScalar(shaped)!)
+                for scalar in cell.text.unicodeScalars.dropFirst() {
+                    text.unicodeScalars.append(scalar)
+                }
+                return Character(text)
+            }
+
+            // Lam followed by an alef variant in the adjacent cell forms the
+            // mandatory lam-alef ligature: the ligature glyph goes in the lam
+            // cell and the alef cell is blanked.
+            if v == 0x0644, i + 1 < n, let lig = lamAlef[baseScalar(i + 1)] {
+                let form = prevConnects ? lig.fin : lig.iso
+                result[i] = withMarks(form, from: cells[i])
+                result[i + 1] = " "
+                i += 2
+                continue
+            }
+
+            guard let form = forms[v] else {
+                i += 1
+                continue
+            }
+            let nextKind = neighbor(from: i, step: 1)
+            let nextConnects = nextKind == .dual || nextKind == .right || nextKind == .causing
+            let shaped: UInt32
+            if kind == .right {
+                shaped = prevConnects ? form.fin : form.iso
+            } else if prevConnects && nextConnects, let med = form.med {
+                shaped = med
+            } else if prevConnects {
+                shaped = form.fin
+            } else if nextConnects, let ini = form.ini {
+                shaped = ini
+            } else {
+                shaped = form.iso
+            }
+            result[i] = withMarks(shaped, from: cells[i])
+            i += 1
+        }
+        return result
+    }
+
+    // MARK: - Full row layout
+
+    /// The joining-relevant scalar at the logical end of a row (for use as
+    /// preceding context of the wrapped row after it).
+    static func trailingScalar(of line: BufferLine, cols: Int, terminal: Terminal) -> UInt32? {
+        var col = min(cols, line.count) - 1
+        while col >= 0 {
+            let ch = line[col]
+            if ch.code != 0 {
+                return terminal.getCharacter(for: ch).unicodeScalars.first?.value
+            }
+            col -= 1
+        }
+        return nil
+    }
+
+    /// The joining-relevant scalar at the logical start of a row (for use as
+    /// following context of the row it wraps from).
+    static func leadingScalar(of line: BufferLine, cols: Int, terminal: Terminal) -> UInt32? {
+        var col = 0
+        let count = min(cols, line.count)
+        while col < count {
+            let ch = line[col]
+            if ch.code != 0 {
+                return terminal.getCharacter(for: ch).unicodeScalars.first?.value
+            }
+            col += max(1, Int(ch.width))
+        }
+        return nil
+    }
+
+    /// Computes the visual layout of a row, or nil when the row needs no BiDi
+    /// processing (pure LTR content or BiDi disabled) and the caller should use
+    /// the plain logical rendering path.
+    ///
+    /// For rows that are part of a soft-wrapped logical line, pass the edge
+    /// scalars of the adjacent rows so Arabic joining survives the wrap seam.
+    static func layout(line: BufferLine, cols: Int, terminal: Terminal,
+                       direction: BidiParagraphDirection, font: AnyObject,
+                       precedingScalar: UInt32? = nil,
+                       followingScalar: UInt32? = nil) -> BidiRowLayout?
+    {
+        if direction == .off { return nil }
+        let (cells, hasRTL) = extractCells(line: line, cols: cols, terminal: terminal)
+        // Fast path: rows with no RTL content lay out identically under auto
+        // or forced-LTR paragraphs. A forced-RTL paragraph reorders even
+        // pure-LTR rows (right alignment via UAX #9 L1), so it always runs.
+        if !hasRTL && direction != .rightToLeft {
+            return nil
+        }
+        if cells.isEmpty {
+            return nil
+        }
+        guard let (order, rtl) = computeVisualOrder(cells: cells, direction: direction, font: font) else {
+            return nil
+        }
+
+        var display = shapeArabic(cells: cells,
+                                  precedingScalar: precedingScalar,
+                                  followingScalar: followingScalar)
+        for (i, cell) in cells.enumerated() where rtl[i] && display[i] == nil {
+            if let mirrored = mirror[cell.text] {
+                display[i] = mirrored
+            } else if terminal.bidiBoxMirroring, let mirrored = boxMirror[cell.text] {
+                display[i] = mirrored
+            }
+        }
+
+        var visualCells: [BidiCell] = []
+        visualCells.reserveCapacity(cells.count)
+        var logicalToVisual = [Int](repeating: 0, count: cols)
+        var visualToLogical = [Int](repeating: 0, count: cols)
+        var visualCol = 0
+        for cellIndex in order {
+            let cell = cells[cellIndex]
+            visualCells.append(BidiCell(logicalCol: cell.logicalCol,
+                                        width: cell.width,
+                                        display: display[cellIndex]))
+            for k in 0..<cell.width {
+                let logical = cell.logicalCol + k
+                let visual = visualCol + k
+                if logical < cols { logicalToVisual[logical] = visual }
+                if visual < cols { visualToLogical[visual] = cell.logicalCol }
+            }
+            visualCol += cell.width
+        }
+        return BidiRowLayout(visualCells: visualCells,
+                             logicalToVisualCol: logicalToVisual,
+                             visualToLogicalCol: visualToLogical)
+    }
+}
+#endif

--- a/Sources/SwiftTerm/EscapeSequenceParser.swift
+++ b/Sources/SwiftTerm/EscapeSequenceParser.swift
@@ -396,7 +396,12 @@ public class EscapeSequenceParser {
         case 0x4c: terminal.cmdInsertLines(pars, collect)       // L
         case 0x4d: terminal.cmdDeleteLines(pars, collect)       // M
         case 0x50: terminal.cmdDeleteChars(pars, collect)       // P
-        case 0x53: terminal.cmdScrollUp(pars, collect)          // S
+        case 0x53:                                              // S
+            if collect == [32] {
+                terminal.cmdSelectPresentationDirection(pars, collect) // SPD
+            } else {
+                terminal.cmdScrollUp(pars, collect)
+            }
         case 0x54: terminal.csiT(pars, collect)                 // T
         case 0x58: terminal.cmdEraseChars(pars, collect)        // X
         case 0x5a: terminal.cmdCursorBackwardTab(pars, collect) // Z

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -698,6 +698,17 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     /// Controls weather to use high ansi colors, if false terminal will use bold text instead of high ansi colors
     public var useBrightColors: Bool = true
 
+    /// Controls bidirectional (Arabic/Hebrew) text rendering: rows containing
+    /// RTL characters are reordered per UAX #9 and Arabic letters are
+    /// contextually shaped at render time; the buffer stays in logical order.
+    public var bidiParagraphDirection: BidiParagraphDirection = .auto {
+        didSet {
+            terminal.updateFullScreen()
+            queuePendingDisplay()
+            updateCursorPosition()
+        }
+    }
+
     /// When true, block element (U+2580-U+259F) and box drawing (U+2500-U+257F) characters use custom rendering.
     public var customBlockGlyphs: Bool = true {
         didSet {
@@ -2391,10 +2402,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         let displayBuffer = terminal.displayBuffer
         let col = Int (point.x / cellDimension.width)
         let row = Int ((frame.height-point.y) / cellDimension.height)
-        let colValue = min (max (0, col), terminal.cols-1)
+        var colValue = min (max (0, col), terminal.cols-1)
         let bufferRow = row + displayBuffer.yDisp
         let maxRow = max (0, displayBuffer.lines.count - 1)
         let rowValue = min (max (0, bufferRow), maxRow)
+        // In BiDi rows the clicked (visual) column is translated back to the
+        // logical buffer column it displays.
+        if effectiveBidiDirection != .off, rowValue < displayBuffer.lines.count,
+           let bidiLayout = TerminalBidi.layout(line: displayBuffer.lines[rowValue],
+                                                cols: terminal.cols,
+                                                terminal: terminal,
+                                                direction: effectiveBidiDirection,
+                                                font: fontSet.normal),
+           colValue < bidiLayout.visualToLogicalCol.count {
+            colValue = bidiLayout.visualToLogicalCol[colValue]
+        }
         return (Position(col: colValue, row: rowValue), toInt (point))
     }
     
@@ -2740,7 +2762,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
         return 1
     }
-    
+
     public override func resetCursorRects() {
         addCursorRect(bounds, cursor: .iBeam)
     }

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -379,6 +379,18 @@ open class Terminal {
     // You can ignore most of the defaults set here, the function
     // reset() will do that again
     var sendFocus: Bool = false
+
+    // Terminal-wg BiDi escapes (https://terminal-wg.pages.freedesktop.org/bidi/):
+    // BDSM (ECMA-48 SM/RM 8): implicit (terminal reorders) vs explicit (app
+    // handles BiDi, terminal presents logical order). SPD (CSI Ps SP S):
+    // paragraph direction, 0 = LTR, 3 = RTL. DECSET/DECRST 2501: autodetect
+    // paragraph direction (we default it on, matching the app's RTL-first
+    // behavior; the spec leaves the default to the implementation). 2500: box
+    // drawing mirroring on RTL lines.
+    public private(set) var bidiSupportEnabled: Bool = true
+    public private(set) var bidiAutodetectDirection: Bool = true
+    public private(set) var bidiRTLPreference: Bool = false
+    public private(set) var bidiBoxMirroring: Bool = false
     var cursorHidden : Bool = false
     
     /// Controls the origin mode (DECOM), when set, the screen is limited to the top and bottom margins
@@ -3274,6 +3286,24 @@ open class Terminal {
         }
     }
 
+    // SPD - Select Presentation Direction (ECMA-48, used by the terminal-wg
+    // BiDi spec): CSI Ps SP S with Ps 0 = LTR, 3 = RTL.
+    func cmdSelectPresentationDirection (_ pars: [Int], _ collect: cstring)
+    {
+        guard collect == [32] else {
+            return
+        }
+        switch pars.first ?? 0 {
+        case 0:
+            bidiRTLPreference = false
+        case 3:
+            bidiRTLPreference = true
+        default:
+            return
+        }
+        updateFullScreen()
+    }
+
     func cmdDecRqm (_ pars: [Int], decMode: Bool) {
         let modeUnknown = 0
         let modeSet = 1
@@ -3379,6 +3409,10 @@ open class Terminal {
                 res = bracketedPasteMode ? modeSet : modeReset
             case 2026:
                 res = synchronizedOutputActive ? modeSet : modeReset
+            case 2500: // box drawing mirroring (terminal-wg)
+                res = bidiBoxMirroring ? modeSet : modeReset
+            case 2501: // autodetect paragraph direction (terminal-wg)
+                res = bidiAutodetectDirection ? modeSet : modeReset
             default:
                 break
             }
@@ -3397,6 +3431,8 @@ open class Terminal {
                 res = modeAlwaysReset
             case 7: // VEM vertical editing
                 res = modeAlwaysReset
+            case 8: // BDSM BiDi support mode (terminal-wg)
+                res = bidiSupportEnabled ? modeSet : modeReset
             case 10: // HEM horizontal editing
                 res = modeAlwaysReset
             case 11: // PUM positioning unit
@@ -4121,6 +4157,10 @@ open class Terminal {
             case 4:
                 // IRM Insert/Replace Mode
                 setInsertMode(false)
+            case 8:
+                // BDSM explicit mode: present logical order, app does BiDi
+                bidiSupportEnabled = false
+                updateFullScreen()
             case 20:
                 // LNM—Line Feed/New Line Mode
                 lineFeedMode = false
@@ -4179,6 +4219,12 @@ open class Terminal {
                 mouseMode = .off
             case 1004: // send focusin/focusout events
                 sendFocus = false
+            case 2500: // box drawing mirroring off
+                bidiBoxMirroring = false
+                updateFullScreen()
+            case 2501: // autodetect off: use the SPD-selected direction
+                bidiAutodetectDirection = false
+                updateFullScreen()
             case 1005: // utf8 ext mode mouse
                 // Resets the coordinate encoding only: 1005/1006/1015/1016 select how mouse
                 // events are encoded, independent of the tracking modes (9/1000-1003). xterm
@@ -4338,6 +4384,10 @@ open class Terminal {
                 // IRM Insert/Replace Mode
                 // https://vt100.net/docs/vt510-rm/IRM.html
                 setInsertMode(true)
+            case 8:
+                // BDSM implicit mode: the terminal performs BiDi reordering
+                bidiSupportEnabled = true
+                updateFullScreen()
 //            case 12:
 //                 SRM—Local Echo: Send/Receive Mode
 //                 When implemented, hook up cmdDecRqm
@@ -4420,6 +4470,12 @@ open class Terminal {
                 // the application does not assume it is unfocused until the
                 // first real focus change.
                 sendFocusReport()
+            case 2500: // box drawing mirroring (terminal-wg)
+                bidiBoxMirroring = true
+                updateFullScreen()
+            case 2501: // autodetect paragraph direction (terminal-wg)
+                bidiAutodetectDirection = true
+                updateFullScreen()
             case 1005:
                 // utf8 ext mode mouse
                 mouseProtocol = .utf8
@@ -5203,6 +5259,10 @@ open class Terminal {
     /// for a soft reset see `softReset`
     public func resetToInitialState ()
     {
+        bidiSupportEnabled = true
+        bidiAutodetectDirection = true
+        bidiRTLPreference = false
+        bidiBoxMirroring = false
         endSynchronizedOutput ()
         options.rows = rows
         options.cols = cols

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1281,6 +1281,22 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     /// Controls weather to use high ansi colors, if false terminal will use bold text instead of high ansi colors
     public var useBrightColors: Bool = true
 
+    /// Number of scrollback lines used when the terminal is created. Set this
+    /// before instantiating a `TerminalView` (it is read during setup and
+    /// whenever the font changes).
+    public static var defaultScrollbackLines: Int = 500
+
+    /// Controls bidirectional (Arabic/Hebrew) text rendering: rows containing
+    /// RTL characters are reordered per UAX #9 and Arabic letters are
+    /// contextually shaped at render time; the buffer stays in logical order.
+    public var bidiParagraphDirection: BidiParagraphDirection = .auto {
+        didSet {
+            terminal.updateFullScreen()
+            queuePendingDisplay()
+            updateCursorPosition()
+        }
+    }
+
     /// When true, block element (U+2580-U+259F) and box drawing (U+2500-U+257F) characters use custom rendering.
     public var customBlockGlyphs: Bool = true {
         didSet {

--- a/Tests/SwiftTermTests/BidiEscapeTests.swift
+++ b/Tests/SwiftTermTests/BidiEscapeTests.swift
@@ -1,0 +1,124 @@
+//
+//  BidiEscapeTests.swift
+//
+//  Terminal-wg BiDi escape sequences: BDSM (SM/RM 8), SPD (CSI Ps SP S),
+//  DECSET/DECRST 2500 (box mirroring) and 2501 (direction autodetect).
+//  https://terminal-wg.pages.freedesktop.org/bidi/
+//
+import Foundation
+import Testing
+
+@testable import SwiftTerm
+
+final class BidiEscapeTests: TerminalDelegate {
+    var sent: [UInt8] = []
+
+    func send(source: Terminal, data: ArraySlice<UInt8>) {
+        sent.append(contentsOf: data)
+    }
+
+    var sentString: String {
+        String(decoding: sent, as: UTF8.self)
+    }
+
+    func makeTerminal() -> Terminal {
+        Terminal(delegate: self, options: TerminalOptions(cols: 80, rows: 25))
+    }
+
+    @Test func defaultsMatchTheAppBehavior() {
+        let terminal = makeTerminal()
+        #expect(terminal.bidiSupportEnabled, "implicit BDSM by default")
+        #expect(terminal.bidiAutodetectDirection, "autodetect on by default (RTL-first app policy)")
+        #expect(!terminal.bidiRTLPreference, "SPD default direction is LTR")
+        #expect(!terminal.bidiBoxMirroring, "box mirroring off by default")
+    }
+
+    @Test func bdsmTogglesImplicitBidi() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[8l")
+        #expect(!terminal.bidiSupportEnabled, "RM 8 selects explicit mode (app-side BiDi)")
+        terminal.feed(text: "\u{1b}[8h")
+        #expect(terminal.bidiSupportEnabled, "SM 8 selects implicit mode")
+    }
+
+    @Test func spdSelectsPresentationDirection() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[3 S")
+        #expect(terminal.bidiRTLPreference, "SPD 3 selects RTL")
+        terminal.feed(text: "\u{1b}[0 S")
+        #expect(!terminal.bidiRTLPreference, "SPD 0 selects LTR")
+        terminal.feed(text: "\u{1b}[3 S")
+        terminal.feed(text: "\u{1b}[ S")
+        #expect(!terminal.bidiRTLPreference, "SPD with no parameter defaults to 0 (LTR)")
+    }
+
+    @Test func spdIgnoresUnsupportedDirections() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[3 S")
+        terminal.feed(text: "\u{1b}[1 S")
+        #expect(terminal.bidiRTLPreference, "vertical directions (1, 2) are ignored")
+        terminal.feed(text: "\u{1b}[7 S")
+        #expect(terminal.bidiRTLPreference)
+    }
+
+    @Test func spdDoesNotSwallowScrollUp() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "hello\r\nworld")
+        // Plain CSI 2 S (no space intermediate) must still scroll, not hit SPD.
+        terminal.feed(text: "\u{1b}[2S")
+        #expect(!terminal.bidiRTLPreference)
+        let firstRow = terminal.getLine(row: 0)?.translateToString(trimRight: true)
+        #expect(firstRow == "", "content scrolled away by CSI 2 S")
+    }
+
+    @Test func decModesToggleAutodetectAndBoxMirroring() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?2501l")
+        #expect(!terminal.bidiAutodetectDirection)
+        terminal.feed(text: "\u{1b}[?2501h")
+        #expect(terminal.bidiAutodetectDirection)
+        terminal.feed(text: "\u{1b}[?2500h")
+        #expect(terminal.bidiBoxMirroring)
+        terminal.feed(text: "\u{1b}[?2500l")
+        #expect(!terminal.bidiBoxMirroring)
+    }
+
+    @Test func decrqmReportsBidiModes() {
+        let terminal = makeTerminal()
+
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[8$p")
+        #expect(sentString == "\u{1b}[8;1$y", "BDSM set by default")
+
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[8l\u{1b}[8$p")
+        #expect(sentString == "\u{1b}[8;2$y", "BDSM reports reset after RM 8")
+
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[?2501$p")
+        #expect(sentString == "\u{1b}[?2501;1$y", "autodetect set by default")
+
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[?2500$p")
+        #expect(sentString == "\u{1b}[?2500;2$y", "box mirroring reset by default")
+
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[?2500h\u{1b}[?2500$p")
+        #expect(sentString == "\u{1b}[?2500;1$y")
+    }
+
+    @Test func fullResetRestoresBidiDefaults() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[8l\u{1b}[?2501l\u{1b}[3 S\u{1b}[?2500h")
+        #expect(!terminal.bidiSupportEnabled)
+        #expect(!terminal.bidiAutodetectDirection)
+        #expect(terminal.bidiRTLPreference)
+        #expect(terminal.bidiBoxMirroring)
+
+        terminal.resetToInitialState()
+        #expect(terminal.bidiSupportEnabled)
+        #expect(terminal.bidiAutodetectDirection)
+        #expect(!terminal.bidiRTLPreference)
+        #expect(terminal.bidiBoxMirroring == false)
+    }
+}

--- a/Tests/SwiftTermTests/BidiRenderTests.swift
+++ b/Tests/SwiftTermTests/BidiRenderTests.swift
@@ -1,0 +1,143 @@
+//
+//  BidiRenderTests.swift
+//
+//  Offscreen smoke tests for the BiDi rendering path: feeds RTL content into a
+//  real TerminalView and renders it to a bitmap, exercising
+//  buildAttributedString/drawTerminalContents with visual reordering, shaped
+//  Arabic forms, and the multi-scalar cell isolation branch.
+//
+#if os(macOS)
+import Foundation
+import AppKit
+import Testing
+
+@testable import SwiftTerm
+
+@MainActor
+final class BidiRenderTests {
+
+    func render(_ view: TerminalView) -> NSBitmapImageRep? {
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            return nil
+        }
+        view.cacheDisplay(in: view.bounds, to: rep)
+        return rep
+    }
+
+    func makeView(feed text: String) -> TerminalView {
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 480, height: 200))
+        view.getTerminal().feed(text: text)
+        return view
+    }
+
+    @Test func rtlContentRendersWithoutCrashing() throws {
+        let view = makeView(feed: "مرحبا بالعالم\r\nשלום עולם\r\n(אב) hello ملف.txt\r\nهذا نص عربي مع English مختلط")
+        let rep = try #require(render(view))
+        #expect(rep.size.width > 0)
+    }
+
+    /// The concatenated text content of all segments of a rendered row.
+    func segmentText(_ view: TerminalView, row: Int) -> String {
+        let terminal = view.getTerminal()
+        let info = view.buildAttributedString(row: row, line: terminal.buffer.lines[row],
+                                              cols: terminal.cols)
+        return info.segments.map { $0.attributedString.string }.joined()
+    }
+
+    @Test func viewEmitsShapedPresentationForms() throws {
+        let view = makeView(feed: "مرحبا")
+        view.bidiParagraphDirection = .auto
+        let bidiText = segmentText(view, row: 0)
+        // The visual row must contain the contextually shaped forms, with the
+        // initial meem as the rightmost (last visual) non-space character.
+        #expect(bidiText.contains("\u{FEE3}"))  // م initial
+        #expect(bidiText.contains("\u{FE92}"))  // ب medial
+        #expect(bidiText.trimmingCharacters(in: .whitespaces).last == "\u{FEE3}")
+
+        view.bidiParagraphDirection = .off
+        let plainText = segmentText(view, row: 0)
+        // Legacy path: logical order, no presentation forms.
+        #expect(!plainText.contains("\u{FEE3}"))
+        #expect(plainText.hasPrefix("مرحبا"))
+    }
+
+    @Test func wrappedArabicWordKeepsJoiningAcrossRows() throws {
+        // A 12-letter beh run in a 10-column terminal wraps 10 + 2. The last
+        // cell of row 0 must render the MEDIAL form (it joins into row 1),
+        // and row 1 must open medial and close final.
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        let cellWidth = view.cellDimension.width
+        let cellHeight = view.cellDimension.height
+        view.setFrameSize(NSSize(width: cellWidth * 10 + 1, height: cellHeight * 5 + 1))
+        let terminal = view.getTerminal()
+        let cols = terminal.cols
+        #expect(cols >= 4)
+
+        terminal.feed(text: String(repeating: "ب", count: cols + 2))
+        #expect(terminal.buffer.lines[1].isWrapped)
+
+        let row0 = segmentText(view, row: 0).trimmingCharacters(in: .whitespaces)
+        let row1 = segmentText(view, row: 1).trimmingCharacters(in: .whitespaces)
+        // Visual order: RTL rows read right-to-left, so the logical last cell
+        // of row 0 is the leftmost character in the segment text.
+        #expect(row0.count == cols)
+        #expect(row0.first == "\u{FE92}", "row 0's seam letter must be medial")
+        #expect(row0.last == "\u{FE91}", "row 0 starts the word with the initial form")
+        #expect(row0.dropFirst().dropLast().allSatisfy { $0 == "\u{FE92}" })
+        #expect(row1.count == 2)
+        #expect(row1.last == "\u{FE92}", "row 1's first logical letter continues medially")
+        #expect(row1.first == "\u{FE90}", "the word's last letter takes the final form")
+    }
+
+    @Test func caretIsDrawnAtVisualColumn() throws {
+        // After feeding مرحبا (5 cells) the logical cursor is at column 5.
+        // In the RTL paragraph the text occupies the right edge, so the caret
+        // must be drawn at visual column cols-6 (just left of the text).
+        let view = makeView(feed: "مرحبا")
+        // The display queue that normally triggers this is throttled and needs
+        // a runloop; call it directly for a deterministic test.
+        view.updateCursorPosition()
+        let terminal = view.getTerminal()
+        let caret = try #require(view.caretView)
+        let cellWidth = view.cellDimension.width
+        let expectedVisualCol = terminal.cols - 6
+        #expect(abs(caret.frame.origin.x - CGFloat(expectedVisualCol) * cellWidth) < 0.5)
+
+        // With BiDi off the caret sits at the logical column.
+        view.bidiParagraphDirection = .off
+        #expect(abs(caret.frame.origin.x - 5 * cellWidth) < 0.5)
+    }
+
+    @Test func forcedRTLRightAlignsLatinRow() throws {
+        // Forced RTL paragraphs place trailing whitespace at the visual left
+        // (UAX #9 L1), so even pure-Latin text right-aligns: a difference the
+        // legacy path cannot produce.
+        let rtlView = makeView(feed: "abc")
+        rtlView.bidiParagraphDirection = .rightToLeft
+        let rtlText = segmentText(rtlView, row: 0)
+        #expect(rtlText.hasSuffix("abc"))
+        let rtlRep = try #require(render(rtlView))
+
+        let plainView = makeView(feed: "abc")
+        plainView.bidiParagraphDirection = .off
+        let plainRep = try #require(render(plainView))
+
+        #expect(rtlRep.tiffRepresentation != plainRep.tiffRepresentation)
+    }
+
+    @Test func emojiAndCombiningCellsRenderInBidiRows() throws {
+        // Emoji (astral, multi-scalar) and Hebrew niqqud inside an RTL row
+        // take the isolated-segment path.
+        let view = makeView(feed: "שָׁלוֹם 🙂 مرحبا")
+        _ = try #require(render(view))
+    }
+
+    @Test func forcedDirectionsRenderAllRows() throws {
+        for direction in [BidiParagraphDirection.auto, .leftToRight, .rightToLeft, .off] {
+            let view = makeView(feed: "abc מרחבא 123 (x)\r\nمرحبا abc")
+            view.bidiParagraphDirection = direction
+            _ = try #require(render(view))
+        }
+    }
+}
+#endif

--- a/Tests/SwiftTermTests/BidiTests.swift
+++ b/Tests/SwiftTermTests/BidiTests.swift
@@ -1,0 +1,203 @@
+//
+//  BidiTests.swift
+//
+//  Tests for cell-level BiDi support: UAX #9 visual reordering, Arabic
+//  contextual shaping to presentation forms, lam-alef ligatures, and
+//  bracket mirroring.
+//
+#if os(macOS)
+import Foundation
+import AppKit
+import Testing
+
+@testable import SwiftTerm
+
+final class BidiTests: TerminalDelegate {
+    func send(source: Terminal, data: ArraySlice<UInt8>) {}
+
+    let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+    func makeTerminal(cols: Int, feed text: String) -> Terminal {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: cols, rows: 4))
+        terminal.feed(text: text)
+        return terminal
+    }
+
+    func layoutRow0(cols: Int, _ text: String,
+                    direction: BidiParagraphDirection = .auto) -> BidiRowLayout? {
+        let terminal = makeTerminal(cols: cols, feed: text)
+        return TerminalBidi.layout(line: terminal.buffer.lines[0], cols: cols,
+                                   terminal: terminal, direction: direction, font: font)
+    }
+
+    func cells(_ text: String) -> [TerminalBidi.Cell] {
+        text.enumerated().map { TerminalBidi.Cell(logicalCol: $0.offset, width: 1, text: $0.element) }
+    }
+
+    // MARK: Fast path
+
+    @Test func pureLTRRowNeedsNoLayout() {
+        #expect(layoutRow0(cols: 10, "hello") == nil)
+        #expect(layoutRow0(cols: 10, "café 123!") == nil)
+    }
+
+    @Test func bidiOffReturnsNoLayout() {
+        #expect(layoutRow0(cols: 10, "שלום", direction: .off) == nil)
+    }
+
+    // MARK: Ordering
+
+    @Test func hebrewRowIsReversedToRightEdge() throws {
+        let cols = 10
+        let layout = try #require(layoutRow0(cols: cols, "שלום"))
+        // First strong character is RTL, so the row is an RTL paragraph:
+        // the text hugs the right edge, reading right-to-left.
+        #expect(layout.logicalToVisualCol[0] == 9)  // ש rightmost
+        #expect(layout.logicalToVisualCol[1] == 8)  // ל
+        #expect(layout.logicalToVisualCol[2] == 7)  // ו
+        #expect(layout.logicalToVisualCol[3] == 6)  // ם
+        #expect(layout.visualToLogicalCol[9] == 0)
+        #expect(layout.visualToLogicalCol[6] == 3)
+        // The permutation must be a bijection over all columns.
+        #expect(Set(layout.visualToLogicalCol).count == cols)
+    }
+
+    @Test func mixedLineKeepsLatinAndReversesHebrew() throws {
+        let cols = 15
+        let layout = try #require(layoutRow0(cols: cols, "abc שלום xyz"))
+        // LTR paragraph (first strong is 'a'): Latin stays, Hebrew segment
+        // is reversed in place.
+        #expect(layout.logicalToVisualCol[0] == 0)   // a
+        #expect(layout.logicalToVisualCol[2] == 2)   // c
+        #expect(layout.logicalToVisualCol[4] == 7)   // ש takes the right end of its segment
+        #expect(layout.logicalToVisualCol[5] == 6)   // ל
+        #expect(layout.logicalToVisualCol[6] == 5)   // ו
+        #expect(layout.logicalToVisualCol[7] == 4)   // ם
+        #expect(layout.logicalToVisualCol[9] == 9)   // x
+        #expect(layout.logicalToVisualCol[11] == 11) // z
+    }
+
+    @Test func forcedRTLParagraphReversesNeutralOnlyContext() throws {
+        // With a forced RTL paragraph the row is right-aligned even though
+        // it contains RTL content in an otherwise LTR context.
+        let cols = 8
+        let layout = try #require(layoutRow0(cols: cols, "אב 12", direction: .rightToLeft))
+        #expect(layout.logicalToVisualCol[0] == 7)  // א rightmost
+        #expect(layout.logicalToVisualCol[1] == 6)  // ב
+        // Numbers read left-to-right even inside RTL text.
+        #expect(layout.logicalToVisualCol[3] < layout.logicalToVisualCol[4])
+    }
+
+    // MARK: Arabic shaping
+
+    @Test func arabicContextualForms() {
+        // مرحبا: meem joins forward to reh; reh does not join forward, so hah
+        // starts a new joined group with beh medial and alef final.
+        let shaped = TerminalBidi.shapeArabic(cells: cells("مرحبا"))
+        #expect(shaped[0] == Character(UnicodeScalar(0xFEE3)!))  // م initial
+        #expect(shaped[1] == Character(UnicodeScalar(0xFEAE)!))  // ر final
+        #expect(shaped[2] == Character(UnicodeScalar(0xFEA3)!))  // ح initial
+        #expect(shaped[3] == Character(UnicodeScalar(0xFE92)!))  // ب medial
+        #expect(shaped[4] == Character(UnicodeScalar(0xFE8E)!))  // ا final
+    }
+
+    @Test func isolatedLettersStayIsolated() {
+        let shaped = TerminalBidi.shapeArabic(cells: cells("ء د"))
+        #expect(shaped[0] == Character(UnicodeScalar(0xFE80)!))  // ء isolated
+        #expect(shaped[2] == Character(UnicodeScalar(0xFEA9)!))  // د isolated
+    }
+
+    @Test func lamAlefLigature() {
+        // Standalone lam+alef: isolated ligature in the lam cell, blank alef cell.
+        var shaped = TerminalBidi.shapeArabic(cells: cells("لا"))
+        #expect(shaped[0] == Character(UnicodeScalar(0xFEFB)!))
+        #expect(shaped[1] == " ")
+        // Preceded by a dual-joining letter: final ligature form.
+        shaped = TerminalBidi.shapeArabic(cells: cells("بلا"))
+        #expect(shaped[0] == Character(UnicodeScalar(0xFE91)!))  // ب initial
+        #expect(shaped[1] == Character(UnicodeScalar(0xFEFC)!))  // لا final
+        #expect(shaped[2] == " ")
+    }
+
+    @Test func latinTextIsNotShaped() {
+        let shaped = TerminalBidi.shapeArabic(cells: cells("hello"))
+        #expect(shaped.allSatisfy { $0 == nil })
+    }
+
+    @Test func harakatPreservedThroughShaping() {
+        // A cell holding beh + fatha: the shaped display keeps the mark
+        // after the presentation form.
+        let cell = TerminalBidi.Cell(logicalCol: 0, width: 1, text: "\u{0628}\u{064E}")
+        let next = TerminalBidi.Cell(logicalCol: 1, width: 1, text: "ب")
+        let shaped = TerminalBidi.shapeArabic(cells: [cell, next])
+        let display = shaped[0]!
+        let scalars = Array(String(display).unicodeScalars)
+        #expect(scalars.count == 2)
+        #expect(scalars[0].value == 0xFE91)  // ب initial
+        #expect(scalars[1].value == 0x064E)  // fatha retained
+
+        // Lam-alef with a mark on the lam keeps the mark on the ligature.
+        let lam = TerminalBidi.Cell(logicalCol: 0, width: 1, text: "\u{0644}\u{064E}")
+        let alef = TerminalBidi.Cell(logicalCol: 1, width: 1, text: "ا")
+        let ligated = TerminalBidi.shapeArabic(cells: [lam, alef])
+        let ligScalars = Array(String(ligated[0]!).unicodeScalars)
+        #expect(ligScalars[0].value == 0xFEFB)
+        #expect(ligScalars.contains { $0.value == 0x064E })
+    }
+
+    @Test func wrappedRowContextPreservesJoining() {
+        // A row ending mid-word: with a dual-joining letter following on the
+        // wrapped row, the last beh must take its medial (not final) form.
+        var shaped = TerminalBidi.shapeArabic(cells: cells("بب"),
+                                              followingScalar: 0x0628)
+        #expect(shaped[0] == Character(UnicodeScalar(0xFE91)!))  // ب initial
+        #expect(shaped[1] == Character(UnicodeScalar(0xFE92)!))  // ب medial (joins into next row)
+
+        // The continuation row: preceded by a dual-joining letter on the
+        // previous row, its first beh is medial and its last is final.
+        shaped = TerminalBidi.shapeArabic(cells: cells("بب"),
+                                          precedingScalar: 0x0628)
+        #expect(shaped[0] == Character(UnicodeScalar(0xFE92)!))  // ب medial
+        #expect(shaped[1] == Character(UnicodeScalar(0xFE90)!))  // ب final
+
+        // Right-joining context letters do not join forward across the seam.
+        shaped = TerminalBidi.shapeArabic(cells: cells("بب"),
+                                          precedingScalar: 0x0627)  // ا
+        #expect(shaped[0] == Character(UnicodeScalar(0xFE91)!))  // ب initial (alef doesn't connect)
+    }
+
+    // MARK: Mirroring
+
+    @Test func bracketsMirrorInRTLRuns() throws {
+        let layout = try #require(layoutRow0(cols: 8, "(אב)"))
+        // RTL paragraph: brackets resolve to RTL levels and must be mirrored.
+        var overrides: [Int: Character] = [:]
+        for cell in layout.visualCells where cell.display != nil {
+            overrides[cell.logicalCol] = cell.display
+        }
+        #expect(overrides[0] == ")")
+        #expect(overrides[3] == "(")
+        // Reading the visual row left to right yields correctly balanced text.
+        let logicalChars = Array("(אב)")
+        let visualText = layout.visualCells.map { cell -> String in
+            if let display = cell.display { return String(display) }
+            return cell.logicalCol < logicalChars.count ? String(logicalChars[cell.logicalCol]) : " "
+        }.joined()
+        #expect(visualText.trimmingCharacters(in: .whitespaces) == "(בא)")
+    }
+
+    // MARK: Full pipeline
+
+    @Test func arabicRowShapesAndReorders() throws {
+        let cols = 10
+        let layout = try #require(layoutRow0(cols: cols, "مرحبا"))
+        // RTL paragraph: م is the rightmost cell.
+        #expect(layout.logicalToVisualCol[0] == 9)
+        #expect(layout.logicalToVisualCol[4] == 5)
+        // The rightmost visual cell carries the shaped initial meem.
+        let rightmost = try #require(layout.visualCells.last)
+        #expect(rightmost.logicalCol == 0)
+        #expect(rightmost.display == Character(UnicodeScalar(0xFEE3)!))
+    }
+}
+#endif

--- a/Tests/bidi-sample.txt
+++ b/Tests/bidi-sample.txt
@@ -1,0 +1,42 @@
+================ SwiftTerm BiDi sample ================
+Try: cat Tests/bidi-sample.txt
+Compare against a browser rendering of this same file
+(browsers implement full UAX #9) and against a build of
+main (logical order, no shaping).
+
+--- 1. Plain Arabic (should read right-to-left, joined) ---
+مرحبا بالعالم
+هذا نص عربي بسيط في سطر واحد
+
+--- 2. Plain Hebrew ---
+שלום עולם
+זהו טקסט עברי פשוט בשורה אחת
+
+--- 3. Mixed direction with Latin and digits ---
+abc שלום xyz و مرحبا 123
+file.txt הוא הקובץ מספר 42 ברשימה
+الإصدار 2.5 من swift متوفر الآن
+
+--- 4. Arabic joining and the lam-alef ligature ---
+لا إله إلا الله
+السلام عليكم
+
+--- 5. Vocalized text (harakat / niqqud stay on their base) ---
+بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ
+שָׁלוֹם עוֹלָם
+
+--- 6. Bracket mirroring inside RTL runs ---
+(אב) [שלום] {עולם}
+قائمة (من اليمين) إلى <اليسار>
+
+--- 7. Numbers keep left-to-right order inside RTL text ---
+המספר הוא 12345 בדיוק
+الرقم هو 12345 تماما
+
+--- 8. A long Arabic line that soft-wraps: joining must survive
+the wrap seam (make the window narrow to see it) ---
+هذا سطر طويل جدا من النص العربي المتصل الذي سوف يلتف على عدة أسطر في النافذة الضيقة ويجب أن تبقى الحروف متصلة بشكل صحيح عند نقطة الالتفاف بين السطور
+
+--- 9. What "before" looks like: on main, all of the above
+renders left-to-right in logical order with disconnected
+letters; on this branch it matches the browser. ---


### PR DESCRIPTION
## Summary

This adds bidirectional text support (Arabic, Hebrew) to SwiftTerm, following the [terminal-wg BiDi recommendation](https://terminal-wg.pages.freedesktop.org/bidi/)'s implicit model (the approach used by mlterm and VTE): the terminal buffer stays in strict logical order, and rows containing RTL content get a visual permutation at render time. BiDi-unaware apps (ls, cat, shells) display Arabic/Hebrew correctly; BiDi-aware apps can opt out via the standard escapes.

**Now rebased onto current main** (single commit, conflict-free) and reduced to BiDi-only — the unrelated fixes and downstream configuration that were previously mixed in are gone (fixes live in #590; the scrollback bits were my app's configuration and did not belong here).

## Try it

```sh
cat Tests/bidi-sample.txt
```

The sample covers plain Arabic/Hebrew, mixed-direction lines with digits, lam-alef ligatures, vocalized text (harakat/niqqud), bracket mirroring, and a long soft-wrapping Arabic paragraph. For a reference rendering, open the same file in a browser (browsers implement full UAX #9); for "before", cat it on a build of main — everything renders left-to-right in logical order with disconnected Arabic letters.

## What's included

### BiDi engine (`Apple/TerminalBidi.swift`, new)
- UAX #9 reordering computed per row via a CoreText probe line (one UTF-16 unit per cell), producing logical↔visual column maps.
- Arabic contextual shaping into presentation forms, lam-alef ligatures, harakat/diacritic preservation.
- Joining context carried across soft-wrapped rows (`BufferLine.isWrapped`) so words shaped across a wrap seam stay joined.
- Bracket mirroring (UAX #9 L4); box-drawing mirroring behind DECSET 2500.
- Paragraph direction: per-row autodetect (first strong character), or forced LTR/RTL/off.

### Renderer integration
- `buildAttributedString` walks rows in visual order with per-cell display substitutions; a utf16→cell map plus `CTRunGetStringIndices` keeps every glyph (combining marks, ligature clusters) anchored to its column.
- Arabic-script cells render as isolated column-anchored segments so font-level required ligatures (e.g. الله) cannot collapse columns.
- Caret drawing and mouse hit-testing translate through the visual maps.

### terminal-wg escape sequences
- **BDSM** (`CSI 8 h/l`): implicit vs explicit BiDi support mode.
- **SPD** (`CSI Ps SP S`): presentation direction, `0` = LTR, `3` = RTL (plain `CSI Ps S` scroll-up unaffected).
- **DECSET/DECRST 2501**: paragraph-direction autodetection; **2500**: box-drawing mirroring.
- All report through DECRQM; RIS restores defaults.
- Public API: `bidiParagraphDirection` (embedder override) and `effectiveBidiDirection` (override resolved against the escape state).

## Testing

`swift test` passes: 469 tests, including new suites for the engine (reordering, shaping, wrap-seam joining, mirroring), the render path, and the escape sequences.

## Notes for review

- Render-time only; the emulation layer is untouched except for the new mode state on `Terminal`.
- The spec leaves the autodetection default to the implementation; this PR defaults it **on** so RTL works out of the box (VTE ships it off — happy to flip for parity).
- Mode changes re-render the visible buffer with the current state; VTE stamps direction per paragraph as written. Per-paragraph stamping would need buffer-side state — proposed as follow-up work if this lands.
