### PR TITLE
Fix Metal renderer crash in packaged apps (Bundle.module fatalErrors)

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -2770,7 +2770,30 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     private static func candidateBundles() -> [Bundle] {
         var bundles: [Bundle] = []
         #if SWIFT_PACKAGE
-        bundles.append(Bundle.module)
+        // Deliberately not `Bundle.module`: SwiftPM's generated accessor for
+        // executable targets calls `fatalError` (aborting the whole process,
+        // not throwing) instead of returning nil when it can't locate
+        // `SwiftTerm_SwiftTerm.bundle`. Its only two candidates are
+        // `Bundle.main.bundleURL` (the .app's *root*, not `Contents/Resources`
+        // where a packaged .app actually puts SwiftPM resource bundles) and
+        // the build machine's absolute `.build/.../SwiftTerm_SwiftTerm.bundle`
+        // path baked into the binary at compile time. That means any app that
+        // bundles this package and ships the resource bundle correctly still
+        // crashes the instant Metal rendering is requested on a machine other
+        // than the one that built it. Probe for the same bundle name
+        // ourselves — mirroring the accessor's own main-bundle-relative
+        // lookup, plus the `Contents/Resources` location it misses — so a
+        // missing bundle falls through to the next candidate instead of
+        // aborting the process.
+        let bundleName = "SwiftTerm_SwiftTerm.bundle"
+        if let url = Bundle.main.resourceURL?.appendingPathComponent(bundleName),
+           let resourceBundle = Bundle(url: url) {
+            bundles.append(resourceBundle)
+        }
+        if let url = Bundle.main.bundleURL.appendingPathComponent(bundleName) as URL?,
+           let resourceBundle = Bundle(url: url) {
+            bundles.append(resourceBundle)
+        }
         #endif
         bundles.append(Bundle(for: MetalTerminalRenderer.self))
         bundles.append(Bundle.main)


### PR DESCRIPTION
Fixes #592.

## Problem

`MetalTerminalRenderer.candidateBundles()` puts `Bundle.module` first when looking for `SwiftTerm_SwiftTerm.bundle`. For an executable target, SwiftPM's generated `Bundle.module` accessor `fatalError`s (aborts the process, doesn't throw/return nil) if it can't find the bundle at either of its two hardcoded candidates:

1. `Bundle.main.bundleURL` — the `.app`'s root, not `Contents/Resources` where a packaged app's build actually has to place an SPM resource bundle to ship it inside a signed `.app` at all.
2. The build machine's absolute `.build/.../SwiftTerm_SwiftTerm.bundle` path, baked into the binary at compile time.

So any app that enables the Metal renderer crashes on every machine except the one that built it — and since the crash happens just from *evaluating* `Bundle.module`, `candidateBundles()`'s other fallback candidates (`Bundle(for:)`, `Bundle.main`) never run.

## Fix

Replace the `Bundle.module` candidate with a manual probe using `Bundle(url:)` — a normal failable initializer, verified to return `nil` for a missing path rather than crashing — checked at:
- `Bundle.main.bundleURL` (matches the generated accessor's own lookup, for bare `swift run` binaries)
- `Bundle.main.resourceURL` (the `Contents/Resources` location a packaged `.app` actually uses, which the generated accessor never checks)

Both are additive probes before the existing `Bundle(for:)`/`Bundle.main` fallbacks, so behavior is unchanged for any environment where the old code didn't crash, and strictly better (an actual chance to find the bundle in a real packaged app) where it did.

## Testing

- `swift build` passes on this branch.
- Verified in isolation that `Bundle(url:)` returns `nil` for a nonexistent path and a working bundle (with resource lookup working) for a real one — the core assumption the fix relies on, unlike `Bundle.module`'s generated accessor.
- Reproduced and worked around the original crash downstream in [Portside](https://github.com/mcglothi/portside) (currently disables the Metal toggle entirely in packaged builds pending this); happy to verify this fix directly against that app's packaging pipeline if useful.