### PR TITLE
Let SwiftTerm cross-compile from macOS to Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,10 +3,17 @@
 import PackageDescription
 import Foundation
 
+// A package manifest is compiled and run on the HOST, so `os(Linux)` is false
+// when cross-compiling from macOS to Linux — and the Apple/Mac/iOS sources are
+// then handed to the Linux target, which fails on `import CoreText`. There is
+// no way for a manifest to see the destination, so allow the exclude to be
+// forced explicitly.
+let excludeAppleSources =
+    ProcessInfo.processInfo.environment["SWIFTTERM_EXCLUDE_APPLE"] == "1"
 #if os(Linux) || os(Windows)
 let platformExcludes = ["Apple", "Mac", "iOS"]
 #else
-let platformExcludes: [String] = []
+let platformExcludes: [String] = excludeAppleSources ? ["Apple", "Mac", "iOS"] : []
 #endif
 
 let isGitHubActions = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"

--- a/Sources/SwiftTerm/KittyGraphics.swift
+++ b/Sources/SwiftTerm/KittyGraphics.swift
@@ -5,7 +5,11 @@
 //
 
 import Foundation
-#if os(Linux)
+#if canImport(Musl)
+// The Swift Static Linux SDK builds against musl, where the C library module
+// is `Musl` and `Glibc` does not exist.
+import Musl
+#elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)
 import WinSDK


### PR DESCRIPTION
Two independent blockers hit when building with the [Swift Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html) from macOS:

```
swift build --swift-sdk x86_64-swift-linux-musl
```

Neither changes behaviour on macOS, iOS, native Linux or Windows.

### 1. The Apple/Mac/iOS excludes don't apply when cross-compiling

`Package.swift` excludes those directories behind `#if os(Linux) || os(Windows)`. But a package manifest is compiled and **run on the host**, so when cross-compiling from a Mac that is false, `platformExcludes` stays empty, and the Apple sources are handed to the Linux target:

```
Sources/SwiftTerm/Apple/CaretView.swift:9:8: error: no such module 'CoreText'
```

A manifest cannot see the destination platform, so this adds an explicit opt-in rather than trying to detect it:

```
SWIFTTERM_EXCLUDE_APPLE=1 swift build --swift-sdk x86_64-swift-linux-musl
```

Native Linux and Windows builds are unaffected — they still take the `#if` branch.

### 2. `KittyGraphics.swift` assumes glibc on Linux

It imports `Glibc` under `os(Linux)`, but the Static Linux SDK builds against musl, where the C library module is `Musl` and `Glibc` does not exist:

```
Sources/SwiftTerm/KittyGraphics.swift:9:8: error: no such module 'Glibc'
```

Switched to `canImport` so the cascade covers musl, glibc and Windows without altering any existing case.

### Verified

Built `x86_64-swift-linux-musl` from macOS (Swift 6.2.4) and ran the resulting statically linked binary on Ubuntu 24.04 with no Swift installed. macOS builds are unchanged.