### PR TITLE
Draw reverse video by swapping the default colors, opaquely

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -462,10 +462,21 @@ extension TerminalView {
                 return nativeBackgroundColor
             }
         case .defaultInvertedColor:
+            // Reverse video *swaps* the default pair, it does not invert its RGB. Inverting
+            // produced the expected pixels only for a pure black/white pair; with any other
+            // palette it produced a color that belongs to neither side (inverting Solarized's
+            // base03 background yields a pink block), and over a translucent background it
+            // produced an unreadable highlight: the block inherited the background's alpha and
+            // vanished, leaving text painted in the inverse of the foreground over whatever the
+            // window showed through.
+            //
+            // The swapped colors are forced opaque, the way Terminal.app draws reverse video
+            // over a translucent background: the highlight is the one thing that must stay
+            // readable at any `backgroundOpacity`.
             if isFg {
-                return nativeForegroundColor.inverseColor()
+                return nativeBackgroundColor.withAlphaComponent(1)
             } else {
-                return nativeBackgroundColor.inverseColor()
+                return nativeForegroundColor.withAlphaComponent(1)
             }
         case .ansi256(let ansi):
             var midx: Int


### PR DESCRIPTION
`.defaultInvertedColor` inverts the RGB of the default pair instead of swapping it. That produces the right pixels for a pure black/white default pair and nothing else:

* with any other palette the highlight lands on a color that belongs to neither side (inverting Solarized's `base03` background gives a pink block);
* over a translucent background — the `backgroundOpacity` added in e4f31b0 — it disappears: `nativeBackgroundColor.inverseColor()` keeps alpha 0, so the block is never painted, and the text is left as the inverse of the foreground over whatever the window shows through. On a dark, see-through terminal that is black text on a dark desktop.

The second one is easy to hit without any TUI involved: zsh marks bracketed-paste input with `ESC[7m` (`zle_highlight` defaults to `paste:standout`), so on a terminal with `backgroundOpacity < 1` every pasted command turns unreadable.

This swaps the pair instead, forcing both sides opaque — the way Terminal.app draws reverse video over a translucent background. For an opaque black-on-white (or white-on-black) default pair the output is byte-identical to before; `inverseColor()` is left in place for anyone else using it.

Reproduces with `printf '\\e[7mreverse\\e[27m\\n'` on a view with `backgroundOpacity = 0`.
