### PR TITLE
Ignore DECCOLM unless the application asks for it, like xterm

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -460,7 +460,16 @@ open class Terminal {
     var gLevel: UInt8 = 0
     var cursorBlink: Bool = false
     
-    var allow80To132 = true
+    /// Whether DECCOLM (`CSI ? 3 h` / `CSI ? 3 l`) may resize the terminal to
+    /// 132 or 80 columns. Off by default, matching xterm's `allowC132`
+    /// resource: xterm's own `rs2` reset string contains `CSI ? 3 ; 4 l`, so
+    /// honouring DECCOLM means anything that resets the terminal — `reset`,
+    /// `tput init`, an ssh or tmux session tearing down — silently snaps the
+    /// buffer to 80 columns and leaves the rest of the view unused. Worse,
+    /// running `reset` to recover re-sends the very sequence that causes it.
+    /// An application that genuinely wants the mode can still ask for it with
+    /// `CSI ? 40 h`.
+    var allow80To132 = false
     
     public var parser: EscapeSequenceParser
     var kittyGraphicsState = KittyGraphicsState()
@@ -929,7 +938,7 @@ open class Terminal {
         cc.send8bit = false
         conformance = .vt500
         
-        allow80To132 = true
+        allow80To132 = false
         
         xtermTitleSetUtf = false
         xtermTitleQueryUtf = false

--- a/Tests/SwiftTermTests/SwiftTermTests.swift
+++ b/Tests/SwiftTermTests/SwiftTermTests.swift
@@ -182,7 +182,6 @@ final class SwiftTermTests {
             "DECSET_DECAWM_NoLineWrapOnTabWithLeftRightMargin",
             "DECSET_DECAWM_OnRespectsLeftRightMargin",
             "DECSET_DECAWM_TabDoesNotWrapAround",
-            "DECSET_DECCOLM",
             "DECSET_DECLRMM",
             "DECSET_DECLRMM_MarginsResetByDECSTR",
             "DECSET_DECLRMM_ModeNotResetByDECSTR",
@@ -195,6 +194,10 @@ final class SwiftTermTests {
             "DECSET_Allow80To132",
                 // Failing:
                 // test_DECSET_Allow80To132
+                // Expected: like xterm's allowC132 resource, DECCOLM is off by
+                // default here, so it does nothing until an application asks for
+                // it with `CSI ? 40 h`.
+                // test_DECSET_DECCOLM
                 // test_DECSET_DECAWM_CursorAtRightMargin
                 // test_DECSET_DECAWM_OffRespectsLeftRightMargin
                 // test_DECSET_DECOM


### PR DESCRIPTION
## Problem

`allow80To132` defaults to `true`, so DECCOLM (`CSI ? 3 h` / `CSI ? 3 l`) resizes the buffer to 132 or 80 columns whenever it turns up in the stream. It turns up more often than it looks: `xterm-256color`'s `rs2` reset string is `ESC [ ! p  ESC [ ? 3 ; 4 l  ESC [ 4 l  ESC >` — DECCOLM is part of the standard reset. So anything that resets the terminal silently snaps it to 80 columns and notifies the host of the new size: `reset`, `tput init`, an ssh or tmux session tearing down. On a view wider than 80 columns everything to the right of column 80 then goes unused until something else resizes the view.

Recovering isn't obvious either. Running `reset` re-sends the very sequence that caused it, and RIS re-arms the flag first (`reset()` sets `allow80To132 = true`) — so neither `reset` nor a preemptive `CSI ? 40 l` durably switches it off. Worth noting the real sequence is `ESC [ ? 3 ; 4 l`, two parameters, so it isn't something an embedder can filter out of the byte stream either.

xterm's equivalent resource is off by default for exactly this reason — `allowC132`: *"Specifies whether control sequences that change the number of columns should be honored. The default is false."* Most modern emulators either default it off or don't implement the resize at all.

Repro against current main, using a headless `Terminal` (201 columns) and feeding it the strings a shell actually emits:

```
rs2 (ESC[!p ESC[?3;4l ESC[4l ESC>)   201 -> 80
resize back to 201, then `reset`      201 -> 80    (rs1 ESCc + rs2)
ESC[?40l then rs2                     stays 201    (the knob works)
ESC c (RIS) then rs2                  201 -> 80    (but RIS re-arms it)
```

## Change

- Default `allow80To132` to `false`.
- `reset()` (RIS) restores that default rather than setting it to `true`.
- `CSI ? 40 h` is untouched, so an application that genuinely wants the mode can still turn it on — after which DECCOLM behaves exactly as before.

## Tests

Full suite passes (460 tests).

esctest's `DECSET_DECCOLM` asserts the resize happens *without* enabling the mode first, so it fails by design now and moves to the known-failing list with a note — alongside `RIS_ResetDECCOLM`, which is already excluded for the neighbouring reason. `DECSET_Allow80To132` covers the `CSI ? 40 h` opt-in that still works.

Re-ran the repro above against the patched build: all four cases stay at 201 columns with zero `sizeChanged` callbacks, and `ESC [ ? 40 h` followed by `ESC [ ? 3 h` still resizes to 132.
