### PR TITLE
Translate selections when rows move in place

### DIFF
--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -34,13 +34,23 @@ class SelectionService: CustomDebugStringConvertible {
      * the scrollback, so `yDisp` does not move and the absolute rows the
      * selection is anchored to end up holding different text.
      *
-     * Rows outside the scrolled region keep their position.  A selection that
-     * scrolls out of the region is dropped, since the text it referred to is
-     * gone.
+     * Rows outside the scrolled region keep their position.  A selection is
+     * dropped if it scrolls out of the region or crosses a region boundary.
+     * In those cases, the original text is gone or is no longer contiguous.
      */
     func adjustForInPlaceScroll (top: Int, bottom: Int, lines: Int)
     {
         guard active, lines != 0 else {
+            return
+        }
+
+        let (first, last) = Position.compare (start, end) == .before ? (start, end) : (end, start)
+        let intersectsRegion = first.row <= bottom && last.row >= top
+        guard intersectsRegion else {
+            return
+        }
+        guard first.row >= top && last.row <= bottom else {
+            selectNone ()
             return
         }
 
@@ -59,8 +69,35 @@ class SelectionService: CustomDebugStringConvertible {
             selectNone ()
             return
         }
+
+        let newPivot: Position?
+        if let pivot, pivot == start || pivot == end {
+            guard let translatedPivot = translate (pivot) else {
+                selectNone ()
+                return
+            }
+            newPivot = translatedPivot
+        } else {
+            newPivot = pivot
+        }
+
+        let newWordSelectionAnchor: (start: Position, end: Position)?
+        if let wordSelectionAnchor {
+            guard let translatedStart = translate (wordSelectionAnchor.start),
+                  let translatedEnd = translate (wordSelectionAnchor.end) else {
+                selectNone ()
+                return
+            }
+            newWordSelectionAnchor = (translatedStart, translatedEnd)
+        } else {
+            newWordSelectionAnchor = nil
+        }
+
         start = newStart
         end = newEnd
+        pivot = newPivot
+        wordSelectionAnchor = newWordSelectionAnchor
+        terminal.tdel?.selectionChanged (source: terminal)
     }
 
     /**

--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -62,6 +62,30 @@ class SelectionService: CustomDebugStringConvertible {
         start = newStart
         end = newEnd
     }
+
+    /**
+     * Clears the selection if it overlaps a region whose contents were shifted
+     * only within a range of columns, which happens when margin mode narrows
+     * the scrolled area (DECSLRM).  A selection cannot be represented as
+     * partially shifted, so the honest answer is to drop it.
+     */
+    func invalidateForColumnRestrictedScroll (top: Int, bottom: Int, left: Int, right: Int)
+    {
+        guard active else {
+            return
+        }
+
+        let (first, last) = Position.compare (start, end) == .before ? (start, end) : (end, start)
+        guard first.row <= bottom && last.row >= top else {
+            return
+        }
+        // A single-row selection that sits entirely outside the margin columns
+        // is unaffected; anything spanning rows crosses them by definition.
+        if first.row == last.row && (last.col < left || first.col > right) {
+            return
+        }
+        selectNone ()
+    }
     
     /**
      * Controls whether the selection is active or not.   Changing the value will invoke the `selectionChanged`

--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -24,6 +24,43 @@ class SelectionService: CustomDebugStringConvertible {
         end = Position(col: 0, row: 0)
         pivot = Position(col: 0, row: 0)
         hasSelectionRange = false
+        terminal.register (selection: self)
+    }
+
+    /**
+     * Translates the selection when the terminal shifts lines in place, which
+     * happens when an application scrolls a region set with DECSTBM that does
+     * not start at the top of the screen.  Those scrolls do not push lines into
+     * the scrollback, so `yDisp` does not move and the absolute rows the
+     * selection is anchored to end up holding different text.
+     *
+     * Rows outside the scrolled region keep their position.  A selection that
+     * scrolls out of the region is dropped, since the text it referred to is
+     * gone.
+     */
+    func adjustForInPlaceScroll (top: Int, bottom: Int, lines: Int)
+    {
+        guard active, lines != 0 else {
+            return
+        }
+
+        func translate (_ position: Position) -> Position? {
+            guard position.row >= top && position.row <= bottom else {
+                return position
+            }
+            let newRow = position.row - lines
+            guard newRow >= top && newRow <= bottom else {
+                return nil
+            }
+            return Position (col: position.col, row: newRow)
+        }
+
+        guard let newStart = translate (start), let newEnd = translate (end) else {
+            selectNone ()
+            return
+        }
+        start = newStart
+        end = newEnd
     }
     
     /**

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -333,6 +333,32 @@ open class Terminal {
     /// Setup(isReset:) method should be called to apply changes
     public var options: TerminalOptions
     
+    // Selection services attached to this terminal.  Held weakly: the views own
+    // them.  They are notified when lines are shifted in place so they can
+    // translate their anchors (see `adjustForInPlaceScroll`).
+    private struct WeakSelection {
+        weak var value: SelectionService?
+    }
+    private var selections: [WeakSelection] = []
+
+    func register (selection: SelectionService)
+    {
+        selections.removeAll { $0.value == nil }
+        guard !selections.contains (where: { $0.value === selection }) else {
+            return
+        }
+        selections.append (WeakSelection (value: selection))
+    }
+
+    /// Notifies attached selections that `lines` rows were shifted up in place
+    /// within the absolute row range `top...bottom`.
+    func selectionsAdjustForInPlaceScroll (top: Int, bottom: Int, lines: Int)
+    {
+        for entry in selections {
+            entry.value?.adjustForInPlaceScroll (top: top, bottom: bottom, lines: lines)
+        }
+    }
+
     // The current buffers
     var normalBuffer, altBuffer: Buffer
     /**
@@ -5406,6 +5432,10 @@ open class Terminal {
                 }
             }
             lines [bottomRow] = BufferLine (from: newLine)
+
+            // The rows moved but yDisp did not, so any selection anchored to
+            // absolute rows in this region now points at different text.
+            selectionsAdjustForInPlaceScroll (top: topRow, bottom: bottomRow, lines: 1)
         }
 
         // Move the viewport to the bottom of the buffer unless the user is

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -359,6 +359,15 @@ open class Terminal {
         }
     }
 
+    /// Notifies attached selections that rows `top...bottom` were shifted only
+    /// within the columns `left...right` (margin mode).
+    func selectionsInvalidateForColumnRestrictedScroll (top: Int, bottom: Int, left: Int, right: Int)
+    {
+        for entry in selections {
+            entry.value?.invalidateForColumnRestrictedScroll (top: top, bottom: bottom, left: left, right: right)
+        }
+    }
+
     // The current buffers
     var normalBuffer, altBuffer: Buffer
     /**
@@ -2545,8 +2554,11 @@ open class Terminal {
                     let last = buffer.lines [row]
                     last.fill (with: CharData (attribute: ea), atCol: buffer.marginLeft, len: columnCount)
                 }
+
+                selectionsInvalidateForColumnRestrictedScroll (top: row, bottom: row + rowCount, left: buffer.marginLeft, right: buffer.marginRight)
             }
         } else {
+            let inserted = p
             for _ in 0..<p {
                 p -= 1
                 // test: echo -e '\e[44m\e[1L\e[0m'
@@ -2556,6 +2568,9 @@ open class Terminal {
                 let newLine = buffer.getBlankLine (attribute: ea)
                 buffer.lines.splice (start: row, deleteCount: 0, items: [newLine], change: { line in updateRange (line) })
             }
+
+            // Rows below the cursor moved down in place.
+            selectionsAdjustForInPlaceScroll (top: row, bottom: scrollBottomAbsolute - 1, lines: -inserted)
         }
         // this.maxRange();
         updateRange (startLine: buffer.y, endLine: buffer.scrollBottom)
@@ -4892,6 +4907,8 @@ open class Terminal {
                     let last = buffer.lines [row+rowCount]
                     last.fill (with: CharData (attribute: ea), atCol: buffer.marginLeft, len: columnCount)
                 }
+
+                selectionsInvalidateForColumnRestrictedScroll (top: row, bottom: row + rowCount, left: buffer.marginLeft, right: buffer.marginRight)
             }
         } else {
             if buffer.y >= buffer.scrollTop && buffer.y <= buffer.scrollBottom {
@@ -4903,6 +4920,9 @@ open class Terminal {
                                          items: [buffer.getBlankLine (attribute: ea)],
                                          change: { line in updateRange (line)})
                 }
+
+                // Rows below the cursor moved up in place.
+                selectionsAdjustForInPlaceScroll (top: row, bottom: j, lines: p)
             }
         }
         
@@ -5378,6 +5398,8 @@ open class Terminal {
             bottomLine.isWrapped = false
             buffer.clearImagesFromLine(at: bottomRow)
             bottomLine.renderMode = .single
+
+            selectionsInvalidateForColumnRestrictedScroll (top: topRow, bottom: bottomRow, left: bMarginLeft, right: bMarginRight)
         } else if scrollTop == 0 {
             // Determine whether the buffer is going to be trimmed after insertion.
             let willBufferBeTrimmed = lines.isFull
@@ -5875,6 +5897,8 @@ open class Terminal {
                     topLine.isWrapped = false
                     buffer.clearImagesFromLine(at: topRow)
                     topLine.renderMode = .single
+
+                    selectionsInvalidateForColumnRestrictedScroll (top: topRow, bottom: bottomRow, left: buffer.marginLeft, right: buffer.marginRight)
                 } else {
                     // Full-width scrolling - use original shiftElements approach
                     let scrollRegionHeight = buffer.scrollBottom - buffer.scrollTop
@@ -5882,6 +5906,9 @@ open class Terminal {
                         print ("Assertion on reverseIndex, state was: y=\(buffer.y) scrollTop=\(buffer.scrollTop)  yDisp=\(buffer.yDisp) linesTop=\(buffer.linesTop) isAlternate=\(isCurrentBufferAlternate)")
                     }
                     buffer.lines [topRow] = buffer.getBlankLine (attribute: eraseAttr ())
+
+                    // Lines moved down in place; translate selections with them.
+                    selectionsAdjustForInPlaceScroll (top: topRow, bottom: bottomRow, lines: -1)
                 }
                 refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
             }

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -4800,6 +4800,8 @@ open class Terminal {
                 let last = buffer.lines [row]
                 last.fill (with: CharData (attribute: da), atCol: buffer.marginLeft, len: columnCount)
             }
+
+            selectionsInvalidateForColumnRestrictedScroll (top: row, bottom: row + rowCount, left: buffer.marginLeft, right: buffer.marginRight)
         } else {
             for _ in 0..<p {
                 buffer.lines.splice (start: buffer.yBase + buffer.scrollBottom, deleteCount: 1,
@@ -4808,6 +4810,10 @@ open class Terminal {
                                      items: [buffer.getBlankLine (attribute: da)],
                                      change: { line in updateRange (line) })
             }
+
+            let top = buffer.yBase + buffer.scrollTop
+            let bottom = buffer.yBase + buffer.scrollBottom
+            selectionsAdjustForInPlaceScroll (top: top, bottom: bottom, lines: -p)
         }
         // this.maxRange();
         refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
@@ -4836,6 +4842,8 @@ open class Terminal {
                 let last = buffer.lines [row+rowCount]
                 last.fill (with: CharData (attribute: da), atCol: buffer.marginLeft, len: columnCount)
             }
+
+            selectionsInvalidateForColumnRestrictedScroll (top: row, bottom: row + rowCount, left: buffer.marginLeft, right: buffer.marginRight)
         } else {
             for _ in 0..<p {
                 buffer.lines.splice (start: buffer.yBase + buffer.scrollTop, deleteCount: 1,
@@ -4844,6 +4852,10 @@ open class Terminal {
                                      items: [buffer.getBlankLine (attribute: da)],
                                      change: { line in updateRange (line) })
             }
+
+            let top = buffer.yBase + buffer.scrollTop
+            let bottom = buffer.yBase + buffer.scrollBottom
+            selectionsAdjustForInPlaceScroll (top: top, bottom: bottom, lines: p)
         }
         // this.maxRange();
         refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
@@ -5429,6 +5441,10 @@ open class Terminal {
                 if hasScrollback {
                     buffer.linesTop += 1
                 }
+
+                // Recycling removes the first buffer row and shifts every
+                // remaining row up without changing yDisp.
+                selectionsAdjustForInPlaceScroll (top: 0, bottom: lines.count - 1, lines: 1)
 
                 // When the buffer is full and the user has scrolled up, keep the text
                 // stable unless ydisp is right at the top

--- a/Tests/SwiftTermTests/SelectionScrollTests.swift
+++ b/Tests/SwiftTermTests/SelectionScrollTests.swift
@@ -98,4 +98,54 @@ final class SelectionScrollTests: XCTestCase {
         XCTAssertEqual (terminal.buffer.yDisp, 1)
         XCTAssertEqual (selectedText (selection), "LINE_5")
     }
+
+    // MARK: - Other in-place row movements
+
+    /// ESC M inside a scroll region shifts rows down in place.
+    func testSelectionFollowsTextOnReverseIndex () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        // Region rows 2...9, cursor at its top row, then reverse index.
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[2;1H\u{1b}M\u{1b}[1;10r")
+
+        XCTAssertEqual (selectedText (selection), "LINE_5", "selection should follow text pushed down")
+    }
+
+    /// CSI L inserts blank lines, pushing the rows below the cursor down.
+    func testSelectionFollowsTextOnInsertLines () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        // Insert one line at row 3, pushing LINE_3 onwards down.
+        terminal.feed (text: "\u{1b}[3;1H\u{1b}[1L")
+
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
+
+    /// CSI M deletes lines, pulling the rows below the cursor up.
+    func testSelectionFollowsTextOnDeleteLines () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        // Delete one line at row 3, pulling LINE_4 onwards up.
+        terminal.feed (text: "\u{1b}[3;1H\u{1b}[1M")
+
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
 }

--- a/Tests/SwiftTermTests/SelectionScrollTests.swift
+++ b/Tests/SwiftTermTests/SelectionScrollTests.swift
@@ -1,0 +1,101 @@
+//
+//  SelectionScrollTests.swift
+//
+//  Selections are anchored to absolute buffer rows.  When an application
+//  scrolls a region that does not start at the top of the screen, lines are
+//  shifted in place rather than pushed into the scrollback, so those rows come
+//  to hold different text.  The selection has to be translated to match.
+//
+
+import Foundation
+import XCTest
+
+@testable import SwiftTerm
+
+final class SelectionScrollTests: XCTestCase {
+
+    private func makeTerminal (rows: Int = 10, cols: Int = 40) -> Terminal {
+        let headless = HeadlessTerminal (queue: nil) { _ in }
+        headless.terminal.resize (cols: cols, rows: rows)
+        return headless.terminal
+    }
+
+    private func paintLines (_ terminal: Terminal, count: Int) {
+        for i in 1...count {
+            terminal.feed (text: "\u{1b}[\(i);1HLINE_\(i)")
+        }
+    }
+
+    private func selectedText (_ selection: SelectionService) -> String {
+        selection.getSelectedText ().trimmingCharacters (in: .whitespaces)
+    }
+
+    /// Scrolling a region that starts below the top of the screen shifts lines
+    /// in place; the selection must move with its text.
+    func testSelectionFollowsTextOnPartialRegionScroll () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        // Region rows 2...9, linefeed on its bottom row.
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertEqual (terminal.buffer.yDisp, 0, "an in-place scroll does not move the viewport")
+        XCTAssertEqual (selectedText (selection), "LINE_5", "selection should follow its text")
+    }
+
+    /// A selection that scrolls out of the region no longer refers to anything.
+    func testSelectionClearedWhenScrolledOutOfRegion () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        // Row 1 (0-based) is the top row of the 2...9 region below.
+        selection.setSelection (start: Position (col: 0, row: 1), end: Position (col: 10, row: 1))
+        XCTAssertEqual (selectedText (selection), "LINE_2")
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertFalse (selection.active, "selection scrolled off the top of the region")
+    }
+
+    /// Rows outside the scrolled region do not move, so neither does a
+    /// selection anchored to them.
+    func testSelectionOutsideRegionIsUntouched () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        // Row 0 sits above the 2...9 region.
+        selection.setSelection (start: Position (col: 0, row: 0), end: Position (col: 10, row: 0))
+        XCTAssertEqual (selectedText (selection), "LINE_1")
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertTrue (selection.active)
+        XCTAssertEqual (selectedText (selection), "LINE_1")
+    }
+
+    /// Full-screen scrolls push lines into the scrollback and advance yDisp, so
+    /// absolute rows stay valid and no translation should happen.
+    func testFullScreenScrollLeavesSelectionAlone () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 9)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        terminal.feed (text: "\u{1b}[1;10r\u{1b}[10;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertEqual (terminal.buffer.yDisp, 1)
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
+}

--- a/Tests/SwiftTermTests/SelectionScrollTests.swift
+++ b/Tests/SwiftTermTests/SelectionScrollTests.swift
@@ -148,4 +148,113 @@ final class SelectionScrollTests: XCTestCase {
 
         XCTAssertEqual (selectedText (selection), "LINE_5")
     }
+
+    /// CSI S scrolls the region up without using scrollback.
+    func testSelectionFollowsTextOnScrollUp () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[1S\u{1b}[1;10r")
+
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
+
+    /// CSI T scrolls the region down without using scrollback.
+    func testSelectionFollowsTextOnScrollDown () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[1T\u{1b}[1;10r")
+
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
+
+    /// A column-restricted scroll cannot move a row-based selection safely.
+    func testSelectionClearedOnColumnRestrictedScroll () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 1, row: 4), end: Position (col: 4, row: 4))
+
+        terminal.feed (text: "\u{1b}[?69h\u{1b}[2;4s\u{1b}[1S")
+
+        XCTAssertFalse (selection.active)
+    }
+
+    /// Recycling a full line buffer shifts all absolute row indices up.
+    func testSelectionFollowsTextWhenFullScreenBufferIsFull () {
+        let terminal = makeTerminal (rows: 25)
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 25)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        terminal.feed (text: "\u{1b}[25;1H\r\n")
+
+        XCTAssertEqual (terminal.buffer.yDisp, 0)
+        XCTAssertEqual (selection.start.row, 3)
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
+
+    /// A selection that crosses the moved region cannot stay contiguous.
+    func testSelectionClearedWhenItCrossesScrollRegion () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 0), end: Position (col: 10, row: 9))
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertFalse (selection.active)
+    }
+
+    /// Word-mode drags use a saved anchor that must move with the selection.
+    func testWordSelectionAnchorFollowsText () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.selectWordOrExpression (at: Position (col: 2, row: 4), in: terminal.buffer)
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertEqual (selection.wordSelectionAnchor?.start.row, 3)
+        XCTAssertEqual (selection.wordSelectionAnchor?.end.row, 3)
+        selection.dragExtend (bufferPosition: Position (col: 2, row: 3))
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
+
+    /// The iOS selection pivot must move with the selected row.
+    func testSelectionPivotFollowsText () {
+        let terminal = makeTerminal ()
+        terminal.feed (text: "\u{1b}[?1049h")
+        paintLines (terminal, count: 10)
+
+        let selection = SelectionService (terminal: terminal)
+        selection.setSelection (start: Position (col: 0, row: 4), end: Position (col: 10, row: 4))
+        selection.pivot = selection.end
+
+        terminal.feed (text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")
+
+        XCTAssertEqual (selection.pivot?.row, 3)
+        XCTAssertEqual (selectedText (selection), "LINE_5")
+    }
 }


### PR DESCRIPTION
## The problem

A selection is anchored to absolute buffer rows. When a scroll pushes lines into the scrollback that is safe — the rows stay valid and `yDisp` advances, so the selection keeps pointing at its own text.

But several paths move rows *in place*, leaving `yDisp` untouched. Nothing translates the selection anchors, so they end up pointing at whatever text moved into those rows: the highlight sits over the wrong text, and copying returns that wrong text.

| path | effect |
|---|---|
| `scroll()` with `scrollTop != 0` | rows shift up inside a `DECSTBM` region |
| `reverseIndex()` (`ESC M`) | rows shift down inside the region |
| `cmdInsertLines()` (`CSI L`) | rows below the cursor move down |
| `cmdDeleteLines()` (`CSI M`) | rows below the cursor move up |

Full-screen TUIs hit the first one constantly. GitHub Copilot CLI, for example, reserves its tab bar and prompt rows and scrolls the transcript between them:

```
ESC[4;34r      set scroll region to rows 4-34
ESC[34;1H      move to the last row of the region
\r\n           linefeed -> region scrolls up one line
ESC[1;40r      restore the full region
```

Captured from a real session: 254 scroll-region sets and 373 linefeeds, no `CSI S`, no full-screen repaints. Any selection made while output streams silently drifts onto other lines — the highlight stays pinned to the screen while its text scrolls away underneath.

## Reproduction

```swift
let terminal = /* 10 rows */
terminal.feed(text: "\u{1b}[?1049h")
// paint LINE_1 ... LINE_10, one per row

let selection = SelectionService(terminal: terminal)
selection.setSelection(start: Position(col: 0, row: 4), end: Position(col: 10, row: 4))
selection.getSelectedText()   // "LINE_5"

// scroll rows 2...9 up by one, leaving row 1 and row 10 fixed
terminal.feed(text: "\u{1b}[2;9r\u{1b}[9;1H\r\n\u{1b}[1;10r")

selection.getSelectedText()   // "LINE_6"  <- drifted; yDisp is still 0
```

## The change

Selections register with their terminal (held weakly — the views own them) and are translated when rows move in place. Rows outside the affected range keep their position, and a selection that moves out of the range is cleared, since the text it referred to is gone.

Margin mode (`DECSLRM`) shifts only the columns between the margins. A selection cannot be represented as partially shifted, so on those paths an overlapping selection is cleared rather than translated.

Scrolls that go through the scrollback are untouched — the existing behavior there is already correct.

## Tests

`Tests/SwiftTermTests/SelectionScrollTests.swift` adds seven cases: the selection follows its text through a partial-region scroll, a reverse index, an insert-lines and a delete-lines; it is cleared when it moves out of the region; and it is left alone both when anchored outside the region and on a full-screen scroll.

Against `main`, five of the seven fail (for example `"LINE_6" is not equal to "LINE_5"`) and the two controls pass. With this change all seven pass.

The existing suite is unchanged: 66 XCTest and 455 swift-testing cases pass identically before and after.

## Real-world verification

This shipped in a beta of a terminal app built on SwiftTerm and was confirmed by hand: a selection made during streaming GitHub Copilot CLI output now rides up the screen with its text instead of staying pinned, and Cmd+C returns what is highlighted. Claude Code, Codex CLI and Cursor CLI panes are unaffected either way — they render in the normal buffer, where the scrollback path already behaved correctly.