### PR TITLE
Fixed flipped mouse reporting toggle

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSAccessoryView.swift
+++ b/Sources/SwiftTerm/iOS/iOSAccessoryView.swift
@@ -214,7 +214,7 @@ public class TerminalAccessory: UIInputView, UIInputViewAudioFeedback {
         rightViews.append(makeAutoRepeatButton ("arrow.up", #selector(up)))
         rightViews.append(makeAutoRepeatButton ("arrow.right", #selector(right)))
         touchButton = makeButton ("", #selector(toggleTouch), icon: "hand.draw", isNormal: false)
-        touchButton.isSelected = terminalView?.allowMouseReporting ?? false
+        touchButton.isSelected = !(terminalView?.allowMouseReporting ?? false)
         rightViews.append (touchButton)
         keyboardButton = makeButton ("", #selector(toggleInputKeyboard), icon: "keyboard.chevron.compact.down", isNormal: false)
         rightViews.append (keyboardButton)


### PR DESCRIPTION
Mouse reporting toggle color is flipped on initialization.
It starts as blue which **later** spells out as _allows mouse reporting **OFF**_ but mouse reporting starts as **ON**.

| Tap # | `allowMouseReporting` | Highlight (before) | Highlight (after) |
|-------|-----------------------|--------------------|-------------------|
| 0     | on                    | blue ❌            | off ✅            |
| 1     | off                   | blue ✅            | blue ✅           |
| 2     | on                    | off ✅             | off ✅            |
