### PR TITLE
Track DECSET/DECRST 1007 (Alternate Scroll Mode)

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2994,6 +2994,20 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             return
         }
 
+        let reportsMouse = allowMouseReporting && !shiftBypassesMouseReporting(for: event) && terminal.mouseMode != .off
+
+        // Alternate Scroll Mode (DECSET 1007): while the alternate screen is
+        // active and the application is not tracking the mouse, the wheel is
+        // translated into cursor keys below. With the mode reset the wheel
+        // produces nothing at all — the alternate buffer has no scrollback to
+        // move either. Decided here, before the accumulator is touched, so that
+        // suppressed motion is not banked and then handed to the first event
+        // after the mode comes back.
+        if !reportsMouse && terminal.isDisplayBufferAlternate && !terminal.alternateScrollMode {
+            scrollAccumulator = 0
+            return
+        }
+
         // Translate the wheel/trackpad delta into a whole number of terminal
         // lines while preserving a 1:1 feel. Precise (trackpad) deltas are pixel
         // values we accumulate and divide by the cell height, keeping the
@@ -3020,7 +3034,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         let scrollingUp = lines > 0
         let magnitude = abs(lines)
 
-        if allowMouseReporting && !shiftBypassesMouseReporting(for: event) && terminal.mouseMode != .off {
+        if reportsMouse {
             let hit = calculateMouseHit(with: event)
             let displayBuffer = terminal.displayBuffer
             let screenRow = max (0, min (displayBuffer.rows - 1, hit.grid.row - displayBuffer.yDisp))

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -5145,6 +5145,8 @@ open class Terminal {
     //    Ps = 1 0 0 3  -> Don't use All Motion Mouse Tracking.
     //    Ps = 1 0 0 4  -> Don't send FocusIn/FocusOut events.
     //    Ps = 1 0 0 5  -> Disable Extended Mouse Mode.
+    //    Ps = 1 0 0 7  -> Disable Alternate Scroll Mode, xterm.  This
+    //    corresponds to the alternateScroll resource.
     //    Ps = 1 0 1 0  -> Don't scroll to bottom on tty output
     //    (rxvt).
     //    Ps = 1 0 1 1  -> Don't scroll to bottom on key press (rxvt).

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -476,6 +476,16 @@ open class Terminal {
     /// Indicates that the application has toggled bracketed paste mode, which means that when content is pasted into
     /// the terminal, the content will be wrapped in "ESC [ 200 ~" to start, and "ESC [ 201 ~" to end.
     public private(set) var bracketedPasteMode: Bool = false
+
+    /// Tracks DECSET/DECRST private mode 1007 (Alternate Scroll Mode, xterm's "alternateScroll" resource).
+    /// When true and the alternate screen buffer is active without an application mouse-tracking mode enabled,
+    /// hosts are expected to translate scroll wheel input into cursor up/down key sequences instead of scrolling,
+    /// so that full-screen apps that do not read the mouse (e.g. `less`, `vim` without `mouse=a`) still respond
+    /// to the scroll wheel. SwiftTerm only tracks the mode's state here; translating wheel events is left to the
+    /// host view, which can read this property to decide how to route them.
+    /// xterm's own default for this resource is false; we default to true here to match modern terminals
+    /// (e.g. Ghostty) that enable it out of the box.
+    public private(set) var alternateScrollMode: Bool = true
     
     private var charset: [UInt8:String]? = nil
     private var gCharsets: [[UInt8:String]?] = [CharSets.defaultCharset, nil, nil, nil]
@@ -954,6 +964,7 @@ open class Terminal {
         setInsertMode(false)
         setWraparound(true)
         bracketedPasteMode = false
+        alternateScrollMode = true
 
         keyboardModeNormal = KeyboardModeState()
         keyboardModeAlt = KeyboardModeState()
@@ -4428,6 +4439,8 @@ open class Terminal {
                 res = mouseProtocol == .utf8 ? modeSet : modeReset
             case 1006:
                 res = mouseProtocol == .sgr ? modeSet : modeReset
+            case 1007:
+                res = alternateScrollMode ? modeSet : modeReset
             case 1015:
                 res = mouseProtocol == .urxvt ? modeSet : modeReset
             case 1016:
@@ -5257,6 +5270,8 @@ open class Terminal {
                 mouseMode = .off
             case 1004: // send focusin/focusout events
                 sendFocus = false
+            case 1007: // alternate scroll mode (xterm's alternateScroll resource)
+                alternateScrollMode = false
             case 2500: // box drawing mirroring off
                 updateCurrentBidiState(property: .boxMirroring) { $0.boxMirroring = false }
             case 2501: // autodetect off: use the SPD-selected direction
@@ -5356,6 +5371,8 @@ open class Terminal {
     //     Ps = 1 0 0 3  -> Use All Motion Mouse Tracking.
     //     Ps = 1 0 0 4  -> Send FocusIn/FocusOut events.
     //     Ps = 1 0 0 5  -> Enable Extended Mouse Mode.
+    //     Ps = 1 0 0 7  -> Enable Alternate Scroll Mode, xterm.  This
+    //     corresponds to the alternateScroll resource.
     //     Ps = 1 0 1 0  -> Scroll to bottom on tty output (rxvt).
     //     Ps = 1 0 1 1  -> Scroll to bottom on key press (rxvt).
     //     Ps = 1 0 3 4  -> Interpret "meta" key, sets eighth bit.
@@ -5506,6 +5523,8 @@ open class Terminal {
                 // the application does not assume it is unfocused until the
                 // first real focus change.
                 sendFocusReport()
+            case 1007: // alternate scroll mode (xterm's alternateScroll resource)
+                alternateScrollMode = true
             case 2500: // box drawing mirroring (terminal-wg)
                 updateCurrentBidiState(property: .boxMirroring) { $0.boxMirroring = true }
             case 2501: // autodetect paragraph direction (terminal-wg)

--- a/Tests/SwiftTermTests/AlternateScrollModeTests.swift
+++ b/Tests/SwiftTermTests/AlternateScrollModeTests.swift
@@ -2,14 +2,17 @@
 //  AlternateScrollModeTests.swift
 //
 //  DECSET/DECRST 1007: Alternate Scroll Mode (xterm's "alternateScroll" resource).
-//  SwiftTerm only tracks the mode's boolean state on Terminal.alternateScrollMode;
-//  translating scroll wheel events into cursor keys while the alt screen is active
-//  is the host view's responsibility.
+//  Terminal tracks the mode's boolean state on Terminal.alternateScrollMode, and
+//  the macOS view gates its wheel-to-cursor-key translation on it.
 //
 import Foundation
 import Testing
 
 @testable import SwiftTerm
+
+#if os(macOS)
+import AppKit
+#endif
 
 final class AlternateScrollModeTests: TerminalDelegate {
     var sent: [UInt8] = []
@@ -75,4 +78,99 @@ final class AlternateScrollModeTests: TerminalDelegate {
         terminal.feed(text: "\u{1b}[?1007$p")
         #expect(String(decoding: sent, as: UTF8.self) == "\u{1b}[?1007;2$y", "reset is reported as 2")
     }
+
+#if os(macOS)
+    /// The point of tracking the mode is that an application can turn the
+    /// translation off: with 1007 reset, the wheel must produce nothing on the
+    /// alternate screen (there is no scrollback there to move either).
+    @MainActor @Test func viewOnlyTranslatesWheelWhileModeIsSet() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let delegate = WheelCapturingDelegate()
+        view.terminalDelegate = delegate
+        view.terminal.feed(text: "\u{1b}[?1049h") // alternate screen, no mouse tracking
+
+        guard let wheel = Self.makeWheelEvent(lines: -1) else {
+            Issue.record("could not synthesize a scroll wheel event")
+            return
+        }
+
+        view.scrollWheel(with: wheel)
+        #expect(delegate.sent == [Array(EscapeSequences.moveDownNormal)], "mode set: the wheel moves the cursor")
+
+        view.terminal.feed(text: "\u{1b}[?1007l")
+        delegate.sent = []
+        view.scrollWheel(with: wheel)
+        #expect(delegate.sent.isEmpty, "mode reset: the wheel must send nothing")
+    }
+
+    /// Suppressed motion must not be banked: trackpad deltas are accumulated
+    /// across events, so scrolling while 1007 is reset has to leave nothing
+    /// behind for the first event after the mode comes back to spend.
+    @MainActor @Test func suppressedScrollingDoesNotBankMotionForLater() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let delegate = WheelCapturingDelegate()
+        view.terminalDelegate = delegate
+        view.terminal.feed(text: "\u{1b}[?1049h\u{1b}[?1007l")
+
+        guard let cellHeight = view.cellDimension?.height, cellHeight > 2 else {
+            Issue.record("no cell metrics to build a sub-line delta from")
+            return
+        }
+        // Just under one line, so on its own this event can never move the cursor.
+        let subLine = Int32((cellHeight * 0.9).rounded())
+        guard let wheel = Self.makePreciseWheelEvent(pixels: -subLine) else {
+            Issue.record("could not synthesize a precise scroll wheel event")
+            return
+        }
+
+        for _ in 0..<5 {
+            view.scrollWheel(with: wheel)
+        }
+        #expect(delegate.sent.isEmpty, "mode reset: nothing may be sent while suppressed")
+
+        view.terminal.feed(text: "\u{1b}[?1007h")
+        view.scrollWheel(with: wheel)
+        #expect(delegate.sent.isEmpty, "a single sub-line delta must not move the cursor on its own")
+    }
+
+    private static func makeWheelEvent(lines: Int32) -> NSEvent? {
+        guard let cg = CGEvent(scrollWheelEvent2Source: nil,
+                               units: .line,
+                               wheelCount: 1,
+                               wheel1: lines,
+                               wheel2: 0,
+                               wheel3: 0) else {
+            return nil
+        }
+        cg.location = CGPoint(x: 10, y: 10)
+        return NSEvent(cgEvent: cg)
+    }
+
+    /// Pixel units give `hasPreciseScrollingDeltas`, i.e. the accumulating path.
+    private static func makePreciseWheelEvent(pixels: Int32) -> NSEvent? {
+        guard let cg = CGEvent(scrollWheelEvent2Source: nil,
+                               units: .pixel,
+                               wheelCount: 1,
+                               wheel1: pixels,
+                               wheel2: 0,
+                               wheel3: 0) else {
+            return nil
+        }
+        cg.location = CGPoint(x: 10, y: 10)
+        return NSEvent(cgEvent: cg)
+    }
+#endif
 }
+
+#if os(macOS)
+private final class WheelCapturingDelegate: TerminalViewDelegate {
+    var sent: [[UInt8]] = []
+
+    func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+    func setTerminalTitle(source: TerminalView, title: String) {}
+    func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+    func send(source: TerminalView, data: ArraySlice<UInt8>) { sent.append(Array(data)) }
+    func scrolled(source: TerminalView, position: Double) {}
+    func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+}
+#endif

--- a/Tests/SwiftTermTests/AlternateScrollModeTests.swift
+++ b/Tests/SwiftTermTests/AlternateScrollModeTests.swift
@@ -1,0 +1,78 @@
+//
+//  AlternateScrollModeTests.swift
+//
+//  DECSET/DECRST 1007: Alternate Scroll Mode (xterm's "alternateScroll" resource).
+//  SwiftTerm only tracks the mode's boolean state on Terminal.alternateScrollMode;
+//  translating scroll wheel events into cursor keys while the alt screen is active
+//  is the host view's responsibility.
+//
+import Foundation
+import Testing
+
+@testable import SwiftTerm
+
+final class AlternateScrollModeTests: TerminalDelegate {
+    var sent: [UInt8] = []
+
+    func send(source: Terminal, data: ArraySlice<UInt8>) {
+        sent.append(contentsOf: data)
+    }
+
+    func makeTerminal() -> Terminal {
+        Terminal(delegate: self, options: TerminalOptions(cols: 80, rows: 25))
+    }
+
+    @Test func defaultsToEnabled() {
+        let terminal = makeTerminal()
+        #expect(terminal.alternateScrollMode == true, "SwiftTerm defaults 1007 to on, matching modern terminals like Ghostty")
+    }
+
+    @Test func decsetEnablesAndDecrstDisables() {
+        let terminal = makeTerminal()
+
+        terminal.feed(text: "\u{1b}[?1007l")
+        #expect(terminal.alternateScrollMode == false)
+
+        terminal.feed(text: "\u{1b}[?1007h")
+        #expect(terminal.alternateScrollMode == true)
+
+        terminal.feed(text: "\u{1b}[?1007l")
+        #expect(terminal.alternateScrollMode == false)
+    }
+
+    @Test func fullResetRestoresDefault() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1007l")
+        #expect(terminal.alternateScrollMode == false)
+
+        // RIS (Reset to Initial State) should restore the mode to its default (on).
+        terminal.feed(text: "\u{1b}c")
+        #expect(terminal.alternateScrollMode == true)
+    }
+
+    @Test func modeIsIndependentOfAltScreenAndMouseTracking() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1007l")
+        terminal.feed(text: "\u{1b}[?1049h") // enter alt screen
+        #expect(terminal.alternateScrollMode == false, "entering the alt screen must not change 1007's own state")
+
+        terminal.feed(text: "\u{1b}[?1000h") // vt200 mouse tracking
+        #expect(terminal.alternateScrollMode == false, "enabling mouse tracking must not implicitly change 1007's state")
+    }
+
+    /// DECRQM (`CSI ? 1007 $ p`) must report the mode, the way the neighbouring
+    /// mouse modes (1000-1006) already do — otherwise an application can set the
+    /// mode but never find out what it currently is.
+    @Test func decrqmReportsCurrentState() {
+        let terminal = makeTerminal()
+
+        sent = []
+        terminal.feed(text: "\u{1b}[?1007$p")
+        #expect(String(decoding: sent, as: UTF8.self) == "\u{1b}[?1007;1$y", "set is reported as 1")
+
+        terminal.feed(text: "\u{1b}[?1007l")
+        sent = []
+        terminal.feed(text: "\u{1b}[?1007$p")
+        #expect(String(decoding: sent, as: UTF8.self) == "\u{1b}[?1007;2$y", "reset is reported as 2")
+    }
+}


### PR DESCRIPTION
### What

Private mode **1007** is xterm's *Alternate Scroll Mode*, which [`ctlseqs`](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html) documents as corresponding to the `alternateScroll` resource: while the alternate screen is active and the application has not enabled mouse tracking, the terminal translates wheel input into cursor up/down keys, so full-screen programs that do not read the mouse (`less`, `vim` without `mouse=a`) still respond to the scroll wheel.

SwiftTerm currently drops 1007 into the `Unhandled DEC Private Mode Set/Reset` branch. That has two consequences for an embedder that implements the translation (as SwiftTerm's own macOS view effectively does today, unconditionally): an application has no way to turn it off, and `DECRQM` cannot answer a query about it even though the neighbouring mouse modes 1000–1006 all can.

### What this does

Tracks the state only, exposed as `Terminal.alternateScrollMode`. Translating wheel events stays with the host view, consistent with how the other mouse-related state is handled. Wired into `DECSET`, `DECRST`, `DECRQM` and `RIS`, mirroring how 1004 is done.

### One choice worth a second opinion

The default here is **true**, matching Ghostty (`src/terminal/modes.zig` marks `mouse_alternate_scroll` default true), while **xterm's own `alternateScroll` resource defaults to false**. `true` keeps the wheel working out of the box in `less`/`vim`, which is what users of macOS terminals tend to expect, and it preserves SwiftTerm's current behaviour for hosts that already translate unconditionally. If you would rather follow the reference implementation, flipping it to `false` is a one-line change — happy to do that.

### Tests

`Tests/SwiftTermTests/AlternateScrollModeTests.swift`: default value, DECSET/DECRST toggling, `DECRQM` reporting `1$y`/`2$y`, `RIS` restoring the default, and independence from alt-screen / mouse-tracking state.

Full suite: 704 tests in 62 suites, all passing.