### PR TITLE
Cache shaped lines so unchanged rows skip CoreText typesetting

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -133,12 +133,40 @@ extension TerminalView {
         }
     }
 
+    /// Identity of a shaped line: everything the typeset result depends on. A hit
+    /// means the CoreText work can be skipped entirely.
+    struct ShapedLineKey: Hashable {
+        let row: Int
+        let line: ObjectIdentifier
+        let generation: UInt64
+        let cols: Int
+        let selection: Range<Int>?
+        /// Bumped for global style changes (font, palette, hovered link).
+        let epoch: UInt64
+    }
+
+    /// A line's built attributed string together with its shaped CTLines.
+    struct ShapedLine {
+        let info: ViewLineInfo
+        let prepared: [(segment: ViewLineSegment, ctLine: CTLine, runs: [CTRun])]
+    }
+
+    /// Cap the cache so a long-lived view cannot accumulate stale generations; the
+    /// visible rows re-shape once after a flush, which is imperceptible.
+    static let shapedLineCacheLimit = 2048
+
+    func bumpShapedLineEpoch () {
+        shapedLineEpoch &+= 1
+        shapedLineCache.removeAll (keepingCapacity: true)
+    }
+
     func resetCaches ()
     {
         self.attributes = [:]
         self.urlAttributes = [:]
         self.colors = Array(repeating: nil, count: 256)
         self.trueColors = [:]
+        bumpShapedLineEpoch ()
     }
     
     // This is invoked when the font changes to recompute state
@@ -392,6 +420,7 @@ extension TerminalView {
     {
         urlAttributes = [:]
         attributes = [:]
+        bumpShapedLineEpoch ()
         
         terminal.updateFullScreen ()
         queuePendingDisplay()
@@ -1424,7 +1453,15 @@ extension TerminalView {
             } 
             #endif
             let line = displayBuffer.lines [row]
-            let lineInfo = buildAttributedString(row: row, line: line, cols: displayBuffer.cols)
+            let shapedKey = ShapedLineKey(row: row,
+                                          line: ObjectIdentifier(line),
+                                          generation: line.generation,
+                                          cols: displayBuffer.cols,
+                                          selection: selectedColumnsRange(row: row, cols: displayBuffer.cols),
+                                          epoch: shapedLineEpoch)
+            let cachedShapedLine = shapedLineCache[shapedKey]
+            let lineInfo = cachedShapedLine?.info
+                ?? buildAttributedString(row: row, line: line, cols: displayBuffer.cols)
             let rowBase = lineOrigin.y + cellDimension.height
             var underTextImages: [AppleImage] = []
             var overTextKittyImages: [AppleImage] = []
@@ -1456,14 +1493,23 @@ extension TerminalView {
                 overTextKittyImages.sort(by: sortKitty)
             }
 
-            // Pre-create CTLines and runs once per row to avoid duplicate creation
-            let preparedSegments: [(segment: ViewLineSegment, ctLine: CTLine, runs: [CTRun])] =
-                lineInfo.segments.compactMap { segment in
+            // Shape the line's segments once, then reuse them for every later redraw
+            // of the same content (see `shapedLineCache`).
+            let preparedSegments: [(segment: ViewLineSegment, ctLine: CTLine, runs: [CTRun])]
+            if let cachedShapedLine {
+                preparedSegments = cachedShapedLine.prepared
+            } else {
+                preparedSegments = lineInfo.segments.compactMap { segment in
                     guard segment.attributedString.length > 0 else { return nil }
                     let ctLine = CTLineCreateWithAttributedString(segment.attributedString)
                     guard let runs = CTLineGetGlyphRuns(ctLine) as? [CTRun] else { return nil }
                     return (segment, ctLine, runs)
                 }
+                if shapedLineCache.count >= Self.shapedLineCacheLimit {
+                    shapedLineCache.removeAll (keepingCapacity: true)
+                }
+                shapedLineCache[shapedKey] = ShapedLine(info: lineInfo, prepared: preparedSegments)
+            }
 
             // Background fill loop — uses cached CTLines
             context.saveGState()

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -155,6 +155,28 @@ extension TerminalView {
     /// visible rows re-shape once after a flush, which is imperceptible.
     static let shapedLineCacheLimit = 2048
 
+    /// Diagnostic counters for the shaped-line cache. Set SWIFTTERM_SHAPED_CACHE_STATS=1
+    /// to have hit/miss totals written to stderr every 5 s; otherwise this is a single
+    /// static bool test per drawn row.
+    static let shapedCacheStatsEnabled =
+        ProcessInfo.processInfo.environment["SWIFTTERM_SHAPED_CACHE_STATS"] == "1"
+
+    func noteShapedCache (hit: Bool) {
+        guard Self.shapedCacheStatsEnabled else { return }
+        if hit { shapedCacheHits &+= 1 } else { shapedCacheMisses &+= 1 }
+        let now = Date().timeIntervalSince1970
+        if now - shapedCacheLastReport >= 5 {
+            shapedCacheLastReport = now
+            let total = shapedCacheHits + shapedCacheMisses
+            let pct = total == 0 ? 0 : Double(shapedCacheHits) / Double(total) * 100
+            let msg = "shaped-cache: \(shapedCacheHits) hits / \(shapedCacheMisses) misses "
+                + "(\(String(format: "%.1f", pct))% hit), \(shapedCacheEvictions) flushes, "
+                + "\(shapedLineCache.count) entries\n"
+            FileHandle.standardError.write(Data(msg.utf8))
+            shapedCacheHits = 0; shapedCacheMisses = 0; shapedCacheEvictions = 0
+        }
+    }
+
     func bumpShapedLineEpoch () {
         shapedLineEpoch &+= 1
         shapedLineCache.removeAll (keepingCapacity: true)
@@ -1460,6 +1482,7 @@ extension TerminalView {
                                           selection: selectedColumnsRange(row: row, cols: displayBuffer.cols),
                                           epoch: shapedLineEpoch)
             let cachedShapedLine = shapedLineCache[shapedKey]
+            noteShapedCache(hit: cachedShapedLine != nil)
             let lineInfo = cachedShapedLine?.info
                 ?? buildAttributedString(row: row, line: line, cols: displayBuffer.cols)
             let rowBase = lineOrigin.y + cellDimension.height
@@ -1507,6 +1530,7 @@ extension TerminalView {
                 }
                 if shapedLineCache.count >= Self.shapedLineCacheLimit {
                     shapedLineCache.removeAll (keepingCapacity: true)
+                    shapedCacheEvictions &+= 1
                 }
                 shapedLineCache[shapedKey] = ShapedLine(info: lineInfo, prepared: preparedSegments)
             }

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -138,7 +138,8 @@ extension TerminalView {
     struct ShapedLineKey: Hashable {
         let row: Int
         let line: ObjectIdentifier
-        let generation: UInt64
+        /// Content digest, not the write counter: a TUI repainting identical text must hit.
+        let contentHash: Int
         let cols: Int
         let selection: Range<Int>?
         /// Bumped for global style changes (font, palette, hovered link).
@@ -1477,7 +1478,7 @@ extension TerminalView {
             let line = displayBuffer.lines [row]
             let shapedKey = ShapedLineKey(row: row,
                                           line: ObjectIdentifier(line),
-                                          generation: line.generation,
+                                          contentHash: line.contentHash,
                                           cols: displayBuffer.cols,
                                           selection: selectedColumnsRange(row: row, cols: displayBuffer.cols),
                                           epoch: shapedLineEpoch)

--- a/Sources/SwiftTerm/BufferLine.swift
+++ b/Sources/SwiftTerm/BufferLine.swift
@@ -11,7 +11,7 @@ import Foundation
 /// BufferLines represents a single line of text displayed on the terminal
 
 public final class BufferLine: CustomDebugStringConvertible {
-    public enum RenderLineMode {
+    public enum RenderLineMode: Hashable {
         /// Render each character using a single cell
         case single
         /// Render character using two cells
@@ -39,7 +39,36 @@ public final class BufferLine: CustomDebugStringConvertible {
     public private(set) var generation: UInt64 = 0
 
     @inline(__always)
-    private func bump() { generation &+= 1 }
+    private func bump() { generation &+= 1; cachedContentHash = nil }
+
+    /// Lazily computed digest of everything that affects how this line draws.
+    private var cachedContentHash: Int? = nil
+
+    /// A hash of the line's *rendered content* — the cells (rune, width, attribute),
+    /// plus `isWrapped`, `renderMode` and image presence.
+    ///
+    /// `generation` counts **writes**, not changes, so a full-screen TUI that repaints
+    /// the same text every frame bumps it on every line and defeats any renderer cache
+    /// (measured: a 10 Hz identical repaint gave a 2.5% hit rate). Comparing content
+    /// instead turns those redundant repaints into hits; recomputing costs one pass over
+    /// the cells, which is orders of magnitude cheaper than re-shaping the line.
+    public var contentHash: Int {
+        if let cachedContentHash { return cachedContentHash }
+        var hasher = Hasher()
+        hasher.combine(isWrapped)
+        hasher.combine(renderMode)
+        hasher.combine(images?.count ?? 0)
+        hasher.combine(dataSize)
+        for i in 0..<dataSize {
+            let cd = data[i]
+            hasher.combine(cd.code)
+            hasher.combine(cd.width)
+            hasher.combine(cd.attribute)
+        }
+        let h = hasher.finalize()
+        cachedContentHash = h
+        return h
+    }
 
     public init (cols: Int, fillData: CharData? = nil, isWrapped: Bool = false)
     {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -290,6 +290,10 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     var shapedLineCache: [TerminalView.ShapedLineKey: TerminalView.ShapedLine] = [:]
     /// Invalidates every cached shaped line when a global style input changes.
     var shapedLineEpoch: UInt64 = 0
+    var shapedCacheHits = 0
+    var shapedCacheMisses = 0
+    var shapedCacheEvictions = 0
+    var shapedCacheLastReport: TimeInterval = 0
     var attributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     var urlAttributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -284,6 +284,12 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // Attribute dictionary, maps a console attribute (color, flags) to the corresponding dictionary
     // of attributes for an NSAttributedString
+    /// Shaped-line cache: skips CoreText typesetting for lines whose content,
+    /// selection and style are unchanged since the last draw. See
+    /// `AppleTerminalView`'s `ShapedLineKey` / `bumpShapedLineEpoch`.
+    var shapedLineCache: [TerminalView.ShapedLineKey: TerminalView.ShapedLine] = [:]
+    /// Invalidates every cached shaped line when a global style input changes.
+    var shapedLineEpoch: UInt64 = 0
     var attributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     var urlAttributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     
@@ -899,7 +905,14 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
     }
 
-    var linkHighlightRange: [Terminal.LinkMatch.RowRange]?
+    /// Hovering a link changes how affected rows are drawn, so a change here has to
+    /// invalidate the shaped-line cache (only on a real change — the mouse moving
+    /// within one link must not thrash it).
+    var linkHighlightRange: [Terminal.LinkMatch.RowRange]? {
+        didSet {
+            if oldValue != linkHighlightRange { bumpShapedLineEpoch () }
+        }
+    }
 
     /**
      * If set to true, this will call the TerminalViewDelegate's rangeChanged method

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -239,6 +239,12 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 
     // Attribute dictionary, maps a console attribute (color, flags) to the corresponding dictionary
     // of attributes for an NSAttributedString
+    /// Shaped-line cache: skips CoreText typesetting for lines whose content,
+    /// selection and style are unchanged since the last draw. See
+    /// `AppleTerminalView`'s `ShapedLineKey` / `bumpShapedLineEpoch`.
+    var shapedLineCache: [TerminalView.ShapedLineKey: TerminalView.ShapedLine] = [:]
+    /// Invalidates every cached shaped line when a global style input changes.
+    var shapedLineEpoch: UInt64 = 0
     var attributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     var urlAttributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
 

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -245,6 +245,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var shapedLineCache: [TerminalView.ShapedLineKey: TerminalView.ShapedLine] = [:]
     /// Invalidates every cached shaped line when a global style input changes.
     var shapedLineEpoch: UInt64 = 0
+    var shapedCacheHits = 0
+    var shapedCacheMisses = 0
+    var shapedCacheEvictions = 0
+    var shapedCacheLastReport: TimeInterval = 0
     var attributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
     var urlAttributes: [Attribute: [NSAttributedString.Key:Any]] = [:]
 


### PR DESCRIPTION
Profiling a terminal hosting an AI-agent TUI (Claude Code) put essentially all of the app's draw time inside `CTLineCreateWithAttributedString`: `drawTerminalContents` rebuilds an attributed string per visible row and runs CoreText's typesetter + OpenType shaping over it **on every draw** — and a terminal redraws unchanged content constantly (partial-rect exposures call it dozens of times per pass, cursor blinks, the 60 Hz tick after a single-row change, and every full repaint of an alt-screen TUI that rewrote one line).

In a 20 s `sample` of a real workload, 774 of 778 `drawTerminalContents` stacks were inside `CTLineCreateWithAttributedString`.

## What this PR does

Shapes each line once and caches the result (`ViewLineInfo` + `CTLine`s + runs). The key carries everything the shaped output depends on:

- the row and the `BufferLine`'s identity,
- a **content digest** of the line (cells' rune/width/attribute + `isWrapped`, `renderMode`, image count),
- the column count and the row's **selection range**,
- an **epoch** bumped on font changes (`resetCaches`), palette changes (`colorsChanged`), and hovered-link highlight changes.

Content-keying (3rd commit) matters more than it looks: `BufferLine.generation` counts **writes**, not changes, so a TUI that repaints identical text every frame invalidates everything — measured **2.5% hit rate** on a 10 Hz identical repaint. Keyed on content it's **100%**, while genuinely changing content (`top`) correctly misses and scrolling output sits at ~95% (hits on exposure/blink redraws of already-shaped rows). The digest is cached on the line and invalidated by the same `bump()` that advances `generation`, so it costs one pass over the cells — orders of magnitude less than re-shaping.

The cache is capped (2048 entries) and flushed wholesale past the cap; a flush costs one reshape of the visible rows.

## Measured

- draw path: `drawTerminalContents` fell from 778 to 68 samples (−91%) in the same 20 s profile
- whole process on a 9-pane agent workload: 247 → 88 ms/s
- pure-scroll synthetic benchmark: ~7% (that workload was already shape-once-per-line; the win is in-place repaints)

The 2nd commit adds opt-in counters (`SWIFTTERM_SHAPED_CACHE_STATS=1` → hits/misses/flushes to stderr every 5 s; a single static bool test per row when unset) — that's how the numbers above were measured, and reviewers can check their own workloads with it.

## Notes

- macOS + iOS builds; the full test suite passes (73 tests).
- The stored properties live on the platform view classes (extensions can't hold storage); the cache logic is shared in `AppleTerminalView.swift`.
- Happy to split the stats commit out, rename things, or rework the eviction policy to LRU if you'd prefer — the wholesale flush was chosen for simplicity and hasn't been observable in practice.