### PR TITLE
Let subclasses customize link and key handling

### DIFF
--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -129,7 +129,14 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
     public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {
         processDelegate?.hostCurrentDirectoryUpdate(source: source, directory: directory)
     }
-    
+
+    /**
+     * Invoked when the user activates a link, override to handle the link yourself
+     */
+    open func requestOpenLink (source: TerminalView, link: String, params: [String:String])
+    {
+        openLink (link)
+    }
 
     /**
      * This method is invoked when input from the user needs to be sent to the client

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2970,13 +2970,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 // Default implementations for TerminalViewDelegate
 
 extension TerminalViewDelegate {
-    public func requestOpenLink (source: TerminalView, link: String, params: [String:String])
+    /**
+     * Opens the link with the default handler for its scheme
+     */
+    func openLink (_ link: String)
     {
         if let url = URL(string: link) {
             NSWorkspace.shared.open(url)
         }
     }
-    
+
+    public func requestOpenLink (source: TerminalView, link: String, params: [String:String])
+    {
+        openLink (link)
+    }
+
     public func bell (source: TerminalView)
     {
         NSSound.beep()

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -2469,7 +2469,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     /// property in case someone needs the return key to send different sequences.
     public var returnByteSequence: [UInt8] = [13]
     
-    public override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+    open override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         var didHandleEvent = false
         let wasCommandActive = commandActive
         let kittyFlags = terminal.keyboardEnhancementFlags


### PR DESCRIPTION
Two customization points that are currently closed off on open classes.

`requestOpenLink` — `LocalProcessTerminalView` sets `terminalDelegate = self`, so link activation resolves to the `TerminalViewDelegate` protocol extension default. Protocol extension methods are statically dispatched, so a subclass can't override link handling at all — embedders have to swap the delegate out at click time to work around it. This adds an open implementation on the class and extracts the existing open logic into an internal openLink helper called from both, so there's no duplication.

`pressesBegan` (iOS) — `TerminalView` is an open class, but `pressesBegan` is declared public override, preventing subclasses outside the module from customizing hardware keyboard handling (e.g. app-level ⌘-shortcuts over a focused terminal). UIResponder declares it open; this just restores the inherited access level.

No API removals and no behavior change for existing users.