### PR TITLE
Render Powerline separators as cell-aligned geometry

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -81,6 +81,7 @@ struct ViewLineInfo {
     var kittyPlaceholders: [KittyPlaceholderCell]
     var blockElements: [BlockElementRenderItem]
     var boxDrawings: [BoxDrawingRenderItem]
+    var powerlineGlyphs: [PowerlineRenderItem]
 }
 
 /// How to place a single glyph within its `columnWidth`-cell slot.
@@ -695,6 +696,7 @@ extension TerminalView {
         var previousPlaceholderAttribute: Attribute?
         var blockElements: [BlockElementRenderItem] = []
         var boxDrawings: [BoxDrawingRenderItem] = []
+        var powerlineGlyphs: [PowerlineRenderItem] = []
         
         // Batching state: accumulate consecutive characters with the same attributes
         var pendingText = ""
@@ -764,9 +766,22 @@ extension TerminalView {
 
             let character = ch.code == 0 ? " " : terminal.getCharacter(for: ch)
 
+            // Render Powerline separators independently of the font so their
+            // joining edge shares the background's exact pixel boundary.
+            if PowerlineRenderer.shouldRender(codePoint: UInt32(ch.code),
+                                              customGlyphsEnabled: customBlockGlyphs) {
+                flushPending()
+                let fgColor = (currentAttributes[.foregroundColor] as? TTColor) ?? nativeForegroundColor
+                powerlineGlyphs.append(PowerlineRenderItem(column: col,
+                                                           columnWidth: width,
+                                                           codePoint: UInt32(ch.code),
+                                                           foregroundColor: fgColor))
+                builder?.append(text: " ", attributes: currentAttributes)
+                previousPlaceholder = nil
+                previousPlaceholderAttribute = nil
             // Renders box drawing characters independently of the font
             // U+2500...U+257F
-            if customBlockGlyphs,
+            } else if customBlockGlyphs,
                ch.code >= BoxDrawingRenderer.lowerBoundary,
                ch.code <= BoxDrawingRenderer.upperBoundary {
                 flushPending()
@@ -828,7 +843,8 @@ extension TerminalView {
                             images: line.images,
                             kittyPlaceholders: kittyPlaceholders,
                             blockElements: blockElements,
-                            boxDrawings: boxDrawings)
+                            boxDrawings: boxDrawings,
+                            powerlineGlyphs: powerlineGlyphs)
     }
 
     func shouldUnderlineLink(row: Int, column: Int, width: Int, cell: CharData) -> Bool
@@ -1250,6 +1266,32 @@ extension TerminalView {
         context.restoreGState()
     }
 
+    private func drawPowerlineGlyphs(_ items: [PowerlineRenderItem],
+                                     lineOrigin: CGPoint,
+                                     renderMode: BufferLine.RenderLineMode,
+                                     in context: CGContext) {
+        guard !items.isEmpty else { return }
+        let scale = backingScaleFactor()
+        let scaleX = renderMode == .single ? scale : scale * 2
+        let scaleY: CGFloat
+        switch renderMode {
+        case .doubledDown, .doubledTop: scaleY = scale * 2
+        case .single, .doubleWidth: scaleY = scale
+        }
+        for item in items {
+            let cellRect = CGRect(x: lineOrigin.x + CGFloat(item.column) * cellDimension.width,
+                                  y: lineOrigin.y,
+                                  width: CGFloat(item.columnWidth) * cellDimension.width,
+                                  height: cellDimension.height)
+            PowerlineRenderer.draw(codePoint: item.codePoint,
+                                   in: context,
+                                   cellRect: cellRect,
+                                   scaleX: scaleX,
+                                   scaleY: scaleY,
+                                   color: item.foregroundColor.cgColor)
+        }
+    }
+
     
     // TODO: this should not render any lines outside the dirtyRect
     func drawTerminalContents (dirtyRect: TTRect, context: CGContext, bufferOffset: Int)
@@ -1497,6 +1539,13 @@ extension TerminalView {
 
             if !lineInfo.blockElements.isEmpty {
                 drawBlockElements(lineInfo.blockElements, lineOrigin: lineOrigin, in: context)
+            }
+
+            if !lineInfo.powerlineGlyphs.isEmpty {
+                drawPowerlineGlyphs(lineInfo.powerlineGlyphs,
+                                    lineOrigin: lineOrigin,
+                                    renderMode: renderMode,
+                                    in: context)
             }
 
             context.setShouldAntialias(true)

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -48,6 +48,18 @@ extension CaretView {
         }
         let caretFG = caretTextColor ?? terminal.nativeForegroundColor
         context.setFillColor(caretFG.cgColor)
+        if let powerlineCodePoint,
+           PowerlineRenderer.shouldRender(codePoint: powerlineCodePoint,
+                                          customGlyphsEnabled: terminal.customBlockGlyphs) {
+            PowerlineRenderer.draw(codePoint: powerlineCodePoint,
+                                   in: context,
+                                   cellRect: bounds,
+                                   scaleX: terminal.backingScaleFactor(),
+                                   scaleY: terminal.backingScaleFactor(),
+                                   color: caretFG.cgColor)
+            context.restoreGState()
+            return
+        }
         for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
             let runGlyphsCount = CTRunGetGlyphCount(run)
             let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -69,6 +69,7 @@ struct ImageDrawBuffer {
 
 struct RowDrawData {
     var backgroundCells: [ColorCell]
+    var powerlineJoinCells: [ColorCell]
     var glyphCellsGray: [TextCell]
     var glyphCellsColor: [TextCell]
     var decorationCells: [ColorCell]
@@ -81,6 +82,8 @@ struct RowDrawData {
 struct RowDrawBuffers {
     var backgroundBuffer: MTLBuffer?
     var backgroundCount: Int
+    var powerlineJoinBuffer: MTLBuffer?
+    var powerlineJoinCount: Int
     var glyphGrayBuffer: MTLBuffer?
     var glyphGrayCount: Int
     var glyphColorBuffer: MTLBuffer?
@@ -102,6 +105,7 @@ struct RowCacheEntry {
 
 struct FrameDrawData {
     var backgroundCells: [ColorCell]
+    var powerlineJoinCells: [ColorCell]
     var glyphCellsGray: [TextCell]
     var glyphCellsColor: [TextCell]
     var decorationCells: [ColorCell]
@@ -450,6 +454,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                           viewport: viewport)
 
             drawVertexBuffers(rows: rows,
+                              bufferKey: \.powerlineJoinBuffer,
+                              countKey: \.powerlineJoinCount,
+                              pipeline: cellColorPipeline,
+                              texture: nil,
+                              encoder: encoder,
+                              viewport: viewport)
+
+            drawVertexBuffers(rows: rows,
                               bufferKey: \.glyphGrayBuffer,
                               countKey: \.glyphGrayCount,
                               pipeline: cellTextGrayPipeline,
@@ -671,6 +683,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         var frameData: FrameDrawData?
         if bufferingMode == .perFrameAggregated {
             frameData = FrameDrawData(backgroundCells: [],
+                                      powerlineJoinCells: [],
                                       glyphCellsGray: [],
                                       glyphCellsColor: [],
                                       decorationCells: [],
@@ -768,6 +781,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             if bufferingMode == .perFrameAggregated {
                 if var currentFrame = frameData {
                     currentFrame.backgroundCells.append(contentsOf: rowData.backgroundCells)
+                    currentFrame.powerlineJoinCells.append(contentsOf: rowData.powerlineJoinCells)
                     currentFrame.glyphCellsGray.append(contentsOf: rowData.glyphCellsGray)
                     currentFrame.glyphCellsColor.append(contentsOf: rowData.glyphCellsColor)
                     currentFrame.decorationCells.append(contentsOf: rowData.decorationCells)
@@ -854,6 +868,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                   virtualPlacementsByImageId: [UInt32: [KittyPlacementRecord]]) -> RowDrawData {
         guard let terminalView = terminalView else {
             return RowDrawData(backgroundCells: [],
+                               powerlineJoinCells: [],
                                glyphCellsGray: [],
                                glyphCellsColor: [],
                                decorationCells: [],
@@ -864,6 +879,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
         if row < 0 || row >= buffer.lines.count {
             return RowDrawData(backgroundCells: [],
+                               powerlineJoinCells: [],
                                glyphCellsGray: [],
                                glyphCellsColor: [],
                                decorationCells: [],
@@ -874,6 +890,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
 
         var backgroundCells: [ColorCell] = []
+        var powerlineJoinCells: [ColorCell] = []
         var glyphCellsGray: [TextCell] = []
         var glyphCellsColor: [TextCell] = []
         var decorationCells: [ColorCell] = []
@@ -919,7 +936,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let underlineThickness = max(round(scale * terminalView.fontSet.underlineThickness()) / scale, 0.5)
         let decorationCellWidth = ceil(cellWidth)
 
-        if !lineInfo.boxDrawings.isEmpty || !lineInfo.blockElements.isEmpty {
+        if !lineInfo.boxDrawings.isEmpty || !lineInfo.blockElements.isEmpty || !lineInfo.powerlineGlyphs.isEmpty {
             let boxThicknessScale: CGFloat = 1.35
             let minThicknessPx = max(1, Int(round(scale)))
             let baseThicknessPx = max(minThicknessPx,
@@ -1011,6 +1028,61 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                                        u1: clipped.u1,
                                                        v1: clipped.v1,
                                                        color: color))
+                }
+            }
+
+            for item in lineInfo.powerlineGlyphs {
+                let itemWidthPx = baseCellWidthPx * item.columnWidth
+                guard let entry = customGlyphEntry(codePoint: item.codePoint,
+                                                   cellWidthPx: itemWidthPx,
+                                                   cellHeightPx: baseCellHeightPx,
+                                                   scale: scale,
+                                                   baseThicknessPx: 0,
+                                                   antiAlias: true) else {
+                    continue
+                }
+                let atlasSize = Float(grayscaleAtlas.size)
+                let u0 = Float(entry.region.x) / atlasSize
+                let v0 = Float(entry.region.y) / atlasSize
+                let u1 = Float(entry.region.x + entry.region.width) / atlasSize
+                let v1 = Float(entry.region.y + entry.region.height) / atlasSize
+                let alignedOriginX = round(lineOriginPx.x) + CGFloat(item.column * baseCellWidthPx)
+                let alignedOriginY = round(lineOriginPx.y)
+                let x0 = alignedOriginX
+                let y0 = alignedOriginY
+                let x1 = x0 + entry.size.width
+                let y1 = y0 + entry.size.height
+                let (tx0, ty0, tx1, ty1) = transformRect(x0: x0, y0: y0, x1: x1, y1: y1)
+                if let clipped = self.clipRect(tx0, ty0, tx1, ty1, u0, v0, u1, v1, clipRect) {
+                    let color = colorToSIMD(item.foregroundColor)
+                    glyphCellsGray.append(makeTextCell(x0: clipped.x0,
+                                                       y0: clipped.y0,
+                                                       x1: clipped.x1,
+                                                       y1: clipped.y1,
+                                                       u0: clipped.u0,
+                                                       v0: clipped.v0,
+                                                       u1: clipped.u1,
+                                                       v1: clipped.v1,
+                                                       color: color))
+                }
+                // Add the joining edge after the DEC line transform so it is
+                // exactly one final device pixel even for 2x line modes.
+                let transformedCellRect = CGRect(x: CGFloat(min(tx0, tx1)),
+                                                 y: CGFloat(min(ty0, ty1)),
+                                                 width: CGFloat(abs(tx1 - tx0)),
+                                                 height: CGFloat(abs(ty1 - ty0)))
+                if let joinRect = PowerlineRenderer.devicePixelJoinRect(codePoint: item.codePoint,
+                                                                        transformedCellRect: transformedCellRect),
+                   let clippedJoin = self.clipRect(Float(joinRect.minX),
+                                                   Float(joinRect.minY),
+                                                   Float(joinRect.maxX),
+                                                   Float(joinRect.maxY),
+                                                   clipRect) {
+                    powerlineJoinCells.append(makeColorCell(x0: clippedJoin.0,
+                                                            y0: clippedJoin.1,
+                                                            x1: clippedJoin.2,
+                                                            y1: clippedJoin.3,
+                                                            color: colorToSIMD(item.foregroundColor)))
                 }
             }
         }
@@ -1419,6 +1491,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
 
         return RowDrawData(backgroundCells: backgroundCells,
+                           powerlineJoinCells: powerlineJoinCells,
                            glyphCellsGray: glyphCellsGray,
                            glyphCellsColor: glyphCellsColor,
                            decorationCells: decorationCells,
@@ -1605,6 +1678,21 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             let cellOrigin = CGPoint.zero
 
             switch codePoint {
+            case let value where PowerlineRenderer.glyph(for: value) != nil:
+                context.setShouldAntialias(true)
+                context.setAllowsAntialiasing(true)
+                context.scaleBy(x: scale, y: scale)
+                PowerlineRenderer.draw(codePoint: codePoint,
+                                       in: context,
+                                       cellRect: CGRect(x: 0,
+                                                        y: 0,
+                                                        width: cellSize.width,
+                                                        height: cellSize.height),
+                                       scaleX: scale,
+                                       scaleY: scale,
+                                       color: TTColor.white.cgColor,
+                                       includeJoinOverdraw: false)
+                return true
             case UInt32(BoxDrawingRenderer.lowerBoundary)...UInt32(BoxDrawingRenderer.upperBoundary):
                 context.setShouldAntialias(false)
                 context.setAllowsAntialiasing(false)
@@ -1971,11 +2059,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
     private func makeRowBuffers(from data: RowDrawData) -> RowDrawBuffers {
         let (backgroundBuffer, backgroundCount) = makeStaticBuffer(data.backgroundCells)
+        let (powerlineJoinBuffer, powerlineJoinCount) = makeStaticBuffer(data.powerlineJoinCells)
         let (glyphGrayBuffer, glyphGrayCount) = makeStaticBuffer(data.glyphCellsGray)
         let (glyphColorBuffer, glyphColorCount) = makeStaticBuffer(data.glyphCellsColor)
         let (decorationBuffer, decorationCount) = makeStaticBuffer(data.decorationCells)
         return RowDrawBuffers(backgroundBuffer: backgroundBuffer,
                               backgroundCount: backgroundCount,
+                              powerlineJoinBuffer: powerlineJoinBuffer,
+                              powerlineJoinCount: powerlineJoinCount,
                               glyphGrayBuffer: glyphGrayBuffer,
                               glyphGrayCount: glyphGrayCount,
                               glyphColorBuffer: glyphColorBuffer,
@@ -2015,6 +2106,12 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                        viewport: viewport)
 
         drawImageBatches(frame.underImageDraws, encoder: encoder, viewport: viewport)
+
+        drawCellBuffer(frame.powerlineJoinCells,
+                       pipeline: cellColorPipeline,
+                       texture: nil,
+                       encoder: encoder,
+                       viewport: viewport)
 
         drawCellBuffer(frame.glyphCellsGray,
                        pipeline: cellTextGrayPipeline,
@@ -2228,6 +2325,40 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
         let charData = buffer.lines[cursorRow][buffer.x]
         let caretTextColor = terminalView.caretTextColor ?? terminalView.nativeForegroundColor
+        if PowerlineRenderer.shouldRender(codePoint: UInt32(charData.code),
+                                          customGlyphsEnabled: terminalView.customBlockGlyphs) {
+            let cursorCellWidthPx = max(1, Int(round(cellWidthPx * doublePosition * cursorColumnWidth)))
+            let cursorCellHeightPx = max(1, Int(round(cellHeightPx)))
+            if let entry = customGlyphEntry(codePoint: UInt32(charData.code),
+                                            cellWidthPx: cursorCellWidthPx,
+                                            cellHeightPx: cursorCellHeightPx,
+                                            scale: scale,
+                                            baseThicknessPx: 0,
+                                            antiAlias: true) {
+                let atlasSize = Float(grayscaleAtlas.size)
+                let u0 = Float(entry.region.x) / atlasSize
+                let v0 = Float(entry.region.y) / atlasSize
+                let u1 = Float(entry.region.x + entry.region.width) / atlasSize
+                let v1 = Float(entry.region.y + entry.region.height) / atlasSize
+                let glyphX0 = Float(x0)
+                let glyphY0 = Float(y0)
+                let glyphX1 = glyphX0 + Float(entry.size.width)
+                let glyphY1 = glyphY0 + Float(entry.size.height)
+                if let clipped = self.clipRect(glyphX0, glyphY0, glyphX1, glyphY1,
+                                               u0, v0, u1, v1, cursorClip) {
+                    glyphVerticesGray.append(contentsOf: glyphQuadVertices(x0: clipped.x0,
+                                                                           y0: clipped.y0,
+                                                                           x1: clipped.x1,
+                                                                           y1: clipped.y1,
+                                                                           u0: clipped.u0,
+                                                                           v0: clipped.v0,
+                                                                           u1: clipped.u1,
+                                                                           v1: clipped.v1,
+                                                                           color: colorToSIMD(caretTextColor)))
+                }
+            }
+            return (colorVertices, glyphVerticesGray, glyphVerticesColor)
+        }
         let attributes = terminalView.getAttributedValue(charData.attribute,
                                                          usingFg: terminalView.caretColor,
                                                          andBg: caretTextColor) ?? [.font: terminalView.fontSet.normal]

--- a/Sources/SwiftTerm/Apple/PowerlineRenderer.swift
+++ b/Sources/SwiftTerm/Apple/PowerlineRenderer.swift
@@ -1,0 +1,125 @@
+#if os(macOS) || os(iOS) || os(visionOS)
+import CoreGraphics
+import Foundation
+
+/// Cell-aligned rendering for the four Powerline separators used by prompts.
+///
+/// Font glyphs are deliberately not used here: their antialiased outline can
+/// land between the terminal's pixel-aligned background cells and expose a
+/// seam.  These shapes share the cell grid with the background renderer and
+/// extend only their joining edge by one physical pixel.
+enum PowerlineRenderer {
+    enum Direction: Equatable {
+        case left
+        case right
+    }
+
+    enum Shape: Equatable {
+        case triangle
+        case rounded
+    }
+
+    struct Glyph {
+        let direction: Direction
+        let shape: Shape
+    }
+
+    static func glyph(for codePoint: UInt32) -> Glyph? {
+        switch codePoint {
+        case 0xE0B0: return Glyph(direction: .right, shape: .triangle)
+        case 0xE0B2: return Glyph(direction: .left, shape: .triangle)
+        case 0xE0B4: return Glyph(direction: .right, shape: .rounded)
+        case 0xE0B6: return Glyph(direction: .left, shape: .rounded)
+        default: return nil
+        }
+    }
+
+    static func shouldRender(codePoint: UInt32, customGlyphsEnabled: Bool) -> Bool {
+        customGlyphsEnabled && glyph(for: codePoint) != nil
+    }
+
+    /// Returns the in-cell shape with all cell boundaries snapped to pixels.
+    static func path(codePoint: UInt32, cellRect: CGRect, scaleX: CGFloat, scaleY: CGFloat) -> CGPath? {
+        guard let glyph = glyph(for: codePoint), scaleX > 0, scaleY > 0 else { return nil }
+        let minX = (cellRect.minX * scaleX).rounded(.down) / scaleX
+        let maxX = (cellRect.maxX * scaleX).rounded(.up) / scaleX
+        let minY = (cellRect.minY * scaleY).rounded(.down) / scaleY
+        let maxY = (cellRect.maxY * scaleY).rounded(.up) / scaleY
+        let midY = ((minY + maxY) * scaleY / 2).rounded() / scaleY
+        let joinX = glyph.direction == .right ? minX : maxX
+        let outerX = glyph.direction == .right ? maxX : minX
+
+        let path = CGMutablePath()
+        switch glyph.shape {
+        case .triangle:
+            path.move(to: CGPoint(x: joinX, y: minY))
+            path.addLine(to: CGPoint(x: outerX, y: midY))
+            path.addLine(to: CGPoint(x: joinX, y: maxY))
+            path.closeSubpath()
+        case .rounded:
+            path.move(to: CGPoint(x: joinX, y: minY))
+            // A half ellipse from the flat edge's top to its bottom.  The
+            // 4/3 control distance makes the curve reach `outerX` at mid-cell.
+            let radiusX = abs(outerX - joinX)
+            let controlX = glyph.direction == .right
+                ? joinX + (4.0 / 3.0) * radiusX
+                : joinX - (4.0 / 3.0) * radiusX
+            path.addCurve(to: CGPoint(x: joinX, y: maxY),
+                          control1: CGPoint(x: controlX, y: minY),
+                          control2: CGPoint(x: controlX, y: maxY))
+            path.closeSubpath()
+        }
+        return path
+    }
+
+    /// A one-device-pixel strip adjoining the flat edge of a cell that has
+    /// already been transformed into device-pixel coordinates.
+    static func devicePixelJoinRect(codePoint: UInt32, transformedCellRect: CGRect) -> CGRect? {
+        guard let glyph = glyph(for: codePoint) else { return nil }
+        let minX = min(transformedCellRect.minX, transformedCellRect.maxX)
+        let maxX = max(transformedCellRect.minX, transformedCellRect.maxX)
+        return glyph.direction == .right
+            ? CGRect(x: minX - 1, y: transformedCellRect.minY, width: 1, height: transformedCellRect.height)
+            : CGRect(x: maxX, y: transformedCellRect.minY, width: 1, height: transformedCellRect.height)
+    }
+
+    static func draw(codePoint: UInt32,
+                     in context: CGContext,
+                     cellRect: CGRect,
+                     scaleX: CGFloat,
+                     scaleY: CGFloat,
+                     color: CGColor,
+                     includeJoinOverdraw: Bool = true) {
+        guard let path = path(codePoint: codePoint, cellRect: cellRect, scaleX: scaleX, scaleY: scaleY) else { return }
+        guard let glyph = glyph(for: codePoint) else { return }
+        let pixel = 1 / scaleX
+        let minX = (cellRect.minX * scaleX).rounded(.down) / scaleX
+        let maxX = (cellRect.maxX * scaleX).rounded(.up) / scaleX
+        let minY = (cellRect.minY * scaleY).rounded(.down) / scaleY
+        let maxY = (cellRect.maxY * scaleY).rounded(.up) / scaleY
+        let joinRect = glyph.direction == .right
+            ? CGRect(x: minX - pixel, y: minY, width: pixel, height: maxY - minY)
+            : CGRect(x: maxX, y: minY, width: pixel, height: maxY - minY)
+        context.saveGState()
+        context.setFillColor(color)
+        if includeJoinOverdraw {
+            context.setShouldAntialias(false)
+            context.setAllowsAntialiasing(false)
+            context.fill(joinRect)
+        }
+        context.setShouldAntialias(true)
+        context.setAllowsAntialiasing(true)
+        context.setFillColor(color)
+        context.addPath(path)
+        context.fillPath()
+        context.restoreGState()
+    }
+}
+
+struct PowerlineRenderItem {
+    let column: Int
+    let columnWidth: Int
+    let codePoint: UInt32
+    let foregroundColor: TTColor
+}
+#endif

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -21,6 +21,7 @@ class CaretView: NSView, CALayerDelegate {
     /// Cell width of the character currently under the caret (2 for full-width
     /// CJK). Used to center its glyph within the caret, matching the text.
     var glyphColumnWidth: Int = 1
+    var powerlineCodePoint: UInt32?
     var bgColor: CGColor
     var tracksFocus = true
     
@@ -49,6 +50,7 @@ class CaretView: NSView, CALayerDelegate {
     
     func setText (ch: CharData) {
         glyphColumnWidth = max(1, Int(ch.width))
+        powerlineCodePoint = PowerlineRenderer.glyph(for: UInt32(ch.code)) == nil ? nil : UInt32(ch.code)
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
             string: UnicodeUtil.textPresentationAdjusted (character),

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -19,6 +19,7 @@ class CaretView: UIView {
     /// Cell width of the character currently under the caret (2 for full-width
     /// CJK). Used to center its glyph within the caret, matching the text.
     var glyphColumnWidth: Int = 1
+    var powerlineCodePoint: UInt32?
     var bgColor: CGColor
     var tracksFocus = true
     
@@ -82,6 +83,7 @@ class CaretView: UIView {
     
     func setText (ch: CharData) {
         glyphColumnWidth = max(1, Int(ch.width))
+        powerlineCodePoint = PowerlineRenderer.glyph(for: UInt32(ch.code)) == nil ? nil : UInt32(ch.code)
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
             string: UnicodeUtil.textPresentationAdjusted (character),

--- a/Tests/SwiftTermTests/PowerlineRendererTests.swift
+++ b/Tests/SwiftTermTests/PowerlineRendererTests.swift
@@ -1,0 +1,158 @@
+#if os(macOS)
+import CoreGraphics
+import XCTest
+@testable import SwiftTerm
+
+final class PowerlineRendererTests: XCTestCase {
+    func testMapsSupportedPowerlineGlyphsAndRejectsOtherPrivateUseCharacters() throws {
+        let rightTriangle = try XCTUnwrap(PowerlineRenderer.glyph(for: 0xE0B0))
+        XCTAssertEqual(rightTriangle.direction, .right)
+        XCTAssertEqual(rightTriangle.shape, .triangle)
+        let leftTriangle = try XCTUnwrap(PowerlineRenderer.glyph(for: 0xE0B2))
+        XCTAssertEqual(leftTriangle.direction, .left)
+        XCTAssertEqual(leftTriangle.shape, .triangle)
+        let rightRounded = try XCTUnwrap(PowerlineRenderer.glyph(for: 0xE0B4))
+        XCTAssertEqual(rightRounded.direction, .right)
+        XCTAssertEqual(rightRounded.shape, .rounded)
+        let leftRounded = try XCTUnwrap(PowerlineRenderer.glyph(for: 0xE0B6))
+        XCTAssertEqual(leftRounded.direction, .left)
+        XCTAssertEqual(leftRounded.shape, .rounded)
+        XCTAssertNil(PowerlineRenderer.glyph(for: 0xE0B1))
+        XCTAssertNil(PowerlineRenderer.glyph(for: 0xE0B3))
+        XCTAssertNil(PowerlineRenderer.glyph(for: 0xE0B5))
+        XCTAssertNil(PowerlineRenderer.glyph(for: 0xE0B7))
+        XCTAssertNil(PowerlineRenderer.glyph(for: 0xE0C0))
+    }
+
+    func testCustomGlyphSettingControlsPowerlineRendering() {
+        XCTAssertTrue(PowerlineRenderer.shouldRender(codePoint: 0xE0B0, customGlyphsEnabled: true))
+        XCTAssertFalse(PowerlineRenderer.shouldRender(codePoint: 0xE0B0, customGlyphsEnabled: false))
+        XCTAssertFalse(PowerlineRenderer.shouldRender(codePoint: 0xE0C0, customGlyphsEnabled: true))
+    }
+
+    func testTriangleDirectionsAndJoinOverdrawAtTwoAndThreeX() throws {
+        for scale in [2, 3] {
+            let right = try bitmap(codePoint: 0xE0B0, scale: scale)
+            let left = try bitmap(codePoint: 0xE0B2, scale: scale)
+            assertTriangle(right, direction: .right)
+            assertTriangle(left, direction: .left)
+            assertHasAntialiasedEdge(right)
+            assertHasAntialiasedEdge(left)
+            assertJoinOverdraw(right, direction: .right)
+            assertJoinOverdraw(left, direction: .left)
+        }
+    }
+
+    func testRoundedDirectionsAndJoinOverdrawAtTwoAndThreeX() throws {
+        for scale in [2, 3] {
+            let right = try bitmap(codePoint: 0xE0B4, scale: scale)
+            let left = try bitmap(codePoint: 0xE0B6, scale: scale)
+            assertRounded(right, direction: .right)
+            assertRounded(left, direction: .left)
+            assertHasAntialiasedEdge(right)
+            assertHasAntialiasedEdge(left)
+            assertJoinOverdraw(right, direction: .right)
+            assertJoinOverdraw(left, direction: .left)
+        }
+    }
+
+    func testJoinOverdrawRemainsOneDevicePixelAfterDoubleWidthTransform() throws {
+        for scale in [2, 3] {
+            let right = try bitmap(codePoint: 0xE0B0, scale: scale, horizontalTransform: 2)
+            let left = try bitmap(codePoint: 0xE0B2, scale: scale, horizontalTransform: 2)
+            assertJoinOverdraw(right, direction: .right)
+            assertJoinOverdraw(left, direction: .left)
+        }
+
+        let transformedCell = CGRect(x: 20, y: 10, width: 32, height: 48)
+        let rightMetalJoin = try XCTUnwrap(PowerlineRenderer.devicePixelJoinRect(codePoint: 0xE0B0,
+                                                                                 transformedCellRect: transformedCell))
+        XCTAssertEqual(rightMetalJoin, CGRect(x: 19, y: 10, width: 1, height: 48))
+        let leftMetalJoin = try XCTUnwrap(PowerlineRenderer.devicePixelJoinRect(codePoint: 0xE0B2,
+                                                                                transformedCellRect: transformedCell))
+        XCTAssertEqual(leftMetalJoin, CGRect(x: 52, y: 10, width: 1, height: 48))
+    }
+
+    private enum Direction { case left, right }
+
+    private struct Bitmap {
+        let width: Int
+        let height: Int
+        let cellMinX: Int
+        let cellMaxX: Int
+        let alpha: [UInt8]
+
+        subscript(_ x: Int, _ y: Int) -> UInt8 { alpha[y * width + x] }
+    }
+
+    private func bitmap(codePoint: UInt32, scale: Int, horizontalTransform: Int = 1) throws -> Bitmap {
+        let cellWidth = 8 * scale * horizontalTransform
+        let cellHeight = 12 * scale
+        let width = cellWidth + 2
+        var pixels = Array(repeating: UInt8(0), count: width * cellHeight * 4)
+        let created = pixels.withUnsafeMutableBytes { raw -> Bool in
+            guard let base = raw.baseAddress,
+                  let context = CGContext(data: base,
+                                          width: width,
+                                          height: cellHeight,
+                                          bitsPerComponent: 8,
+                                          bytesPerRow: width * 4,
+                                          space: CGColorSpaceCreateDeviceRGB(),
+                                          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return false }
+            let scaleX = CGFloat(scale * horizontalTransform)
+            context.scaleBy(x: scaleX, y: CGFloat(scale))
+            let rect = CGRect(x: 1.0 / scaleX,
+                              y: 0,
+                              width: 8,
+                              height: CGFloat(cellHeight) / CGFloat(scale))
+            PowerlineRenderer.draw(codePoint: codePoint,
+                                   in: context,
+                                   cellRect: rect,
+                                   scaleX: scaleX,
+                                   scaleY: CGFloat(scale),
+                                   color: CGColor(gray: 1, alpha: 1))
+            return true
+        }
+        XCTAssertTrue(created)
+        var alpha = Array(repeating: UInt8(0), count: width * cellHeight)
+        for index in alpha.indices { alpha[index] = pixels[index * 4 + 3] }
+        return Bitmap(width: width, height: cellHeight, cellMinX: 1, cellMaxX: 1 + cellWidth, alpha: alpha)
+    }
+
+    private func assertTriangle(_ bitmap: Bitmap, direction: Direction, file: StaticString = #filePath, line: UInt = #line) {
+        let midY = bitmap.height / 2
+        let outerX = direction == .right ? bitmap.cellMaxX - 1 : bitmap.cellMinX
+        XCTAssertGreaterThan(bitmap[outerX, midY], 0, file: file, line: line)
+        XCTAssertLessThan(bitmap[outerX, midY], 255, file: file, line: line)
+        XCTAssertLessThan(bitmap[outerX, 0], 32, file: file, line: line)
+        XCTAssertLessThan(bitmap[outerX, bitmap.height - 1], 32, file: file, line: line)
+    }
+
+    private func assertRounded(_ bitmap: Bitmap, direction: Direction, file: StaticString = #filePath, line: UInt = #line) {
+        let midY = bitmap.height / 2
+        let outerX = direction == .right ? bitmap.cellMaxX - 1 : bitmap.cellMinX
+        XCTAssertGreaterThan(bitmap[outerX, midY], 128, file: file, line: line)
+        XCTAssertLessThan(bitmap[outerX, 0], 32, file: file, line: line)
+    }
+
+    private func assertJoinOverdraw(_ bitmap: Bitmap, direction: Direction, file: StaticString = #filePath, line: UInt = #line) {
+        let joinX = direction == .right ? bitmap.cellMinX - 1 : bitmap.cellMaxX
+        for y in 0..<bitmap.height {
+            XCTAssertEqual(bitmap[joinX, y], 255, "join edge must cover exactly one adjacent physical pixel", file: file, line: line)
+        }
+        let beyondJoinX = direction == .right ? joinX - 1 : joinX + 1
+        if beyondJoinX >= 0 && beyondJoinX < bitmap.width {
+            for y in 0..<bitmap.height {
+                XCTAssertEqual(bitmap[beyondJoinX, y], 0, "renderer must not overdraw beyond one physical pixel", file: file, line: line)
+            }
+        }
+    }
+
+    private func assertHasAntialiasedEdge(_ bitmap: Bitmap, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(bitmap.alpha.contains(where: { $0 > 0 && $0 < 255 }),
+                      "sloped and rounded outer edges should remain antialiased",
+                      file: file,
+                      line: line)
+    }
+}
+#endif


### PR DESCRIPTION
## What changed

- custom-render `U+E0B0`, `U+E0B2`, `U+E0B4`, and `U+E0B6` when `customBlockGlyphs` is enabled
- share normalized separator geometry across CoreGraphics and Metal
- preserve resolved foreground colors for selection, inverse, and dim states
- render Powerline glyphs correctly under block cursors and DEC double-width/double-height line modes
- add one-device-pixel join overdraw to prevent seams without vertical cell overflow

## Why

Powerline separators rendered through Core Text can cover one physical pixel outside the terminal cell while the cell background remains pixel-aligned. This produces visible steps at the top or bottom of Starship and Powerline segments, and font-outline changes do not reliably solve it across fonts, sizes, scales, and rendering backends.

Treating these cell-joining symbols as terminal graphics primitives makes their bounds deterministic and follows the same approach already used for box drawing and block elements.

## Validation

- `swift test --filter PowerlineRendererTests`: 5 tests, 0 failures
- `swift test`: 59 XCTest tests and 452 Swift Testing tests, 0 failures
- verified CoreGraphics and Metal code paths
- verified iOS/macOS block cursor paths
- verified 2x/3x geometry and DEC double-width join behavior
- real iPhone 17 Pro Simulator at 3x over Docker SSH, fish, Starship 1.26.0, and the official Gruvbox Rainbow preset
- before: separator solid-color bounds were 61 physical pixels high while the segment cell was 60 pixels
- after: all six sampled segment colors were exactly 60 physical pixels high
