### PR TITLE
Mac: repaint the rows where screen updates actually land while scrolled back

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1166,12 +1166,33 @@ extension TerminalView {
 
     func invalidateLinkHighlightRow(_ bufferRow: Int)
     {
+        // The highlighted row can live in the scrollback (visible while the
+        // user has scrolled up), which the update-range machinery cannot
+        // express — its rows are relative to the live screen (yBase). Since
+        // the highlight is view state (no buffer line changes), invalidate
+        // the displayed row directly instead.
         let displayBuffer = terminal.displayBuffer
-        let screenRow = bufferRow - displayBuffer.yDisp
-        guard screenRow >= 0 && screenRow < terminal.rows else {
+        let viewRow = bufferRow - displayBuffer.yDisp
+        guard viewRow >= 0 && viewRow < terminal.rows else {
             return
         }
-        terminal.updateRange(borrowing: displayBuffer, screenRow)
+        #if canImport(MetalKit)
+        if metalView != nil {
+            if let current = metalDirtyRange {
+                metalDirtyRange = min (current.lowerBound, bufferRow)...max (current.upperBound, bufferRow)
+            } else {
+                metalDirtyRange = bufferRow...bufferRow
+            }
+            requestMetalDisplay()
+            return
+        }
+        #endif
+        #if os(macOS)
+        let rowY = frame.height - (CGFloat(viewRow) + 1) * cellDimension.height
+        setNeedsDisplay(CGRect (x: 0, y: rowY, width: frame.width, height: cellDimension.height))
+        #else
+        setNeedsDisplay(bounds)
+        #endif
     }
 
     func linkVisibleForClick(match: Terminal.LinkMatch, hasCommandModifier: Bool) -> Bool
@@ -2128,61 +2149,68 @@ extension TerminalView {
         terminal.clearUpdateRange ()
 
         #if os(macOS)
+        // getUpdateRange() reports rows of the live screen (relative to yBase),
+        // but the view displays rows starting at yDisp. When the user has
+        // scrolled back (yDisp < yBase) the changed rows appear (yBase - yDisp)
+        // rows lower in the view — or below the viewport entirely — so translate
+        // them into view rows before invalidating. Invalidating the untranslated
+        // rows repaints unchanged scrollback while the changed rows stay stale
+        // until something forces a full redraw (such as scrolling to the bottom).
         let displayBuffer = terminal.displayBuffer
-        var redrawStart = rowStart
-        var redrawEnd = rowEnd
+        let scrollbackOffset = displayBuffer.yBase - displayBuffer.yDisp
+        var viewStart: Int
+        var viewEnd: Int
         var absoluteDependencyRange: ClosedRange<Int>?
+        if rowStart <= 0 && rowEnd >= terminal.rows - 1 {
+            // A full-screen refresh (updateFullScreen / refresh of every row)
+            // means "repaint everything visible" regardless of scroll position.
+            viewStart = 0
+            viewEnd = terminal.rows - 1
+        } else {
+            viewStart = max (0, rowStart + scrollbackOffset)
+            viewEnd = min (rowEnd + scrollbackOffset, terminal.rows - 1)
+        }
         if !displayBuffer.lines.isEmpty,
            rowStart >= 0, rowEnd >= rowStart, rowEnd < terminal.rows {
+            // A bidi paragraph is shaped as a unit, so a change can alter how the
+            // rows around it render; widen the repaint to the paragraph's
+            // dependency range. That range is in absolute buffer rows, and the
+            // rows that changed belong to the live screen — yBase-relative, not
+            // yDisp-relative, which agree only at the bottom of the scrollback.
             let maxRow = displayBuffer.lines.count - 1
-            let absoluteStart = max(0, min(displayBuffer.yDisp + rowStart, maxRow))
+            let absoluteStart = max(0, min(displayBuffer.yBase + rowStart, maxRow))
             let absoluteEnd = max(absoluteStart,
-                                  min(displayBuffer.yDisp + rowEnd, maxRow))
+                                  min(displayBuffer.yBase + rowEnd, maxRow))
             let dependencies = TerminalBidi.renderingDependencyRange(
                 rows: absoluteStart...absoluteEnd,
                 buffer: displayBuffer,
                 maximumRows: terminal.options.maximumBidiParagraphRows)
             absoluteDependencyRange = dependencies
-            redrawStart = max(0, dependencies.lowerBound - displayBuffer.yDisp)
-            redrawEnd = min(terminal.rows - 1,
-                            dependencies.upperBound - displayBuffer.yDisp)
+            viewStart = max (0, min (viewStart, dependencies.lowerBound - displayBuffer.yDisp))
+            viewEnd = min (terminal.rows - 1, max (viewEnd, dependencies.upperBound - displayBuffer.yDisp))
         }
-        let baseLine = frame.height
-        var region: CGRect
-        // `rowStart`/`rowEnd` come from the terminal's update range, which is recorded
-        // in `buffer.y` space (relative to `yBase`, the live screen). The rect below
-        // maps them to the screen as if row `y` were screen row `y`, but
-        // drawTerminalContents maps screen rects back to buffer rows via `yDisp`.
-        // Those two agree only while the viewport is pinned to the bottom. Once the
-        // user scrolls back by `k` rows, the cells that changed are drawn at screen
-        // row `y + k` while the invalidation still covers screen row `y`, so the rows
-        // that actually changed are never repainted and keep stale pixels until
-        // something forces a full redraw. Invalidate everything in that case; the
-        // draw still only repaints rows intersecting the dirty rect and reads each
-        // from its correct `yDisp`-relative buffer line.
-        if displayBuffer.yDisp != displayBuffer.yBase {
-            region = CGRect (x: 0, y: 0, width: frame.width, height: frame.height)
-        } else {
-            region = CGRect (x: 0,
-                             y: baseLine - (cellDimension.height + CGFloat(redrawEnd) * cellDimension.height),
-                             width: frame.width,
-                             height: CGFloat(redrawEnd-redrawStart + 1) * cellDimension.height)
+        var region: CGRect? = nil
+        if viewStart <= viewEnd {
+            let baseLine = frame.height
+            var dirty = CGRect (x: 0,
+                                y: baseLine - (cellDimension.height + CGFloat(viewEnd) * cellDimension.height),
+                                width: frame.width,
+                                height: CGFloat(viewEnd-viewStart + 1) * cellDimension.height)
 
             // If we are the last line, we should also queue a refresh for the "remaining" bits at the
             // end which can be redrawn by large unicode
-            if redrawEnd == terminal.rows - 1 {
-                let oh = region.height
-                let oy = region.origin.y
-                region = CGRect (x: 0, y: 0, width: frame.width, height: oh + oy)
+            if viewEnd == terminal.rows - 1 {
+                dirty = CGRect (x: 0, y: 0, width: frame.width, height: dirty.maxY)
             } else {
                 // Region ends mid-screen (a restricted DECSTBM region): extend the
                 // invalidation down by one cell so the sub-cell remainder just below the
                 // band's bottom row (descenders / tall unicode) is cleared too. Previously
                 // only rowEnd == rows-1 got this, leaving a one-row ghost below the region.
                 let extra = cellDimension.height
-                let newY = max (0, region.origin.y - extra)
-                region = CGRect (x: 0, y: newY, width: frame.width, height: region.maxY - newY)
+                let newY = max (0, dirty.origin.y - extra)
+                dirty = CGRect (x: 0, y: newY, width: frame.width, height: dirty.maxY - newY)
             }
+            region = dirty
         }
 #if canImport(MetalKit)
         if metalView != nil {
@@ -2196,8 +2224,10 @@ extension TerminalView {
                 let visibleStart = buffer.yDisp
                 let visibleEnd = min(maxRow, buffer.yDisp + buffer.rows - 1)
                 if rowStart >= 0 && rowEnd >= rowStart && rowEnd < terminal.rows {
-                    let absStart = buffer.yDisp + rowStart
-                    let absEnd = buffer.yDisp + rowEnd
+                    // Update-range rows are relative to the live screen (yBase),
+                    // not to the scrolled viewport (yDisp).
+                    let absStart = buffer.yBase + rowStart
+                    let absEnd = buffer.yBase + rowEnd
                     let clampedStart = max(0, min(absStart, maxRow))
                     let clampedEnd = max(0, min(absEnd, maxRow))
                     if clampedStart <= clampedEnd {
@@ -2215,11 +2245,13 @@ extension TerminalView {
             }
             lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
             requestMetalDisplay()
-        } else {
+        } else if let region {
             setNeedsDisplay(region)
         }
 #else
-        setNeedsDisplay(region)
+        if let region {
+            setNeedsDisplay(region)
+        }
 #endif
         #else
         // TODO iOS: need to update the code above, but will do that when I get some real

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1178,11 +1178,7 @@ extension TerminalView {
         }
         #if canImport(MetalKit)
         if metalView != nil {
-            if let current = metalDirtyRange {
-                metalDirtyRange = min (current.lowerBound, bufferRow)...max (current.upperBound, bufferRow)
-            } else {
-                metalDirtyRange = bufferRow...bufferRow
-            }
+            addMetalDirtyRows (bufferRow...bufferRow)
             requestMetalDisplay()
             return
         }
@@ -2160,7 +2156,6 @@ extension TerminalView {
         let scrollbackOffset = displayBuffer.yBase - displayBuffer.yDisp
         var viewStart: Int
         var viewEnd: Int
-        var absoluteDependencyRange: ClosedRange<Int>?
         if rowStart <= 0 && rowEnd >= terminal.rows - 1 {
             // A full-screen refresh (updateFullScreen / refresh of every row)
             // means "repaint everything visible" regardless of scroll position.
@@ -2185,7 +2180,6 @@ extension TerminalView {
                 rows: absoluteStart...absoluteEnd,
                 buffer: displayBuffer,
                 maximumRows: terminal.options.maximumBidiParagraphRows)
-            absoluteDependencyRange = dependencies
             viewStart = max (0, min (viewStart, dependencies.lowerBound - displayBuffer.yDisp))
             viewEnd = min (terminal.rows - 1, max (viewEnd, dependencies.upperBound - displayBuffer.yDisp))
         }
@@ -2215,32 +2209,18 @@ extension TerminalView {
 #if canImport(MetalKit)
         if metalView != nil {
             let buffer = displayBuffer
-            if buffer.lines.count == 0 {
-                metalDirtyRange = nil
-            } else if let absoluteDependencyRange {
-                metalDirtyRange = absoluteDependencyRange
-            } else {
+            // The renderer indexes absolute buffer rows, so translate the view
+            // rows computed above (they start at yDisp) rather than the raw
+            // update range: that way both paths agree on where the changed rows
+            // are displayed, on the bidi dependency expansion, on treating a
+            // full-screen refresh as "everything visible", and on leaving rows
+            // below the viewport alone.
+            if viewStart <= viewEnd && buffer.lines.count > 0 {
                 let maxRow = buffer.lines.count - 1
-                let visibleStart = buffer.yDisp
-                let visibleEnd = min(maxRow, buffer.yDisp + buffer.rows - 1)
-                if rowStart >= 0 && rowEnd >= rowStart && rowEnd < terminal.rows {
-                    // Update-range rows are relative to the live screen (yBase),
-                    // not to the scrolled viewport (yDisp).
-                    let absStart = buffer.yBase + rowStart
-                    let absEnd = buffer.yBase + rowEnd
-                    let clampedStart = max(0, min(absStart, maxRow))
-                    let clampedEnd = max(0, min(absEnd, maxRow))
-                    if clampedStart <= clampedEnd {
-                        metalDirtyRange = clampedStart...clampedEnd
-                    } else if visibleStart <= visibleEnd {
-                        metalDirtyRange = visibleStart...visibleEnd
-                    } else {
-                        metalDirtyRange = nil
-                    }
-                } else if visibleStart <= visibleEnd {
-                    metalDirtyRange = visibleStart...visibleEnd
-                } else {
-                    metalDirtyRange = nil
+                let absStart = min (buffer.yDisp + viewStart, maxRow)
+                let absEnd = min (buffer.yDisp + viewEnd, maxRow)
+                if absStart <= absEnd {
+                    addMetalDirtyRows (absStart...absEnd)
                 }
             }
             lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
@@ -2258,7 +2238,9 @@ extension TerminalView {
         // life data being fed into it.
         #if canImport(MetalKit)
         if metalView != nil {
-            metalDirtyRange = metalVisibleRange()
+            if let visible = metalVisibleRange() {
+                addMetalDirtyRows (visible)
+            }
             let buffer = terminal.displayBuffer
             lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
             requestMetalDisplay()
@@ -2362,6 +2344,22 @@ extension TerminalView {
     }
 
 #if canImport(MetalKit)
+    /// Adds rows to the pending Metal dirty range instead of replacing it.
+    ///
+    /// The renderer consumes and clears the range when it draws, and drawing
+    /// happens on a later run-loop pass, so several invalidations can pile up
+    /// between frames — a link highlight and a screen update, say. Replacing
+    /// the range drops the earlier one, and a lost link-highlight row is not
+    /// recoverable: highlights are view state, so the buffer line's generation
+    /// does not change and the renderer keeps its cached row.
+    func addMetalDirtyRows (_ range: ClosedRange<Int>) {
+        if let current = metalDirtyRange {
+            metalDirtyRange = min (current.lowerBound, range.lowerBound)...max (current.upperBound, range.upperBound)
+        } else {
+            metalDirtyRange = range
+        }
+    }
+
     func requestMetalDisplay() {
         guard let metalView = metalView else {
             return

--- a/Tests/SwiftTermTests/ScrollbackRefreshRegionTests.swift
+++ b/Tests/SwiftTermTests/ScrollbackRefreshRegionTests.swift
@@ -1,0 +1,130 @@
+//
+//  ScrollbackRefreshRegionTests.swift
+//  SwiftTerm
+//
+//  Regression tests for the dirty-region math in updateDisplay: the update
+//  range reported by the terminal is relative to the live screen (yBase),
+//  while the view displays rows starting at yDisp. When the user has
+//  scrolled back, the invalidated rect must follow the rows to where they
+//  are actually displayed, otherwise newly echoed output stays invisible
+//  until something forces a full redraw.
+//
+
+#if os(macOS)
+import Foundation
+import Testing
+import AppKit
+@testable import SwiftTerm
+
+/// Records every rect passed to `setNeedsDisplay(_:)` so tests can assert
+/// which parts of the view an update actually invalidated.
+final class InvalidationRecordingTerminalView: TerminalView {
+    var recordedRects: [CGRect] = []
+
+    override func setNeedsDisplay(_ invalidRect: NSRect) {
+        recordedRects.append(invalidRect)
+        super.setNeedsDisplay(invalidRect)
+    }
+}
+
+final class ScrollbackRefreshRegionTests {
+
+    /// Builds a terminal view whose buffer has plenty of scrollback and whose
+    /// display is at the bottom (yDisp == yBase).
+    private func makeView() -> (InvalidationRecordingTerminalView, Terminal) {
+        let frame = CGRect(x: 0, y: 0, width: 400, height: 200)
+        let view = InvalidationRecordingTerminalView(frame: frame)
+        view.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let terminal = view.getTerminal()
+        for i in 0..<(terminal.rows + 30) {
+            view.feed(text: "line \(i)\r\n")
+        }
+        return (view, terminal)
+    }
+
+    /// Center of the given view row (0 = top of the viewport) in view
+    /// coordinates, suitable for containment checks against dirty rects.
+    private func midpoint(ofViewRow row: Int, in view: TerminalView) -> CGPoint {
+        CGPoint(x: view.frame.width / 2,
+                y: view.frame.height - (CGFloat(row) + 0.5) * view.cellDimension.height)
+    }
+
+    private func covered(_ rects: [CGRect], _ point: CGPoint) -> Bool {
+        rects.contains { $0.contains(point) }
+    }
+
+    /// Scrolled to the bottom, the update range maps 1:1 onto view rows —
+    /// the pre-existing behavior must not change.
+    @Test func testInvalidationAtBottomIsUntranslated() {
+        let (view, terminal) = makeView()
+        let buffer = terminal.buffer
+        #expect(terminal.rows > 8)
+        #expect(buffer.yBase > 5)
+        #expect(buffer.yDisp == buffer.yBase)
+
+        terminal.clearUpdateRange()
+        view.recordedRects.removeAll()
+        terminal.updateRange(3)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(covered(view.recordedRects, midpoint(ofViewRow: 3, in: view)))
+    }
+
+    /// The core regression: with the view scrolled back N rows, a change on
+    /// live-screen row r is displayed on view row r + N, and that is the row
+    /// that must be invalidated — not view row r, which shows unchanged
+    /// scrollback.
+    @Test func testInvalidationFollowsRowsWhenScrolledBack() {
+        let (view, terminal) = makeView()
+        let buffer = terminal.buffer
+        let scrollOffset = 2
+        view.scrollTo(row: buffer.yBase - scrollOffset, notifyAccessibility: false)
+        #expect(buffer.yDisp == buffer.yBase - scrollOffset)
+
+        terminal.clearUpdateRange()
+        view.recordedRects.removeAll()
+        terminal.updateRange(3)
+        view.updateDisplay(notifyAccessibility: false)
+
+        // The changed row is displayed scrollOffset rows lower.
+        #expect(covered(view.recordedRects, midpoint(ofViewRow: 3 + scrollOffset, in: view)))
+        // The untranslated position shows unchanged scrollback; repainting it
+        // instead of the real row is exactly the bug this guards against.
+        #expect(!covered(view.recordedRects, midpoint(ofViewRow: 3, in: view)))
+    }
+
+    /// A change on a live-screen row that has been pushed below the viewport
+    /// by scrolling back must not invalidate anything: nothing visible
+    /// changed, and scrolling back down repaints the whole view anyway.
+    @Test func testRowsBelowViewportAreSkippedWhenScrolledBack() {
+        let (view, terminal) = makeView()
+        let buffer = terminal.buffer
+        view.scrollTo(row: buffer.yBase - 5, notifyAccessibility: false)
+
+        terminal.clearUpdateRange()
+        view.recordedRects.removeAll()
+        terminal.updateRange(terminal.rows - 1)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(view.recordedRects.isEmpty)
+    }
+
+    /// A full-screen refresh means "repaint everything visible", so it must
+    /// cover the whole viewport even while scrolled back (updateFullScreen and
+    /// friends are used for palette changes and the like, which also affect
+    /// the visible scrollback).
+    @Test func testFullScreenRefreshCoversViewportWhenScrolledBack() {
+        let (view, terminal) = makeView()
+        let buffer = terminal.buffer
+        view.scrollTo(row: buffer.yBase - 2, notifyAccessibility: false)
+
+        terminal.clearUpdateRange()
+        view.recordedRects.removeAll()
+        terminal.refresh(startRow: 0, endRow: terminal.rows - 1)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(covered(view.recordedRects, midpoint(ofViewRow: 0, in: view)))
+        #expect(covered(view.recordedRects, midpoint(ofViewRow: terminal.rows - 1, in: view)))
+    }
+}
+#endif

--- a/Tests/SwiftTermTests/ScrollbackRefreshRegionTests.swift
+++ b/Tests/SwiftTermTests/ScrollbackRefreshRegionTests.swift
@@ -127,4 +127,109 @@ final class ScrollbackRefreshRegionTests {
         #expect(covered(view.recordedRects, midpoint(ofViewRow: terminal.rows - 1, in: view)))
     }
 }
+
+#if canImport(MetalKit)
+import MetalKit
+
+/// The Metal renderer rebuilds a row when it falls in `metalDirtyRange` or when
+/// the buffer line's generation changed, so the range has to describe the same
+/// rows the CoreGraphics path invalidates — and it must not drop invalidations
+/// that are still waiting for the next frame.
+@MainActor
+final class MetalScrollbackDirtyRangeTests {
+
+    /// Builds a view whose buffer has plenty of scrollback and whose display is
+    /// at the bottom, with an MTKView attached so `updateDisplay` takes the
+    /// Metal path.
+    ///
+    /// The view is deliberately attached directly rather than through
+    /// `setUseMetal(true)`: the dirty-range bookkeeping under test never draws,
+    /// so no device, renderer or shader library is needed, and the test stays
+    /// hermetic on machines and CI runners without a usable GPU.
+    private func makeMetalView() -> (TerminalView, Terminal) {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
+        view.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let terminal = view.getTerminal()
+        for i in 0..<(terminal.rows + 30) {
+            view.feed(text: "line \(i)\r\n")
+        }
+        view.metalView = MTKView(frame: view.bounds, device: nil)
+        return (view, terminal)
+    }
+
+    private func visibleRange(_ terminal: Terminal) -> ClosedRange<Int> {
+        let buffer = terminal.buffer
+        return buffer.yDisp...min(buffer.lines.count - 1, buffer.yDisp + buffer.rows - 1)
+    }
+
+    /// A change on live-screen row r is displayed (yBase - yDisp) rows lower, so
+    /// the dirty row is yBase + r — not yDisp + r, which is what the renderer
+    /// used to be told.
+    @Test func testDirtyRangeFollowsLiveScreenRowsWhenScrolledBack() {
+        let (view, terminal) = makeMetalView()
+        let buffer = terminal.buffer
+        view.scrollTo(row: buffer.yBase - 2, notifyAccessibility: false)
+
+        terminal.clearUpdateRange()
+        view.metalDirtyRange = nil
+        terminal.updateRange(3)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(view.metalDirtyRange == (buffer.yBase + 3)...(buffer.yBase + 3))
+    }
+
+    /// A full-screen refresh means "repaint everything visible" — translating it
+    /// from yBase would leave the visible scrollback rows above yBase stale for
+    /// changes that do not bump the line generation, such as a palette change.
+    @Test func testFullScreenRefreshCoversVisibleRangeWhenScrolledBack() {
+        let (view, terminal) = makeMetalView()
+        let buffer = terminal.buffer
+        view.scrollTo(row: buffer.yBase - 2, notifyAccessibility: false)
+
+        terminal.clearUpdateRange()
+        view.metalDirtyRange = nil
+        terminal.refresh(startRow: 0, endRow: terminal.rows - 1)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(view.metalDirtyRange == visibleRange(terminal))
+    }
+
+    /// Rows pushed below the viewport by scrolling back changed nothing visible,
+    /// so they must not add dirty rows.
+    @Test func testRowsBelowViewportAddNothingWhenScrolledBack() {
+        let (view, terminal) = makeMetalView()
+        let buffer = terminal.buffer
+        view.scrollTo(row: buffer.yBase - 5, notifyAccessibility: false)
+
+        terminal.clearUpdateRange()
+        view.metalDirtyRange = nil
+        terminal.updateRange(terminal.rows - 1)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(view.metalDirtyRange == nil)
+    }
+
+    /// The renderer clears the dirty range when it draws, and drawing happens on
+    /// a later run-loop pass, so a link-highlight row queued in between must
+    /// survive an intervening screen update: the highlight leaves the line
+    /// generation untouched, so a lost row stays stale on screen.
+    @Test func testPendingLinkHighlightRowSurvivesScreenUpdate() {
+        let (view, terminal) = makeMetalView()
+        let buffer = terminal.buffer
+        let highlightRow = buffer.yDisp + 1
+
+        view.metalDirtyRange = nil
+        view.invalidateLinkHighlightRow(highlightRow)
+        #expect(view.metalDirtyRange?.contains(highlightRow) == true)
+
+        // A screen update somewhere else must not discard the queued row.
+        terminal.clearUpdateRange()
+        terminal.updateRange(terminal.rows - 1)
+        view.updateDisplay(notifyAccessibility: false)
+
+        #expect(view.metalDirtyRange?.contains(highlightRow) == true)
+        #expect(view.metalDirtyRange?.contains(buffer.yBase + terminal.rows - 1) == true)
+    }
+}
+#endif
 #endif


### PR DESCRIPTION
Rebased on top of #620, which fixed the CoreGraphics half of this while the PR was open by invalidating the whole view when `yDisp != yBase`.

What this changes:

- **CG**: invalidate the rows the change actually lands on instead of the whole view. Rows below the viewport invalidate nothing; a full-screen refresh still covers everything visible.
- **Metal**: the dirty range used `yDisp + row` where the absolute row is `yBase + row`. Now derived from the same view rows as the CG path, so the full-screen rule matches too — it was marking `31...43` dirty for a visible `29...41`.
- **Bidi** (new since I opened this): `renderingDependencyRange` is asked about `yDisp + rowStart`, the same conflation a third time. Now `yBase`-relative, unioned into the view rows so both paths inherit it.
- **`metalDirtyRange` was replaced, not merged**, so a link-highlight row queued before the renderer drew was dropped. Highlights don't bump the line generation, so the renderer's cache check can't recover it.
- **`invalidateLinkHighlightRow`** no longer routes through `updateRange`, which can't express a scrollback row at all.

8 tests, 4 per path. The Metal ones attach a bare `MTKView(device: nil)` instead of calling `setUseMetal(true)` — the range bookkeeping never draws, so no GPU is needed and they actually run on CI. Gating on a real device makes them silently skip under `swift test`: the shader bundle sits next to the `.xctest` bundle, which `candidateBundles()` doesn't probe, so `setUseMetal(true)` throws `shaderSourceMissing`.

#620's test passes unchanged. Full suite (690 tests) passes, iOS builds.
