### PR TITLE
Mouse motion row and focus reporting fixes

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2682,7 +2682,14 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         
         if terminal.mouseMode.sendMotionEvent() {
             let flags = encodeMouseEvent(with: event, overwriteRelease: true)
-            terminal.sendMotion(buttonFlags: flags, x: hit.grid.col, y: hit.grid.row, pixelX: hit.pixels.col, pixelY: hit.pixels.row)
+            // Report the viewport row, not the buffer-absolute row: with
+            // scrollback present the absolute row is far outside the screen
+            // and applications tracking hover (e.g. TUIs with clickable rows)
+            // never match their hit targets. Press/release/drag already
+            // subtract yDisp via their own screenRow computations.
+            let displayBuffer = terminal.displayBuffer
+            let screenRow = max (0, min (displayBuffer.rows - 1, hit.grid.row - displayBuffer.yDisp))
+            terminal.sendMotion(buttonFlags: flags, x: hit.grid.col, y: screenRow, pixelX: hit.pixels.col, pixelY: hit.pixels.row)
         }
     }
     

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -569,12 +569,22 @@ open class Terminal {
         }
     }
     
+    /// Tracks the host view's focus so that enabling focus reporting (DECSET
+    /// 1004) can immediately tell the application the current state, the way
+    /// xterm does. Defaults to focused.
+    var reportedFocusState: Bool = true
+
     /// Invoke this command when the terminal receives and loses focus
     public func setTerminalFocus(_ focused: Bool) {
+        reportedFocusState = focused
         if sendFocus {
-            let data: [UInt8] = cc.CSI + [focused ? 0x49 : 0x4f]
-            tdel?.send(source: self, data: data[0...])
+            sendFocusReport()
         }
+    }
+
+    func sendFocusReport() {
+        let data: [UInt8] = cc.CSI + [reportedFocusState ? 0x49 : 0x4f]
+        tdel?.send(source: self, data: data[0...])
     }
     
     ///
@@ -4406,6 +4416,10 @@ open class Terminal {
                    // focusin: ^[[I
                    // focusout: ^[[O
                 sendFocus = true
+                // Report the current state right away (xterm behavior), so
+                // the application does not assume it is unfocused until the
+                // first real focus change.
+                sendFocusReport()
             case 1005:
                 // utf8 ext mode mouse
                 mouseProtocol = .utf8

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -5749,7 +5749,6 @@ open class Terminal {
             let isRelease = (buttonFlags & 3) == 3 && (buttonFlags & 32) == 0
             let bflags : Int = isRelease ? (buttonFlags & ~3) : buttonFlags
             let m = isRelease ? "m" : "M"
-            print ("\(pixelX);\(pixelY)")
             sendResponse(cc.CSI, "<\(bflags);\(pixelX);\(pixelY)\(m)")
             
         case .urxvt:

--- a/Tests/SwiftTermTests/FocusReportTests.swift
+++ b/Tests/SwiftTermTests/FocusReportTests.swift
@@ -1,0 +1,61 @@
+//
+//  FocusReportTests.swift
+//
+//  DECSET 1004 focus reporting: enabling reports the current focus state
+//  immediately (xterm behavior), then focus changes report as they happen.
+//
+import Foundation
+import Testing
+
+@testable import SwiftTerm
+
+final class FocusReportTests: TerminalDelegate {
+    var sent: [UInt8] = []
+
+    func send(source: Terminal, data: ArraySlice<UInt8>) {
+        sent.append(contentsOf: data)
+    }
+
+    var sentString: String {
+        String(decoding: sent, as: UTF8.self)
+    }
+
+    func makeTerminal() -> Terminal {
+        Terminal(delegate: self, options: TerminalOptions(cols: 80, rows: 25))
+    }
+
+    @Test func enablingFocusReportingSendsCurrentState() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1004h")
+        #expect(sentString == "\u{1b}[I", "enable while focused reports focus-in immediately")
+
+        sent.removeAll()
+        terminal.setTerminalFocus(false)
+        #expect(sentString == "\u{1b}[O")
+
+        sent.removeAll()
+        terminal.setTerminalFocus(true)
+        #expect(sentString == "\u{1b}[I")
+    }
+
+    @Test func enablingWhileUnfocusedReportsFocusOut() {
+        let terminal = makeTerminal()
+        terminal.setTerminalFocus(false)
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[?1004h")
+        #expect(sentString == "\u{1b}[O", "enable while unfocused reports focus-out immediately")
+    }
+
+    @Test func focusChangesAreSilentWhenReportingDisabled() {
+        let terminal = makeTerminal()
+        terminal.setTerminalFocus(false)
+        terminal.setTerminalFocus(true)
+        #expect(sent.isEmpty)
+
+        terminal.feed(text: "\u{1b}[?1004h")
+        sent.removeAll()
+        terminal.feed(text: "\u{1b}[?1004l")
+        terminal.setTerminalFocus(false)
+        #expect(sent.isEmpty, "no reports after DECRST 1004")
+    }
+}


### PR DESCRIPTION
Split out from #589 as requested — the bug fixes from that branch that are not already on main (the SGR release/motion-flag fix, OSC 52 clipboard delivery, `setTerminalFocus`, and `performFindPanelAction` all landed independently since I branched).

**1. DECSET 1004 reports nothing on enable.** xterm reports the current focus state as soon as an application enables focus reporting; without it, applications that enable 1004 while the terminal is already focused believe they are unfocused until the first real focus change. Concretely: Claude Code gates its Enter handling on focus, so pressing Enter did nothing until you clicked away and back. `Terminal` now tracks the host view's focus (`setTerminalFocus` records it even while reporting is off) and `DECSET 1004` replies with `CSI I`/`CSI O` right away. Covered by new tests (enable focused, enable unfocused, silent when disabled).

**2. Mouse motion events report buffer-absolute rows.** `sendMotion` in the Mac view received `hit.grid.row`, which includes `yDisp`, while the press/release/drag paths already convert to screen rows. Once any scrollback exists, hover-tracking applications receive rows far outside the viewport and their hit-testing never matches (observed as dead hover targets in TUIs with clickable rows).

**3. Stray debug `print` in the SGR-pixel mouse encoder** fires on every event; removed.

Full suite passes (444 tests).