### PR TITLE
decode Kitty placeholder IDs in RGB order

### DIFF
--- a/Sources/SwiftTerm/KittyPlaceholder.swift
+++ b/Sources/SwiftTerm/KittyPlaceholder.swift
@@ -107,7 +107,7 @@ enum KittyPlaceholderDecoder {
         case .ansi256(let code):
             return UInt32(code)
         case .trueColor(let red, let green, let blue):
-            return UInt32(red) | (UInt32(green) << 8) | (UInt32(blue) << 16)
+            return (UInt32(red) << 16) | (UInt32(green) << 8) | UInt32(blue)
         case .defaultColor, .defaultInvertedColor:
             return 0
         }

--- a/Tests/SwiftTermTests/KittyUnicodeTests.swift
+++ b/Tests/SwiftTermTests/KittyUnicodeTests.swift
@@ -259,6 +259,39 @@ final class KittyUnicodeTests {
         #expect(runs[0].placeholderCol == 0)
     }
 
+    @Test func testUnicodePlacementTrueColorIdsUseRGBByteOrder() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: TerminalOptions(cols: 5, rows: 5)) { _ in }
+        let t = h.terminal!
+        t.feed(text: "\u{1b}[38;2;66;172;138m\u{1b}[58;2;17;34;51m\u{10EEEE}\u{0305}\u{0305}")
+        let runs = placeholderRuns(in: t)
+        #expect(runs.count == 1)
+        #expect(runs[0].imageId == 0x42AC8A)
+        #expect(runs[0].placementId == 0x112233)
+    }
+
+    @Test func testUnicodePlacementTrueColorIdComposesWithHighByteDiacritic() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: TerminalOptions(cols: 5, rows: 5)) { _ in }
+        let t = h.terminal!
+        t.feed(text: "\u{1b}[38;2;66;172;138m\u{10EEEE}\u{0305}\u{0305}\u{030E}")
+        let runs = placeholderRuns(in: t)
+        #expect(runs.count == 1)
+        #expect(runs[0].imageId == 0x0242AC8A)
+    }
+
+    @Test func testUnicodePlacementTrueColorMatchesTransmittedImageAndPlacementIds() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: TerminalOptions(cols: 5, rows: 5)) { _ in }
+        let t = h.terminal!
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg=="
+        t.feed(text: "\u{1b}_Ga=T,f=100,t=d,i=4369546,p=1122867,U=1,c=1,r=1,q=2;\(png)\u{1b}\\")
+        t.feed(text: "\u{1b}[38;2;66;172;138m\u{1b}[58;2;17;34;51m\u{10EEEE}\u{0305}\u{0305}")
+
+        let runs = placeholderRuns(in: t)
+        #expect(t.kittyGraphicsState.imagesById[0x42AC8A] != nil)
+        #expect(runs.count == 1)
+        #expect(runs[0].imageId == 0x42AC8A)
+        #expect(runs[0].placementId == 0x112233)
+    }
+
     @Test func testUnicodeRenderPlacementDog4x2() {
         let placement = KittyPlaceholderRenderPlacement.compute(imageSize: CGSize(width: 500, height: 306),
                                                                 placementCols: 4,


### PR DESCRIPTION
Kitty Unicode placeholders encode truecolor image and placement IDs in RGB byte order. Decoding them in reverse stores the transmitted PNG under one ID while placeholder cells look up another, leaving correctly-sized blank regions.

## What
- Decode truecolor placeholder IDs as `(red << 16) | (green << 8) | blue`.
- Cover asymmetric image/placement IDs, high-byte composition, and transmitted-image lookup.

## Tests
The full SwiftTerm suite passes (436 tests), including a golden case captured from Copilot CLI: APC ID `0x42AC8A` with placeholder RGB `42 AC 8A`.
