### PR TITLE
Expose BufferLine.isWrapped as public read-only

### DIFF
--- a/Sources/SwiftTerm/BufferLine.swift
+++ b/Sources/SwiftTerm/BufferLine.swift
@@ -21,7 +21,9 @@ public final class BufferLine: CustomDebugStringConvertible {
         /// Renders the bottom of a character, using two cells
         case doubledDown
     }
-    var isWrapped: Bool
+    /// True when this line is a continuation of the previous line: the text
+    /// soft-wrapped onto it rather than starting after an explicit newline.
+    public internal(set) var isWrapped: Bool
     var renderMode: RenderLineMode = .single
     private var data: UnsafeMutableBufferPointer<CharData>
     private var dataSize: Int


### PR DESCRIPTION
Embedders that reconstruct logical lines from the buffer — e.g. to copy soft-wrapped text without injecting hard newlines at wrap boundaries — need to know whether a row is a continuation of the previous one. SwiftTerm already tracks this exactly in `BufferLine.isWrapped`, but the property is internal, so consumers are forced into text heuristics that provably fail when a wrap boundary lands on a space (a trailing space is indistinguishable from grid padding).

This PR makes the getter public while keeping the setter internal (`public internal(set)`), so external code can read the ground truth without being able to corrupt buffer state. No behavior change; one property + doc comment.

Context: found while fixing dirty multiline copy in a macOS terminal app built on SwiftTerm; we're temporarily shipping a fork with this change and would love to unpin.