### PR TITLE
Metal: place glyphs on the terminal cell grid, not on CoreText advances

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -1134,16 +1134,32 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 let runFont = runAttributes[.font] as? TTFont ?? terminalView.fontSet.normal
                 let ctFont = runFont as CTFont
                 let startColumn = shaped.segment.column + (processedGlyphs * shaped.segment.columnWidth)
-                let baseX = lineOrigin.x + (cellWidth * CGFloat(startColumn))
-                let xOffset = baseX - run.shaperRun.firstX
+                // Place every glyph on the terminal's own cell grid, the way the
+                // CoreGraphics path does (AppleTerminalView.drawTerminalContents).
+                // Anchoring only the run's first glyph and letting CoreText's shaped
+                // advances carry the rest drifts, because cellWidth is
+                // ceil(advance("W") * scale) / scale — strictly wider than the font's
+                // advance. Each column loses that sub-pixel, so the row falls behind
+                // the grid (~3 cells by column 80) and the cursor, which *is* drawn on
+                // the grid, appears to run ahead of the text just typed.
+                func glyphX(_ indexInRun: Int) -> CGFloat {
+                    lineOrigin.x + cellWidth * CGFloat(startColumn + indexInRun * shaped.segment.columnWidth)
+                }
 
                 let textColor = runAttributes[.foregroundColor] as? TTColor ?? terminalView.nativeForegroundColor
                 let textColorSIMD = colorToSIMD(textColor)
 
+                // Column of the glyph being placed, counted across the shaper's runs —
+                // `i` restarts per glyph run, the grid position does not.
+                var indexInRun = 0
                 for glyphRun in run.shaperRun.glyphRuns {
                     let scaledFont = scaledFontFor(font: glyphRun.font, scale: scale)
                     for i in 0..<glyphRun.glyphs.count {
                         let glyph = glyphRun.glyphs[i]
+                        let column = indexInRun
+                        // Advance before any skip, or a glyph the atlas rejects would
+                        // pull the whole rest of the row one cell to the left.
+                        indexInRun += 1
                         guard let entry = glyphEntry(for: scaledFont, glyph: glyph) else {
                             continue
                         }
@@ -1151,7 +1167,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                             continue
                         }
                         let ctPos = glyphRun.positions[i]
-                        let basePos = CGPoint(x: ctPos.x + xOffset,
+                        let basePos = CGPoint(x: glyphX(column),
                                               y: lineOrigin.y + yOffset + ctPos.y)
                         let pxX = basePos.x * scale + entry.bearing.x
                         let pxY = basePos.y * scale + entry.bearing.y
@@ -1197,8 +1213,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     let thickness = underlineThickness * scale
                     let segmentStyle: UnderlineStyle = underlineStyle == .double ? .single : underlineStyle
 
-                    for ctPos in run.shaperRun.positions {
-                        let basePos = CGPoint(x: ctPos.x + xOffset,
+                    for (column, ctPos) in run.shaperRun.positions.enumerated() {
+                        let basePos = CGPoint(x: glyphX(column),
                                               y: lineOrigin.y + yOffset + ctPos.y)
                         let x0 = basePos.x * scale
                         let x1 = (basePos.x + decorationCellWidth) * scale
@@ -1248,8 +1264,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     let strikeThickness = max(round(scale * CTFontGetUnderlineThickness(ctFont)) / scale, 0.5)
                     let strikePosition = (CTFontGetXHeight(ctFont) + strikeThickness) * 0.5
 
-                    for ctPos in run.shaperRun.positions {
-                        let basePos = CGPoint(x: ctPos.x + xOffset,
+                    for (column, ctPos) in run.shaperRun.positions.enumerated() {
+                        let basePos = CGPoint(x: glyphX(column),
                                               y: lineOrigin.y + yOffset + ctPos.y)
                         let x0 = basePos.x * scale
                         let x1 = (basePos.x + decorationCellWidth) * scale


### PR DESCRIPTION
### Symptom

With the Metal renderer enabled, text drifts left of the terminal's cell grid as a row
gets longer. Because the cursor, cell backgrounds and box-drawing glyphs are all drawn
on the grid, what you actually see is the cursor sitting several cells to the *right* of
the last character you typed, with the gap growing along the line: roughly 3 cells by
column 80 with a 14pt monospace font. The CoreGraphics renderer does not have this
problem.

### Cause

`MetalTerminalRenderer.buildRowDrawData` anchors only the **first** glyph of each run at
its column and lets CoreText's shaped positions carry the rest:

```swift
let baseX = lineOrigin.x + (cellWidth * CGFloat(startColumn))
let xOffset = baseX - run.shaperRun.firstX
...
let basePos = CGPoint(x: ctPos.x + xOffset, y: lineOrigin.y + yOffset + ctPos.y)
```

`ctPos.x` advances by the font's own advance width. But the terminal's cell width is
snapped up to the pixel grid in `AppleTerminalView.computeFontDimensions`:

```swift
let cellWidth = fontSet.normal.advancement(forGlyph: glyph).width  // "W"
let snappedWidth = ceil(cellWidth * scale) / scale
```

so `cellWidth` is strictly wider than the advance (up to 1/scale). Every column after
the run's first loses that sub-pixel, and the error accumulates left to right.

The CoreGraphics path in `AppleTerminalView.drawTerminalContents` does not drift because
it computes a position **per glyph** from the column index, using CoreText only for `y`:

```swift
let glyphColumn = startColumn + (i * prepared.segment.columnWidth)
positions[i] = CGPoint(x: lineOrigin.x + CGFloat(glyphColumn) * cellDimension.width,
                       y: lineOrigin.y + yOffset + ctPosition.y)
```

### Fix

Mirror that in the Metal path: derive each glyph's `x` from its column on the cell grid,
and use the same grid positions for the underline and strikethrough decorations, which
read from `shaperRun.positions` and drifted identically. CoreText's `y` offsets are
still honoured, so baseline shifts are unaffected.

The glyph column is tracked across the shaper's glyph runs (`i` restarts per glyph run,
the grid position does not) and advances before the atlas-miss `continue`, so a glyph the
atlas rejects cannot pull the remainder of the row one cell left.

### Testing

Built and run against a full-screen TUI (Claude Code / codex CLIs in a pty) on macOS
15.5, Apple silicon, 2x backing scale, SF Mono 13pt. Cursor and text stay aligned across
the full width of the line, at every column, with the Metal renderer on. Bold, italic,
underline, strikethrough, box drawing and emoji cells all still land on their cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
