### PR TITLE
Mac: open implicit file-path links instead of failing with paramErr (-50)

### DIFF
--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -156,6 +156,15 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
     open func rangeChanged(source: TerminalView, startY: Int, endY: Int) {
         //
     }
+
+    /// Implementation of the TerminalViewDelegate method. Being a class
+    /// member (unlike the protocol-extension default) it can be overridden
+    /// by subclasses, for example to resolve relative paths against the
+    /// shell's current working directory.
+    open func requestOpenLink (source: TerminalView, link: String, params: [String:String])
+    {
+        TerminalView.openDefaultLink(link)
+    }
     
     /**
      * Launches a child process inside a pseudo-terminal.

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2967,14 +2967,32 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 }
 
 
+extension TerminalView {
+    /// Default handling for a link produced by an explicit hyperlink or by
+    /// implicit detection. Links with a URL scheme open normally; anything
+    /// else is treated as a filesystem path and must go through
+    /// `URL(fileURLWithPath:)` — building a scheme-less URL with
+    /// `URL(string:)` makes Launch Services fail with paramErr (-50), and
+    /// paths containing spaces do not survive `URL(string:)` at all.
+    public static func openDefaultLink (_ link: String)
+    {
+        if let url = URL(string: link), url.scheme != nil {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        let path = NSString(string: link).expandingTildeInPath
+        if FileManager.default.fileExists(atPath: path) {
+            NSWorkspace.shared.open(URL(fileURLWithPath: path))
+        }
+    }
+}
+
 // Default implementations for TerminalViewDelegate
 
 extension TerminalViewDelegate {
     public func requestOpenLink (source: TerminalView, link: String, params: [String:String])
     {
-        if let url = URL(string: link) {
-            NSWorkspace.shared.open(url)
-        }
+        TerminalView.openDefaultLink(link)
     }
     
     public func bell (source: TerminalView)


### PR DESCRIPTION
## Problem

Cmd-clicking an implicitly detected filesystem path (e.g. `/Users/me/file.png`) pops the Finder dialog **"The application can't be opened. -50"**.

The default `requestOpenLink` implementation builds every link with `URL(string:)`. Implicit detection returns raw paths, so this produces a *scheme-less* URL, which Launch Services rejects with `paramErr` (OSStatus -50). Paths containing spaces fail `URL(string:)` outright, so clicking them silently does nothing.

## Change

- Add `TerminalView.openDefaultLink(_:)`: links with a URL scheme open as before; scheme-less links are treated as filesystem paths and opened via `URL(fileURLWithPath:)`, with tilde expansion and an existence check (so nonexistent/relative paths become a no-op instead of an error dialog).
- The `TerminalViewDelegate` protocol-extension default now delegates to that helper.
- `LocalProcessTerminalView` gets a real `open func requestOpenLink` member. The protocol-extension default cannot be overridden from app code (the conformance witness is resolved statically), so embedding apps previously had no way to customize link handling — e.g. to resolve relative paths against the shell's actual cwd. Now subclasses can.

Complements #594 (quoted-path detection): the paths with spaces that #594 starts detecting can only be opened with this fix, though each PR stands on its own.