### PR TITLE
Make SelectionService and TerminalView.selection public

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -279,7 +279,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     private var progressReportTimer: Timer?
     private var lastProgressValue: UInt8?
 
-    var selection: SelectionService!
+    /// Tracks the selection state of the terminal, and can be used to set it
+    /// programmatically (see `SelectionService`).
+    public var selection: SelectionService!
     private var scroller: NSScroller!
     
     // Attribute dictionary, maps a console attribute (color, flags) to the corresponding dictionary

--- a/Sources/SwiftTerm/SelectionService.swift
+++ b/Sources/SwiftTerm/SelectionService.swift
@@ -13,7 +13,7 @@ import Foundation
  * property, and if that is true, then the `start` and `end` represents offsets within
  * the terminal's buffer.  They are guaranteed to be ordered.
  */
-class SelectionService: CustomDebugStringConvertible {
+public class SelectionService: CustomDebugStringConvertible {
     var terminal: Terminal
     
     public init (terminal: Terminal)

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -233,7 +233,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     private var progressReportTimer: Timer?
     private var lastProgressValue: UInt8?
     
-    var selection: SelectionService!
+    /// Tracks the selection state of the terminal, and can be used to set it
+    /// programmatically (see `SelectionService`).
+    public var selection: SelectionService!
     var attrStrBuffer: CircularList<ViewLineInfo>!
     var images:[(image: TerminalImage, col: Int, row: Int)] = []
 


### PR DESCRIPTION
Every member of `SelectionService` is already declared `public` and documented as API — `setSelection(start:end:)`, `select(row:)`, `shiftExtend`, `pivotExtend`, `dragExtend`, `selectWordOrExpression`, `selectNone`, `getSelectedText`, `start`/`end`/`active`/`isMultiLine` — but the class itself is internal, and so is the `selection` property on `TerminalView`. The result is that none of that surface is reachable from an app embedding SwiftTerm: the only selection API an embedder gets is `selectionActive`, `getSelection()`, `selectAll()` and `selectNone()`, none of which is positional.

This raises two access levels and changes nothing else:

- `SelectionService` → `public class`
- `TerminalView.selection` → `public`, on both the AppKit and UIKit views so the API stays symmetric

**Why.** I maintain a terminal-first app where the terminal view *is* the primary surface, and I want a keyboard-driven copy mode over the scrollback: a selection cursor moved with the arrows, extended with shift, copied with ⌘C. The search API (`findNext`/`findPrevious`) already proves the selection can be driven programmatically — it calls `selection.setSelection(start:end:)` internally — but it only reaches the selection through a needle. Without this change an embedder has to draw its own highlight over the terminal, which means duplicating the view's cell geometry (`cellDimension` is internal) and ending up with two selections on one surface: a second highlight that can drift a row away from the text it claims, next to the real one the mouse produces. Reusing `SelectionService` gives one selection, drawn by the view that owns the layout.

**No behavior change.** Nothing is added, renamed or moved, and no call site changes; only the access level of a class and one property.

**Access-control audit.** Making the class public compiles as-is because no public member of `SelectionService` mentions an internal type: `Position`, `Buffer` and `Terminal` are already public/open, and everything that isn't (`terminal`, `setActiveAndNotify`, `clamp`, `wordSelectionAnchor`, `simpleScanSelection`, `balancedSearchForward`/`Backward`, `extendToWordBoundary`, `character(at:in:)`, `nullChar`) stays internal and legal inside a public class. Verified with `swift build`.
