### PR TITLE
Avoid force-casting CTRun font/color attributes

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1515,7 +1515,7 @@ extension TerminalView {
                         continue
                     }
                     let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
-                    let runFont = runAttributes[.font] as! TTFont
+                    let runFont = (runAttributes[.font] as? TTFont) ?? fontSet.normal
                     let startColumn = prepared.segment.column + (processedGlyphs * prepared.segment.columnWidth)
 
                     let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
@@ -1537,8 +1537,7 @@ extension TerminalView {
 
                     nativeForegroundColor.setFill()
 
-                    if runAttributes.keys.contains(.foregroundColor) {
-                        let color = runAttributes[.foregroundColor] as! TTColor
+                    if let color = runAttributes[.foregroundColor] as? TTColor {
                         color.setFill()
                     }
 

--- a/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Sources/SwiftTerm/Apple/CaretView.swift
@@ -51,7 +51,7 @@ extension CaretView {
         for run in CTLineGetGlyphRuns(ctline) as? [CTRun] ?? [] {
             let runGlyphsCount = CTRunGetGlyphCount(run)
             let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
-            let runFont = runAttributes[.font] as! TTFont
+            let runFont = (runAttributes[.font] as? TTFont) ?? terminal.fontSet.normal
             let ctRunFont = runFont as CTFont
 
             let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in


### PR DESCRIPTION
Reading font and foreground-color attributes out of a `CTRun`'s attribute dictionary used force-casts (`as!`), which crash if an attribute is missing or has an unexpected type.

Use conditional casts (`as?`) with sensible fallbacks instead, so an unexpected attribute dictionary degrades gracefully rather than crashing. Touches `AppleTerminalView` and `CaretView`.

### Testing
Full suite green (452 tests).
