### PR TITLE
Notify the view when a full reset replaces the buffer (blank terminal after RIS)

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -5578,6 +5578,14 @@ open class Terminal {
         cursorHidden = savedCursorHidden
         refresh (startRow: 0, endRow: rows-1)
         syncScrollArea ()
+        // A full reset replaces the buffer, so the view's scroll geometry — which
+        // is derived from `lines.count` and `yDisp` — is stale. `syncScrollArea()`
+        // is a no-op stub, and none of the other paths that recompute it fire
+        // here (no buffer switch, no scrolled line, no keystroke, no resize), so
+        // notify explicitly. Without this the view keeps the contentSize and
+        // contentOffset of a buffer that no longer exists and renders blank until
+        // some unrelated layout pass happens to correct it.
+        tdel?.bufferActivated (source: self)
     }
 
     // Support for:

--- a/Tests/SwiftTermTests/ResetScrollAreaTests.swift
+++ b/Tests/SwiftTermTests/ResetScrollAreaTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import SwiftTerm
+
+/// A full reset (RIS, `ESC c`) replaces the buffer, so any view that derives its
+/// scroll geometry from `lines.count` / `yDisp` has to be told about it.
+/// `syncScrollArea()` is a no-op stub, and none of the other paths that make a
+/// view recompute that geometry run here — there is no buffer switch, no scrolled
+/// line, no keystroke and no resize — so `resetToInitialState()` notifies
+/// explicitly. Without that, a view keeps the contentSize/contentOffset of the
+/// buffer that was just discarded and renders blank.
+@Suite("Full reset scroll area")
+struct ResetScrollAreaTests {
+    @Test("RIS notifies the delegate that the buffer changed")
+    func fullResetNotifiesDelegate() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal(cols: 80, rows: 24, scrollback: 500)
+
+        // Build up scrollback so the reset is a real change in buffer size.
+        for i in 0..<200 {
+            terminal.feed(text: "line \(i)\r\n")
+        }
+        #expect(terminal.buffer.lines.count > terminal.rows)
+
+        let before = delegate.bufferActivatedCount
+        terminal.feed(text: "\u{1b}c")
+
+        // The buffer really did shrink back to a single screen...
+        #expect(terminal.buffer.lines.count == terminal.rows)
+        #expect(terminal.buffer.yBase == 0)
+        #expect(terminal.buffer.yDisp == 0)
+        // ...and the delegate heard about it exactly once.
+        #expect(delegate.bufferActivatedCount == before + 1)
+    }
+
+    @Test("Keypad mode changes do not claim the buffer changed")
+    func keypadModeDoesNotNotify() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal(cols: 80, rows: 24, scrollback: 500)
+
+        let before = delegate.bufferActivatedCount
+        terminal.feed(text: "\u{1b}=")   // application keypad
+        terminal.feed(text: "\u{1b}>")   // numeric keypad
+
+        // These also call syncScrollArea(), but they do not touch the buffer, so
+        // they must not be reported as a buffer activation: on iOS that resets
+        // the scroll-follow state and would yank a user who has scrolled back
+        // down to the bottom.
+        #expect(delegate.bufferActivatedCount == before)
+    }
+}

--- a/Tests/SwiftTermTests/TerminalTestHarness.swift
+++ b/Tests/SwiftTermTests/TerminalTestHarness.swift
@@ -3,6 +3,7 @@ import Testing
 
 final class TerminalTestDelegate: TerminalDelegate {
     private(set) var sentData: [[UInt8]] = []
+    private(set) var bufferActivatedCount = 0
     var cellSizeInPixelsValue: (width: Int, height: Int)? = nil
 
     func showCursor(source: Terminal) {}
@@ -13,7 +14,7 @@ final class TerminalTestDelegate: TerminalDelegate {
     func sizeChanged(source: Terminal) {}
     func scrolled(source: Terminal, yDisp: Int) {}
     func linefeed(source: Terminal) {}
-    func bufferActivated(source: Terminal) {}
+    func bufferActivated(source: Terminal) { bufferActivatedCount += 1 }
     func bell(source: Terminal) {}
 
     func send(source: Terminal, data: ArraySlice<UInt8>) {


### PR DESCRIPTION
## Terminal renders blank after RIS (`ESC c`): the scroll area is never re-synced

### The bug

`Terminal.resetToInitialState()` replaces the buffer (`setup(isReset: true)` →
`resetNormalBuffer()`), then calls `syncScrollArea()` so the view can recompute
its scroll geometry. But `syncScrollArea()` is an empty stub:

```swift
func syncScrollArea () {
    // This should call the viewport sync-scroll-area
}
```

On iOS, `contentSize.height` and `contentOffset.y` are only recomputed by
`TerminalView.updateScroller()`, which has exactly four callers — and none of
them fire on this path:

| caller | why it doesn't fire after RIS |
|---|---|
| `bufferActivated` | no buffer switch |
| `scrolled` | a reset is followed by a prompt, not a scrolled line |
| `ensureCaretIsVisible` | keystroke-driven; for Ctrl+C it runs *before* the app emits RIS |
| `sizeChanged` | no resize |

So the scroll view keeps the geometry of a buffer that no longer exists, and
nothing ever corrects it.

### What the user sees

Quitting a full-screen TUI with Ctrl+C (any program that emits RIS while tearing
down) leaves the terminal blank with no visible cursor. The content is intact but
sits far above the viewport, so you have to scroll up to find it. Presenting a
sheet, rotating, or toggling the keyboard silently fixes it — because those
trigger a layout pass, which reaches `updateScroller()`.

Measured on an iPad, 163x51 grid, cell height 16:

```
buffer           yDisp=0   cursor y=9     (prompt on row 9, caret not hidden)
contentSize.h    4656.0    -> the view still thinks there are 291 rows
contentOffset.y  3798.0    -> == 4656 - 858, pinned to the bottom of stale content
```

Live content occupies rows 0-9; the viewport shows rows ~237+. Hence "blank".

### The fix

Notify the delegate from `resetToInitialState()`. Semantically it *is* a fresh
buffer, and both the iOS and macOS `bufferActivated` handlers already do exactly
the right thing (reset the scroll-follow state and recompute `contentSize`).

### Why not implement `syncScrollArea()` itself

That was my first instinct, but it would be a regression. `syncScrollArea()` has
eight call sites, and five of them are keypad-mode changes (`ESC =` / `ESC >`,
`resetMode`/`setMode` 66, `cmdSoftReset`) that don't touch the buffer at all. On
iOS `bufferActivated` calls `resetManualScrollTracking()`, so routing those
through it would yank a user who has scrolled back down to the bottom every time
an application toggles keypad mode. The two alt-buffer sites (`?1047` / `?47`)
already call `bufferActivated` explicitly right after, so `resetToInitialState()`
is the only one actually missing a notification.

The second test in this PR pins that down.

### Tests

`Tests/SwiftTermTests/ResetScrollAreaTests.swift`:

- **RIS notifies the delegate that the buffer changed** — builds 200 lines of
  scrollback, feeds `ESC c`, asserts the buffer collapsed back to one screen
  (`lines.count == rows`, `yBase == yDisp == 0`) and that `bufferActivated` fired
  exactly once. Verified to fail on `main` without the fix:
  `Expectation failed: (delegate.bufferActivatedCount → 0) == (before + 1 → 1)`
- **Keypad mode changes do not claim the buffer changed** — guards against the
  broader `syncScrollArea()` change described above.

`TerminalTestDelegate` gains a `bufferActivatedCount` counter (the existing
`bufferActivated` was an empty stub).

Full suite passes locally on macOS.
