### PR TITLE
Fix unbounded Metal BufferPool growth under constantly-changing content

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -1719,7 +1719,22 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
 
         private func alignedLength(_ length: Int) -> Int {
-            return ((length + alignment - 1) / alignment) * alignment
+            // Round up to a coarse power-of-two size class. Exact-length
+            // buckets never match again when the number of drawn cells
+            // changes every frame (e.g. htop), so the pool would retain
+            // up to maxBuffersPerSize buffers per distinct length and grow
+            // without bound. Size classes keep the bucket count small and
+            // make recycled buffers actually reusable.
+            let aligned = ((length + alignment - 1) / alignment) * alignment
+            let minimumClass = 4096
+            if aligned <= minimumClass {
+                return minimumClass
+            }
+            var size = minimumClass
+            while size < aligned {
+                size *= 2
+            }
+            return size
         }
 
         private func dequeue(length: Int) -> MTLBuffer? {


### PR DESCRIPTION
## Problem

With the Metal renderer enabled, app memory grows without bound while a program that keeps redrawing with varying content is running in the terminal (`htop`, `tail -f`, build logs). Observed on macOS: **IOAccelerator regions grew from 12 MB to 63 MB in 4 minutes** with a single `htop` session open, and kept climbing. Memory stops growing the moment output stops.

## Root cause

`MetalTerminalRenderer.BufferPool` keys its recycle buckets by the exact 256-byte-aligned buffer length:

```swift
private func alignedLength(_ length: Int) -> Int {
    return ((length + alignment - 1) / alignment) * alignment
}
```

Per-frame vertex buffers (background/glyph/decoration cells) change size almost every frame when the number of drawn cells changes, so nearly every frame allocates a **new** bucket. `maxBuffersPerSize = 4` caps each bucket, but the number of buckets is unbounded — each distinct length permanently retains up to 4 MTLBuffers (~440 KB each at typical window sizes). `vmmap` shows hundreds of IOAccelerator regions in dozens of distinct ~400–480 KB sizes, while the malloc heap stays flat (which is why `leaks` finds nothing).

## Fix

Round requested lengths up to power-of-two size classes (4 KB minimum) before bucketing. This caps the bucket count at ~log2 of the largest buffer size and makes recycled buffers actually reusable. Worst-case per-buffer overhead is 2x, and the pool total plateaus at a few MB.

## Verification

Measured with `footprint`/`vmmap` on the same workload (htop open, ~10 minutes):

| | before | after |
|---|---|---|
| IOAccelerator after 4 min | 63 MB / 209 regions (climbing) | ~3 MB / small fixed set (flat) |
| App footprint | +32 MB per 4 min, unbounded | plateaus, stays flat |

🤖 Generated with [Claude Code](https://claude.com/claude-code)