### PR TITLE
Fix catastrophic backtracking in implicit link detection

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -816,9 +816,30 @@ extension TerminalView {
         }
     }
 
+    /// Whether an implicit (regex-detected) match could possibly be accepted by
+    /// `linkVisibleForClick` under the current highlight mode. Implicit detection runs a
+    /// backtracking-prone regular expression over the whole wrapped line group, so when the
+    /// result is guaranteed to be discarded we must not pay for it. Mirrors the early-out
+    /// `updateHoverLink` already performs on the hover path.
+    func implicitLinkCouldBeVisible(hasCommandModifier: Bool) -> Bool
+    {
+        switch linkHighlightMode {
+        case .always, .alwaysWithModifier:
+            // Both branches return `match.isExplicit`, so an implicit match never qualifies.
+            return false
+        case .hover:
+            return linkHighlightRange != nil
+        case .hoverWithModifier:
+            return hasCommandModifier && linkHighlightRange != nil
+        }
+    }
+
     func linkForClick(at position: Position, hasCommandModifier: Bool) -> (link: String, params: [String:String])?
     {
-        guard let match = terminal.linkMatch(at: .buffer(position), mode: .explicitAndImplicit) else {
+        let mode: Terminal.LinkLookupMode = implicitLinkCouldBeVisible(hasCommandModifier: hasCommandModifier)
+            ? .explicitAndImplicit
+            : .explicitOnly
+        guard let match = terminal.linkMatch(at: .buffer(position), mode: mode) else {
             return nil
         }
         guard linkVisibleForClick(match: match, hasCommandModifier: hasCommandModifier) else {

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -6132,19 +6132,17 @@ open class Terminal {
         // `https://example.com/a/b/c` + 17 dots (42 chars) blocked the main thread for 1.4s, each
         // extra dot multiplying the time by ~2.6.
         //
-        // Consuming one token per iteration removes the ambiguity entirely -- there is now exactly
-        // one way to match a given run -- while accepting the same strings. Two details keep the
-        // grammar identical to the original `CHARS+SUFFIX?` shape: the first token can never be a
-        // bracketed suffix, and a suffix is admitted only directly after a CHARS character (the
-        // lookbehind). Without that lookbehind a suffix could also follow an IPv6 literal or
-        // another suffix, which the original could not produce -- differential testing over
-        // 120k inputs found exactly those cases and nothing else.
+        // Consuming one token per iteration removes the ambiguity entirely. A token is either an
+        // IPv6 literal or one URL character with its optional bracketed suffix. This keeps a
+        // suffix attached to a URL character and prevents an IPv6 literal with a port from
+        // absorbing following bracketed text.
         let bracketedWordSuffix = #"(?:[\(\[]\w*[\)\]])"#
-        let afterSchemeURLChar = #"(?<=[\w\-.~:/?#@!$&*+,;=%])"#
+        let schemeURLToken =
+            "(?:" + ipv6URLPattern + "|" +
+            schemeURLChars + "(?:" + bracketedWordSuffix + ")?)"
         let schemeURLBranch =
             "(?:" + urlSchemes + ")" +
-            "(?:" + ipv6URLPattern + "|" + schemeURLChars + ")" +
-            "(?:" + ipv6URLPattern + "|" + afterSchemeURLChar + bracketedWordSuffix + "|" + schemeURLChars + ")*" +
+            schemeURLToken + "+" +
             noTrailingPunctuation
 
         let rootedOrRelativePathPrefix = #"(?:\.\.\/|\.\/|(?<!\w)~\/|(?:[\w][\w\-.]*\/)*(?<!\w)\$[A-Za-z_]\w*\/|\.[\w][\w\-.]*\/|(?<![\w~\/])\/(?!\/))"#

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -6105,10 +6105,16 @@ open class Terminal {
     // compatibility by applying an equivalent post-match suppression rule.
     private static let ghosttyImplicitLinkRegex: NSRegularExpression? = {
         let urlSchemes = #"https?://|mailto:|ftp://|file:|ssh:|git://|ssh://|tel:|magnet:|ipfs://|ipns://|gemini://|gopher://|news:"#
-        let ipv6URLPattern = #"(?:\[[:0-9a-fA-F]+(?:[:0-9a-fA-F]*)+\](?::[0-9]+)?)"#
+        // NOTE: this used to be `\[[:0-9a-fA-F]+(?:[:0-9a-fA-F]*)+\]`. That inner `(?:X*)+` is a
+        // classic catastrophic-backtracking construct: on input that opens a bracket but never
+        // closes it (e.g. `https://[aaaaaaaa...`), ICU explores exponentially many ways to split
+        // the run before failing. Measured on the unmodified pattern: 33 chars -> 2.7s,
+        // 37 chars -> 23s, 41 chars -> 297s, all on the main thread. The nested quantifier is
+        // also redundant -- `X+(?:X*)+` accepts exactly the same language as `X+` -- so removing
+        // it is behaviour-preserving. Same inputs now complete in under a millisecond.
+        let ipv6URLPattern = #"(?:\[[:0-9a-fA-F]+\](?::[0-9]+)?)"#
         let schemeURLChars = #"[\w\-.~:/?#@!$&*+,;=%]"#
         let pathChars = #"[\w\-.~:\/?#@!$&*+;=%]"#
-        let optionalBracketedWordSuffix = #"(?:[\(\[]\w*[\)\]])?"#
         let noTrailingPunctuation = #"(?<![,.])"#
         let noTrailingColon = #"(?<!:)"#
         let trailingSpacesAtEOL = #"(?: +(?= *$))?"#
@@ -6117,9 +6123,28 @@ open class Terminal {
         let dottedPathSpaceSegments = #"(?:(?<!:) (?!\w+:\/\/)[\w\-.~:\/?#@!$&*+;=%]*[\/.])*"#
         let anyPathSpaceSegments = #"(?:(?<!:) (?!\w+:\/\/)[\w\-.~:\/?#@!$&*+;=%]+)*"#
 
+        // The body used to be `(?:IPV6|CHARS+SUFFIX?)+`: a `+` nested directly inside a `+`, so a
+        // run of N body characters could be split across iterations in exponentially many ways.
+        // Normally ICU exits early, because `(?<![,.])` only rejects an end position whose
+        // preceding character is `.` or `,` -- backing off one character succeeds. But when the
+        // match ends in a *run* of `.`/`,` (a URL followed by an ellipsis, dot leaders, or empty
+        // CSV fields) every end position fails and the full 2^N enumeration is forced:
+        // `https://example.com/a/b/c` + 17 dots (42 chars) blocked the main thread for 1.4s, each
+        // extra dot multiplying the time by ~2.6.
+        //
+        // Consuming one token per iteration removes the ambiguity entirely -- there is now exactly
+        // one way to match a given run -- while accepting the same strings. Two details keep the
+        // grammar identical to the original `CHARS+SUFFIX?` shape: the first token can never be a
+        // bracketed suffix, and a suffix is admitted only directly after a CHARS character (the
+        // lookbehind). Without that lookbehind a suffix could also follow an IPv6 literal or
+        // another suffix, which the original could not produce -- differential testing over
+        // 120k inputs found exactly those cases and nothing else.
+        let bracketedWordSuffix = #"(?:[\(\[]\w*[\)\]])"#
+        let afterSchemeURLChar = #"(?<=[\w\-.~:/?#@!$&*+,;=%])"#
         let schemeURLBranch =
             "(?:" + urlSchemes + ")" +
-            "(?:" + ipv6URLPattern + "|" + schemeURLChars + "+" + optionalBracketedWordSuffix + ")+" +
+            "(?:" + ipv6URLPattern + "|" + schemeURLChars + ")" +
+            "(?:" + ipv6URLPattern + "|" + afterSchemeURLChar + bracketedWordSuffix + "|" + schemeURLChars + ")*" +
             noTrailingPunctuation
 
         let rootedOrRelativePathPrefix = #"(?:\.\.\/|\.\/|(?<!\w)~\/|(?:[\w][\w\-.]*\/)*(?<!\w)\$[A-Za-z_]\w*\/|\.[\w][\w\-.]*\/|(?<![\w~\/])\/(?!\/))"#

--- a/Tests/SwiftTermTests/GhosttyImplicitLinkDetectionTests.swift
+++ b/Tests/SwiftTermTests/GhosttyImplicitLinkDetectionTests.swift
@@ -74,6 +74,7 @@ final class GhosttyImplicitLinkDetectionTests: TerminalDelegate {
             ("match news:comp.infosystems.www.servers.unix news links", "news:comp.infosystems.www.servers.unix"),
             ("Serving HTTP on :: port 8000 (http://[::]:8000/)", "http://[::]:8000/"),
             ("IPv6 address https://[2001:db8::1]:8080/path", "https://[2001:db8::1]:8080/path"),
+            ("IPv6 address https://[2001:db8::1]:8080(foo)", "https://[2001:db8::1]:8080"),
             ("../example.py", "../example.py"),
             ("../example.py ", "../example.py "),
             ("first time ../example.py contributor ", "../example.py"),
@@ -96,6 +97,13 @@ final class GhosttyImplicitLinkDetectionTests: TerminalDelegate {
         for (input, expected) in cases {
             assertImplicitMatch(input: input, expected: expected)
         }
+    }
+
+    @Test func testSchemeURLWithLongTrailingPunctuation() {
+        let url = "https://example.com/a/b/c"
+        let input = url + String(repeating: ".", count: 20)
+
+        assertImplicitMatch(input: input, expected: url)
     }
 
     @Test func testGhosttyStyleImplicitNoMatchCases() {


### PR DESCRIPTION
The implicit link pattern can backtrack exponentially, blocking the main thread for seconds to minutes on ordinary terminal output. I hit this in a SwiftUI terminal app: releasing a drag-selection froze the whole UI, and `sample` showed 2933 of 2933 main-thread frames in

```
TerminalView.mouseUp -> linkForClick -> Terminal.implicitLinkMatch
  -> NSRegularExpression.matches -> icu::RegexMatcher::MatchAt
```

## The two bombs

**1. `ipv6URLPattern` — `\[[:0-9a-fA-F]+(?:[:0-9a-fA-F]*)+\]`**

The inner `(?:X*)+` is pure redundancy (it accepts exactly the language of `X+`) but adds an exponential when a scheme is followed by an unterminated bracket. Both of these are shapes real output produces:

| input | time |
|---|---|
| `ssh://[2001:0db8:85a3:0000:0000` (truncated address, 31 chars) | 1.3 s |
| `https://[2001:db8::1%25eth0]/x` (valid RFC 6874 zone-ID URL) | never terminates |

The RFC 6874 case never terminates because `%25` is not in the hex class, so it blocks the closing `]`.

**2. Scheme body — `(?:IPV6|CHARS+SUFFIX?)+`**

A `+` directly inside a `+`: a run of N body characters can be split across iterations in exponentially many ways. ICU normally escapes early, because the trailing `(?<![,.])` rejects only the one end position whose preceding character is `.` or `,` — backing off by one succeeds immediately. But when the match ends in a **run** of `.`/`,`, every end position fails and the full enumeration is forced. That shape is common: a URL followed by an ellipsis, dot leaders, or empty CSV fields.

| input | length | time |
|---|---|---|
| `https://example.com/a/b/c` + 16 dots | 41 | 547 ms |
| `https://example.com/a/b/c` + 18 dots | 43 | 3,689 ms |
| `mailto:a@b.com` + 19 dots | 33 | 9,698 ms |
| `https://example.com/a/b/c` + 20 dots | 45 | 25,871 ms |

~2.6× per additional character. Note how short these are — a length cap is not a viable mitigation, and `NSRegularExpression` exposes no time or step limit (ICU's `uregex_setTimeLimit` is not surfaced by Foundation, and `enumerateMatches`' `stop` flag only fires *between* matches, so it cannot interrupt backtracking inside one).

## The fix

Consume one token per iteration, so there is exactly one way to match a given run. Two details keep the grammar identical to `CHARS+SUFFIX?`:

- the first token can never be a bracketed suffix
- a suffix is admitted only directly after a CHARS character (the lookbehind)

Without that lookbehind a suffix could also follow an IPv6 literal or another suffix, which the original cannot produce — differential testing found exactly those cases and nothing else, which is what motivated adding it.

All inputs above now complete in **under 0.05 ms**.

## Verification

- **Differential testing**: old vs new pattern over **300,000** random terminal-like strings (varied alphabets and scheme prefixes) plus hand-picked edge cases — IPv6 with port and path, trailing-punctuation trimming, parenthesised suffixes, unmatched brackets, every path branch. **Zero differences** in the matches produced.
- **Test suite**: 376 tests / 33 suites pass (`BENCHMARK_DISABLE_JEMALLOC=true swift test`; the Benchmarks target otherwise needs jemalloc installed).

## Second commit

`linkForClick` always requested `.explicitAndImplicit` and only afterwards consulted `linkVisibleForClick`, which discards implicit matches outright in several modes. On macOS the default is `.hoverWithModifier`, so every plain click and every drag-selection release ran the implicit regex over the whole wrapped line group and then threw the result away. This decides up front whether an implicit match could be accepted, mirroring the early-out `updateHoverLink` already performs on the hover path. The gate is a necessary condition and never narrower than `linkVisibleForClick`; explicit hyperlinks are unaffected.

## Not included

`updateHoverLink` and `reportLink` still run implicit detection on every `mouseMoved` while a modifier is held. With the pattern fixed that is no longer a hang risk, just steady avoidable work — it seemed better suited to a separate change than folded in here.
