### PR TITLE
Guard the unknown-DECRQSS log against a non-ASCII payload

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -1119,7 +1119,7 @@ open class Terminal {
             default:
                 ok = 0 // this means the request is not valid, report that to the host.
                 // invalid: DCS 0 $ r Pt ST (xterm)
-                terminal.log ("Unknown DCS + \(newData!)")
+                terminal.log ("Unknown DCS + \(newData ?? "")")
                 // Do not report 'newData', because it can be exploited
                 // see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=510030
                 result = ""

--- a/Tests/SwiftTermTests/DcsTests.swift
+++ b/Tests/SwiftTermTests/DcsTests.swift
@@ -53,6 +53,18 @@ final class DcsTests {
         // Response format: DCS 1 $ r <SGR params> m ST
     }
 
+    /// DECRQSS with a non-ASCII payload byte: the payload does not decode as
+    /// ASCII, and the unknown-request branch must answer rather than crash.
+    @Test func testDecrqssNonAsciiPayload() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }
+        let t = h.terminal!
+
+        // DECRQSS (ESC P $ q <0xA0> ESC \) with a non-ASCII payload byte.
+        t.feed(byteArray: [0x1b, 0x50, 0x24, 0x71, 0xa0, 0x1b, 0x5c])
+
+        // Should not crash.
+    }
+
     /// Test DECRQSS for DECSTBM (scrolling region)
     @Test func testDecrqssDecstbm() {
         let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }


### PR DESCRIPTION
The DCS `$q` (DECRQSS) handler decodes the request payload as ASCII, which is `nil` for any byte ≥ 0x80. The unknown-request branch then logs it as `\(newData!)`, so a DECRQSS whose payload carries a non-ASCII byte traps on the force-unwrap:

```
ESC P $ q <0xA0> ESC \   →   Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

This is reachable from ordinary terminal output. The fix logs `newData ?? ""` instead — the nil-safe form already used for the response in this same handler, and everywhere else this file decodes ASCII (`if let` / `guard let` / `?? default`).

Adds a `DcsTests` regression that feeds a non-ASCII DECRQSS payload and confirms it no longer crashes.
