### PR TITLE
Share one VT500 transition table across parsers; clamp oversized CSI/DCS/OSC params

### DIFF
--- a/Sources/SwiftTerm/EscapeSequenceParser.swift
+++ b/Sources/SwiftTerm/EscapeSequenceParser.swift
@@ -87,7 +87,7 @@ enum ParserAction : UInt8 {
 class TransitionTable {
     // data is packed like this:
     // currentState << 8 | characterCode  -->  action << 4 | nextState
-    var table: [UInt8]
+    private(set) var table: [UInt8]
     
     init (len: Int)
     {
@@ -341,12 +341,13 @@ public class EscapeSequenceParser {
     var printHandler: PrintHandler = { (slice : ArraySlice<UInt8>) -> () in }
     var printStateReset: () -> () = {  }
     
-    var table: TransitionTable
+    private static let sharedVt500Table: TransitionTable = EscapeSequenceParser.buildVt500TransitionTable()
+    let table: TransitionTable
     
     init (terminal: Terminal? = nil)
     {
         self.terminal = terminal
-        table = EscapeSequenceParser.buildVt500TransitionTable()
+        table = EscapeSequenceParser.sharedVt500Table
         _osc = []
         _apc = []
         _pars = [0]

--- a/Sources/SwiftTerm/EscapeSequenceParser.swift
+++ b/Sources/SwiftTerm/EscapeSequenceParser.swift
@@ -342,6 +342,7 @@ public class EscapeSequenceParser {
     var printStateReset: () -> () = {  }
     
     private static let sharedVt500Table: TransitionTable = EscapeSequenceParser.buildVt500TransitionTable()
+    static let maximumParameterValue = Int(UInt16.max)
     let table: TransitionTable
     
     init (terminal: Terminal? = nil)
@@ -353,6 +354,15 @@ public class EscapeSequenceParser {
         _pars = [0]
         _parsTxt = []
         _collect = []
+    }
+
+    @inline(__always)
+    private static func appendingParameterDigit(_ code: UInt8, to currentValue: Int) -> Int {
+        let digit = Int(code) - 48
+        if currentValue > (maximumParameterValue - digit) / 10 {
+            return maximumParameterValue
+        }
+        return currentValue * 10 + digit
     }
 
     // MARK: - Dispatch Methods
@@ -669,11 +679,7 @@ public class EscapeSequenceParser {
             
             // shortcut for CSI params
             if currentState == .csiParam && (code > 0x2f && code < 0x3a) {
-                let newV = pars [pars.count - 1] * 10 + Int(code) - 48
-                
-                // Prevent attempts at overflowing - crash 
-                let willOverflow =  newV > ((Int.max/10)-10)
-                pars [pars.count - 1] = willOverflow ? 0 : newV
+                pars [pars.count - 1] = EscapeSequenceParser.appendingParameterDigit(code, to: pars [pars.count - 1])
                 i += 1
                 continue
             }
@@ -746,11 +752,7 @@ public class EscapeSequenceParser {
                     parsTxt.append(code)
                     pars.append (0)
                 } else {
-                    let newV = pars [pars.count - 1] * 10 + Int(code) - 48
-
-                    // Prevent attempts at overflowing - crash
-                    let willOverflow =  newV > ((Int.max/10)-10)
-                    pars [pars.count - 1] = willOverflow ? 0 : newV
+                    pars [pars.count - 1] = EscapeSequenceParser.appendingParameterDigit(code, to: pars [pars.count - 1])
                 }
             case .escDispatch:
                 dispatchEsc(collect: collect, code: code)
@@ -886,13 +888,8 @@ public class EscapeSequenceParser {
             if x < 48 || x > 57 {
                 return result
             }
-            
-            let newV = result * 10 + Int ((x - 48))
-            let willOverflow =  newV > ((Int.max/10)-10)
-            if willOverflow {
-                return 0
-            }
-            result = newV
+
+           result = appendingParameterDigit(x, to: result)
         }
         return result
     }

--- a/Tests/SwiftTermTests/CsiParameterParsingTests.swift
+++ b/Tests/SwiftTermTests/CsiParameterParsingTests.swift
@@ -275,4 +275,30 @@ final class CsiParameterParsingTests {
         terminal.feed(text: "\(esc)[;H")
         TerminalTestHarness.assertCursor(terminal.buffer, col: 0, row: 0)
     }
+
+    @Test func testIntegerOverflowParamClampsCursorDownFromNonZeroPosition() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal(cols: 80, rows: 24)
+        terminal.feed(text: "\(esc)[10;10H")
+        terminal.feed(text: "\(esc)[999999999999999999999999999999B")
+        TerminalTestHarness.assertCursor(terminal.buffer, col: 9, row: 23)
+    }
+
+    @Test func testIntegerOverflowParamClampsCursorForwardFromNonZeroPosition() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal(cols: 80, rows: 24)
+        terminal.feed(text: "\(esc)[10;10H")
+        terminal.feed(text: "\(esc)[999999999999999999999999999999C")
+        TerminalTestHarness.assertCursor(terminal.buffer, col: 79, row: 9)
+    }
+
+    @Test func testDcsIntegerOverflowParamIsBounded() {
+        let parser = EscapeSequenceParser()
+        let sequence = Array("\(esc)P999999999999999999999999999999".utf8)
+        parser.parse(data: sequence[...])
+        #expect(parser._pars == [EscapeSequenceParser.maximumParameterValue])
+    }
+
+    @Test func testOscIntegerOverflowParamIsBounded() {
+        let digits = Array("999999999999999999999999999999".utf8)
+        #expect(EscapeSequenceParser.parseInt(digits[...]) == EscapeSequenceParser.maximumParameterValue)
+    }
 }


### PR DESCRIPTION
Two related hardening changes to `EscapeSequenceParser`.

### 1. Reuse a single VT500 transition table across parser instances
The VT500 transition table is immutable once built, but a fresh copy was constructed for every parser instance. Build it once as a static and share it — cheaper parser creation, less allocation.

### 2. Clamp oversized CSI/DCS/OSC numeric parameters instead of resetting to zero
Numeric parameter parsing computed `pars[last] * 10 + digit` and, once the running value crossed an overflow guard, silently reset the whole parameter to `0`. Because the accumulator was reset before it could grow large enough to overflow the multiply, this never actually trapped — but it did turn legitimately huge values (e.g. a crafted sequence like `\x1b[99999999999999999999999m`) into `0` instead of "very large".

The new `appendingParameterDigit` checks *before* multiplying and clamps to `UInt16.max` (the largest value the parser ever needs) on overflow — matching xterm's behavior of capping oversized parameters. Applied to the CSI param shortcut, the DCS/APC accumulator, and `parseInt` (OSC).

### Testing
Added `CsiParameterParsingTests`. Full suite green (456 tests).
