### PR TITLE
Metal: align the caret to the rounded glyph cell grid (fixes cursor drift that grows with column)

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -2251,15 +2251,21 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let lineOriginPx = CGPoint(x: lineOrigin.x * scale, y: lineOrigin.y * scale)
         let cellWidthPx = cellWidth * scale
         let cellHeightPx = cellHeight * scale
+        // Place the caret on the SAME rounded, pixel-aligned grid the glyphs use in
+        // buildRowData (round(origin) + col * round(cellWidthPx)). Using the unrounded
+        // fractional grid here made the caret drift from the glyphs by an amount that
+        // grows with the column — a visible gap between a long prompt and the cursor.
+        let baseCellWidthPx = CGFloat(max(1, Int(round(cellWidthPx))))
+        let alignedOriginX = round(lineOriginPx.x)
         let doublePosition: CGFloat = buffer.lines[cursorRow].renderMode == .single ? 1.0 : 2.0
         // Span the cursor across the full character so a block/underline cursor
         // covers a full-width (CJK) glyph instead of only its left half, matching
         // the CoreGraphics caret.
         let cursorColumnWidth = CGFloat(max(1, Int(buffer.lines[cursorRow][buffer.x].width)))
 
-        let x0 = lineOriginPx.x + CGFloat(buffer.x) * cellWidthPx * doublePosition
+        let x0 = alignedOriginX + CGFloat(buffer.x) * baseCellWidthPx * doublePosition
         let y0 = lineOriginPx.y
-        let x1 = x0 + cellWidthPx * doublePosition * cursorColumnWidth
+        let x1 = x0 + baseCellWidthPx * doublePosition * cursorColumnWidth
         let y1 = y0 + cellHeightPx
 
         #if os(macOS)


### PR DESCRIPTION
## Problem
On the Metal renderer, the text cursor drifts to the right of the glyphs, and the offset **grows with the column** — invisible near the left edge, a visible multi-cell gap at a long prompt (e.g. a ~30-column shell prompt leaves ~1–2 empty cells between the prompt and the cursor / typed input). The CoreGraphics renderer is unaffected.

## Root cause
Glyphs and the caret are placed on **different horizontal grids**:

- Glyphs (`buildRowData`) snap to a **rounded, pixel-aligned** grid:
  `x = round(lineOriginPx.x) + column * round(cellWidthPx)`
- The caret (`buildCursorDrawData`) used the **unrounded fractional** grid:
  `x = lineOriginPx.x + buffer.x * cellWidthPx`

So the caret diverges from the glyphs by `round(lineOriginPx.x) - lineOriginPx.x` plus `buffer.x * (round(cellWidthPx) - cellWidthPx)` — a per-column error that accumulates with `buffer.x`.

## Fix
Position the caret on the same rounded/aligned grid the glyphs use (`baseCellWidthPx` + `alignedOriginX`), preserving the existing `doublePosition` and `cursorColumnWidth` (full-width/CJK) behavior:

```swift
let baseCellWidthPx = CGFloat(max(1, Int(round(cellWidthPx))))
let alignedOriginX  = round(lineOriginPx.x)
...
let x0 = alignedOriginX + CGFloat(buffer.x) * baseCellWidthPx * doublePosition
let x1 = x0 + baseCellWidthPx * doublePosition * cursorColumnWidth
```

## Note (related, optional)
The same fractional-vs-rounded inconsistency exists for background/decoration cells in `buildRowData` (they use `column * cellWidthPx`), which can make the cell highlight / underline drift from the glyph on long lines too. I kept this PR surgical (caret only) since that's the most visible symptom — happy to fold those into the same rounded grid here or in a follow-up.

## Repro
Retina Mac, Metal renderer on, any shell with a ~30-column prompt (e.g. conda's `(base) …`). Type a character: it appears ~1–2 cells right of the prompt's end; the gap scales with prompt length. Off on CoreGraphics. After the patch: the caret sits tight against the prompt at all columns.

`swift build` passes.