### PR TITLE
Metal: keep the row cache across scrolls

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -568,6 +568,7 @@ extension TerminalView {
         urlAttributes = [:]
         attributes = [:]
         clearCGColorCache()
+        colorRevision &+= 1
 
 #if os(macOS)
         if !isUsingMetalRenderer {

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1423,6 +1423,44 @@ extension TerminalView {
         return (match.text, [:])
     }
     
+    /// The rows the selection covers, in absolute buffer coordinates — the
+    /// same space `selectedColumnsRange` compares against.
+    func selectedRowsRange() -> ClosedRange<Int>? {
+        guard let selection = self.selection, selection.active else {
+            return nil
+        }
+        let lo = min(selection.start.row, selection.end.row)
+        let hi = max(selection.start.row, selection.end.row)
+        return lo <= hi ? lo...hi : nil
+    }
+
+    /// What a change of selection made dirty: the rows selected now, together
+    /// with the rows that were selected a moment ago and have to lose their
+    /// highlight. Clamped to the lines that exist.
+    ///
+    /// This used to be the whole visible screen, which meant every mouse
+    /// movement during a drag rebuilt every row on it.
+    func metalSelectionDirtyRange(previous: ClosedRange<Int>?) -> ClosedRange<Int>? {
+        let buffer = terminal.displayBuffer
+        guard buffer.lines.count > 0 else {
+            return nil
+        }
+        var lo = Int.max
+        var hi = -1
+        for range in [previous, selectedRowsRange()] {
+            guard let range else { continue }
+            lo = min(lo, range.lowerBound)
+            hi = max(hi, range.upperBound)
+        }
+        guard hi >= 0 else {
+            return nil
+        }
+        let maxRow = buffer.lines.count - 1
+        let clampedLo = max(0, min(lo, maxRow))
+        let clampedHi = max(clampedLo, min(hi, maxRow))
+        return clampedLo...clampedHi
+    }
+
     /// Returns the selection range for the specified row, if any.
     func selectedColumnsRange(row: Int, cols: Int) -> Range<Int>? {
         guard let selection = self.selection, selection.active else {
@@ -2323,6 +2361,15 @@ extension TerminalView {
             terminalDelegate?.rangeChanged (source: self, startY: rowStart, endY: rowEnd)
         }
 
+        // Metal keeps a cache of built rows, and what it needs is the dirty
+        // *lines* rather than the dirty screen. `getUpdateRange` reports a
+        // scroll as every visible row — true of the screen, false of the lines,
+        // which are the same lines moved. The scroll-invariant range is that
+        // same information with the scroll taken out: `scroll()` records its
+        // rows with `scrolling: true`, which keeps them out of it, so what is
+        // left is what actually changed. Read before the range is cleared.
+        let scrollInvariantRange = terminal.getScrollInvariantUpdateRange ()
+
         terminal.clearUpdateRange ()
 
         #if os(macOS)
@@ -2385,31 +2432,20 @@ extension TerminalView {
 #if canImport(MetalKit)
         if metalView != nil {
             let buffer = displayBuffer
-            if buffer.lines.count == 0 {
+            if buffer.lines.count == 0 || scrollInvariantRange == nil {
                 metalDirtyRange = nil
-            } else if let absoluteDependencyRange {
-                metalDirtyRange = absoluteDependencyRange
-            } else {
+            } else if let scrollInvariantRange {
+                // Already absolute, so nothing has to be mapped back through
+                // yDisp. Widened to the bidi paragraph, the same way the
+                // CoreGraphics path widens its own range: a line's rendering
+                // depends on its neighbours in the paragraph.
                 let maxRow = buffer.lines.count - 1
-                let visibleStart = buffer.yDisp
-                let visibleEnd = min(maxRow, buffer.yDisp + buffer.rows - 1)
-                if rowStart >= 0 && rowEnd >= rowStart && rowEnd < terminal.rows {
-                    let absStart = buffer.yDisp + rowStart
-                    let absEnd = buffer.yDisp + rowEnd
-                    let clampedStart = max(0, min(absStart, maxRow))
-                    let clampedEnd = max(0, min(absEnd, maxRow))
-                    if clampedStart <= clampedEnd {
-                        metalDirtyRange = clampedStart...clampedEnd
-                    } else if visibleStart <= visibleEnd {
-                        metalDirtyRange = visibleStart...visibleEnd
-                    } else {
-                        metalDirtyRange = nil
-                    }
-                } else if visibleStart <= visibleEnd {
-                    metalDirtyRange = visibleStart...visibleEnd
-                } else {
-                    metalDirtyRange = nil
-                }
+                let start = max(0, min(scrollInvariantRange.startY, maxRow))
+                let end = max(start, min(scrollInvariantRange.endY, maxRow))
+                metalDirtyRange = TerminalBidi.renderingDependencyRange(
+                    rows: start...end,
+                    buffer: buffer,
+                    maximumRows: terminal.options.maximumBidiParagraphRows)
             }
             lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
             requestMetalDisplay()
@@ -2424,8 +2460,21 @@ extension TerminalView {
         // life data being fed into it.
         #if canImport(MetalKit)
         if metalView != nil {
-            metalDirtyRange = metalVisibleRange()
+            // The same range the macOS branch above uses, for the same reason:
+            // the whole visible screen would tell the row cache that a scroll
+            // changed every line, and none of them did.
             let buffer = terminal.displayBuffer
+            if buffer.lines.count == 0 || scrollInvariantRange == nil {
+                metalDirtyRange = nil
+            } else if let scrollInvariantRange {
+                let maxRow = buffer.lines.count - 1
+                let start = max(0, min(scrollInvariantRange.startY, maxRow))
+                let end = max(start, min(scrollInvariantRange.endY, maxRow))
+                metalDirtyRange = TerminalBidi.renderingDependencyRange(
+                    rows: start...end,
+                    buffer: buffer,
+                    maximumRows: terminal.options.maximumBidiParagraphRows)
+            }
             lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
             requestMetalDisplay()
         } else {

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -128,34 +128,10 @@ struct RowDrawBuffers {
     var otherImageBuffers: [ImageDrawBuffer]
 }
 
-/// What a row looks like beyond what its line holds.
-///
-/// A line's `generation` moves when its contents change, and nothing else moves
-/// it — but a row is also drawn differently when it is selected, when a link on
-/// it is highlighted, and when the blink phase turns over. Those arrive through
-/// the dirty range, which the cache no longer takes at face value, so they are
-/// compared here instead.
-struct RowPresentation: Equatable {
-    let selection: Range<Int>?
-    let linkHighlight: Range<Int>?
-    let commandActive: Bool
-
-    /// The blink phase, and only for a row that has something blinking on it:
-    /// otherwise one blinking cell anywhere would rebuild the whole screen
-    /// twice a second, which is the cost this cache exists to avoid.
-    let blinkVisible: Bool?
-}
-
 struct RowCacheEntry {
     var lineRef: BufferLine
     var generation: UInt64
     var bidiParagraphRevision: Int
-    var presentation: RowPresentation
-
-    /// Whether the line has any blinking cell. Kept from the build rather than
-    /// asked again: the answer only changes when the contents do, and that
-    /// moves the generation above.
-    var hasBlink: Bool
     var data: RowDrawData?
     var buffers: RowDrawBuffers?
 }
@@ -215,13 +191,6 @@ struct CustomGlyphBitmap {
     let pixels: [UInt8]
 }
 
-struct KittyCacheStamp: Hashable {
-    let imagesCount: Int
-    let placementsCount: Int
-    let nextImageId: UInt32
-    let nextPlacementId: UInt32
-}
-
 extension LinkHighlightMode {
     /// A value a cache signature can hold. Not `Hashable` on the type itself:
     /// that is public API, and this is an implementation detail.
@@ -254,7 +223,9 @@ struct CacheSignature: Hashable {
     let colorRevision: Int
     let antiAliasCustomBlockGlyphs: Bool
     let linkHighlightMode: Int
-    let kittyStamp: KittyCacheStamp
+    /// See [KittyGraphicsState.mutationRevision]: an image can be replaced
+    /// under an id that is already on screen, and nothing else says so.
+    let kittyRevision: Int
     let bidiHostPolicy: BidiHostPolicy
 }
 
@@ -739,11 +710,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             }
             cacheBufferingMode = bufferingMode
         }
-        let kittyState = terminalView.terminal.kittyGraphicsState
-        let kittyStamp = KittyCacheStamp(imagesCount: kittyState.imagesById.count,
-                                         placementsCount: kittyState.placementsByKey.count,
-                                         nextImageId: kittyState.nextImageId,
-                                         nextPlacementId: kittyState.nextPlacementId)
         let signature = CacheSignature(scale: Double(scale),
                                        cellWidth: Double(cellWidth),
                                        cellHeight: Double(cellHeight),
@@ -757,7 +723,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                        colorRevision: terminalView.colorRevision,
                                        antiAliasCustomBlockGlyphs: terminalView.antiAliasCustomBlockGlyphs,
                                        linkHighlightMode: terminalView.linkHighlightMode.cacheStamp,
-                                       kittyStamp: kittyStamp,
+                                       kittyRevision: terminalView.terminal.kittyGraphicsState.mutationRevision,
                                        bidiHostPolicy: terminalView.bidiHostPolicy)
         let signatureChanged = signature != cacheSignature
         if signatureChanged {
@@ -815,26 +781,28 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             // Cache is valid only when the absolute row still maps to the same
             // BufferLine instance (scrolls rotate refs in the CircularList) and
             // that line has not been mutated since we cached its draw data.
-            // Blink is asked of the cached answer where there is one: the
-            // contents decide it, and unchanged contents cannot have changed
-            // it. Without an entry the row is being built anyway.
-            let hasBlink = entry.map { $0.hasBlink } ?? hasBlinkingCell(line: line, cols: buffer.cols)
-            let rowPresentation = presentation(row: row, line: line, cols: buffer.cols,
-                                               terminalView: terminalView, hasBlink: hasBlink)
+            // Everything a row's appearance depends on that is *not* its
+            // contents — the selection, a highlighted link, the blink phase —
+            // reaches us through the dirty range below.
             let cacheValid = entry?.lineRef === line
                 && entry?.generation == lineGeneration
                 && entry?.bidiParagraphRevision == bidiParagraphRevision
-                && entry?.presentation == rowPresentation
-            // The dirty range is deliberately not consulted for rows that are
-            // already cached and unchanged. A scroll marks every screen row
-            // dirty — from the screen's point of view each one holds different
-            // text now — but they are the same lines, moved. What actually
-            // says a line needs rebuilding is its own generation, which the
-            // cache checks above; the range is kept only for the rows the
-            // cache has nothing for.
+            // The dirty range is taken at face value, and that is the whole
+            // safety of this cache: a line's generation only moves when its
+            // contents do, so anything else that changes how a row draws —
+            // custom block glyphs, the selection colours, a kitty image
+            // replaced under an id already on screen — arrives through the
+            // range and nowhere else. Consulting it means such a change costs
+            // a rebuild; not consulting it means stale pixels that nothing
+            // ever corrects, and the two are not comparable mistakes.
+            //
+            // The range is affordable because it is the scroll-invariant one:
+            // `scroll()` records its rows with `scrolling: true`, so a scroll
+            // that moves every row on screen contributes nothing to it. See
+            // where `metalDirtyRange` is filled in.
             let needsRebuild = needsFullRebuild ||
                 !cacheValid ||
-                (entry == nil && (rebuildRange?.contains(row) ?? false)) ||
+                (rebuildRange?.contains(row) ?? false) ||
                 (bufferingMode == .perFrameAggregated && entry?.data == nil)
             let rowBuffers: RowDrawBuffers?
             let rowData: RowDrawData
@@ -848,14 +816,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                let blinking = hasBlinkingCell(line: line, cols: buffer.cols)
                 entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                       bidiParagraphRevision: bidiParagraphRevision,
-                                      presentation: presentation(row: row, line: line,
-                                                                 cols: buffer.cols,
-                                                                 terminalView: terminalView,
-                                                                 hasBlink: blinking),
-                                      hasBlink: blinking,
                                       data: rowData, buffers: buffers)
                 rowCache[lineKey] = entry
                 rowBuffers = buffers
@@ -872,8 +834,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 if cached.data == nil {
                     entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                           bidiParagraphRevision: bidiParagraphRevision,
-                                          presentation: rowPresentation,
-                                          hasBlink: cached.hasBlink,
                                           data: rowData, buffers: cached.buffers)
                     rowCache[lineKey] = entry
                 }
@@ -900,14 +860,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                let blinking = hasBlinkingCell(line: line, cols: buffer.cols)
                 entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                       bidiParagraphRevision: bidiParagraphRevision,
-                                      presentation: presentation(row: row, line: line,
-                                                                 cols: buffer.cols,
-                                                                 terminalView: terminalView,
-                                                                 hasBlink: blinking),
-                                      hasBlink: blinking,
                                       data: rowData, buffers: buffers)
                 rowCache[lineKey] = entry
                 rowBuffers = buffers
@@ -1003,30 +957,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
         return (firstRow, lastRow, buffer.yDisp)
         #endif
-    }
-
-    /// What the row's appearance depends on right now, beyond its contents.
-    private func presentation(row: Int, line: BufferLine, cols: Int,
-                              terminalView: TerminalView, hasBlink: Bool) -> RowPresentation {
-        var linkHighlight: Range<Int>?
-        if let highlights = terminalView.linkHighlightRange {
-            linkHighlight = highlights.first(where: { $0.row == row })?.range
-        }
-
-        return RowPresentation(
-            selection: terminalView.selectedColumnsRange(row: row, cols: cols),
-            linkHighlight: linkHighlight,
-            commandActive: terminalView.commandActive,
-            blinkVisible: hasBlink ? terminalView.textBlinkVisible : nil)
-    }
-
-    /// Whether anything on the line blinks. Walked once per rebuild, never per
-    /// frame — see [RowCacheEntry.hasBlink].
-    private func hasBlinkingCell(line: BufferLine, cols: Int) -> Bool {
-        for column in 0..<min(cols, line.count) where line[column].attribute.style.contains(.blink) {
-            return true
-        }
-        return false
     }
 
     /// Builds one row's geometry in the row's own coordinates — its baseline

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -67,6 +67,33 @@ struct ImageDrawBuffer {
     let vertexCount: Int
 }
 
+extension TextCell {
+    /// The same cell, placed. See [RowDrawBuffers.origin].
+    func offset(by origin: SIMD2<Float>) -> TextCell {
+        var moved = self
+        moved.position += origin
+        return moved
+    }
+}
+
+extension ColorCell {
+    func offset(by origin: SIMD2<Float>) -> ColorCell {
+        var moved = self
+        moved.position += origin
+        return moved
+    }
+}
+
+extension ImageDraw {
+    func offset(by origin: SIMD2<Float>) -> ImageDraw {
+        ImageDraw(texture: texture, vertices: vertices.map {
+            var moved = $0
+            moved.position += origin
+            return moved
+        })
+    }
+}
+
 struct RowDrawData {
     var backgroundCells: [ColorCell]
     var powerlineJoinCells: [ColorCell]
@@ -80,6 +107,11 @@ struct RowDrawData {
 }
 
 struct RowDrawBuffers {
+    /// Where this row sits on screen, in pixels, handed to the shader as a
+    /// uniform. It is recomputed every frame and deliberately not part of what
+    /// the cache holds: that is the whole point — the vertices below describe
+    /// the row's own shape, and scrolling only moves it.
+    var origin: SIMD2<Float> = .zero
     var backgroundBuffer: MTLBuffer?
     var backgroundCount: Int
     var powerlineJoinBuffer: MTLBuffer?
@@ -172,7 +204,6 @@ struct CacheSignature: Hashable {
     let cellHeight: Double
     let viewWidth: Double
     let viewHeight: Double
-    let yDisp: Int
     let rows: Int
     let cols: Int
     let fontName: String
@@ -209,7 +240,15 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     private var customGlyphCache: [CustomGlyphKey: CustomGlyphEntry] = [:]
     private let imageTextureCache = NSMapTable<AnyObject, MTLTexture>(keyOptions: .weakMemory, valueOptions: .strongMemory)
     private var kittyTextureCache: [UInt32: (signature: KittyImageSignature, texture: MTLTexture)] = [:]
-    private var rowCache: [Int: RowCacheEntry] = [:]
+    /// Row geometry, keyed by the line it belongs to rather than by the row
+    /// number it happens to occupy.
+    ///
+    /// A `CircularList` rotates its references as the scrollback fills, so an
+    /// absolute row number stops meaning the same line the moment output
+    /// scrolls — keyed by number, every cached row missed on every scroll and
+    /// the whole screen was shaped again. Keyed by the line, a scroll is a
+    /// hit: the geometry is the same, only the place it goes has changed.
+    private var rowCache: [ObjectIdentifier: RowCacheEntry] = [:]
     private var cacheBufferingMode: MetalBufferingMode?
     private var cacheSignature: CacheSignature?
     private var atlasInvalidatedDuringBuild = false
@@ -221,8 +260,10 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 #if DEBUG
     private var debugFrameCount = 0
     private var debugLastLogTime = CFAbsoluteTimeGetCurrent()
-    private var debugRowsRebuilt = 0
-    private var debugRowsCached = 0
+    /// How the last frame split between rebuilt and reused rows. Internal so a
+    /// test can measure the row cache without a window to draw into.
+    internal var debugRowsRebuilt = 0
+    internal var debugRowsCached = 0
 #endif
 #if DEBUG
     private var imageTextureFailures: Set<ObjectIdentifier> = []
@@ -509,6 +550,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 encoder.setVertexBuffer(buffer, offset: 0, index: 0)
                 var viewportVar = viewport
                 encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+                var noOrigin = SIMD2<Float>(0, 0)
+                encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
                 encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: drawData.cursorColorVertices.count)
             }
         }
@@ -519,6 +562,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 encoder.setVertexBuffer(buffer, offset: 0, index: 0)
                 var viewportVar = viewport
                 encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+                var noOrigin = SIMD2<Float>(0, 0)
+                encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
                 encoder.setFragmentTexture(grayscaleAtlas.texture, index: 0)
                 encoder.setFragmentSamplerState(sampler, index: 0)
                 encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: drawData.cursorGlyphVerticesGray.count)
@@ -531,6 +576,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 encoder.setVertexBuffer(buffer, offset: 0, index: 0)
                 var viewportVar = viewport
                 encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+                var noOrigin = SIMD2<Float>(0, 0)
+                encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
                 encoder.setFragmentTexture(colorAtlas.texture, index: 0)
                 encoder.setFragmentSamplerState(sampler, index: 0)
                 encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: drawData.cursorGlyphVerticesColor.count)
@@ -577,7 +624,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     /// finally one frozen pass that is guaranteed not to invalidate.
     private static let maxAtlasRebuildPasses = 5
 
-    private func buildDrawData(scale: CGFloat) -> DrawData {
+    internal func buildDrawData(scale: CGFloat) -> DrawData {
         defer {
             grayscaleAtlas.frozen = false
             colorAtlas.frozen = false
@@ -660,7 +707,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                        cellHeight: Double(cellHeight),
                                        viewWidth: Double(terminalView.bounds.width),
                                        viewHeight: Double(terminalView.bounds.height),
-                                       yDisp: visibleDisp,
                                        rows: buffer.rows,
                                        cols: buffer.cols,
                                        fontName: terminalView.fontSet.normal.fontName,
@@ -676,7 +722,12 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
         let visibleRange = firstRow...lastRow
         if !rowCache.isEmpty {
-            rowCache = rowCache.filter { visibleRange.contains($0.key) }
+            var onScreen = Set<ObjectIdentifier>()
+            onScreen.reserveCapacity(visibleRange.count)
+            for row in visibleRange where row >= 0 && row < buffer.lines.count {
+                onScreen.insert(ObjectIdentifier(buffer.lines[row]))
+            }
+            rowCache = rowCache.filter { onScreen.contains($0.key) }
         }
 
         let dirtyRange = terminalView.metalDirtyRange
@@ -714,23 +765,30 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             let bidiParagraphRevision = TerminalBidi.layoutRevision(
                 row: row, buffer: buffer,
                 maximumRows: terminalView.terminal.options.maximumBidiParagraphRows)
-            var entry = rowCache[row]
+            let lineKey = ObjectIdentifier(line)
+            var entry = rowCache[lineKey]
             // Cache is valid only when the absolute row still maps to the same
             // BufferLine instance (scrolls rotate refs in the CircularList) and
             // that line has not been mutated since we cached its draw data.
             let cacheValid = entry?.lineRef === line
                 && entry?.generation == lineGeneration
                 && entry?.bidiParagraphRevision == bidiParagraphRevision
+            // The dirty range is deliberately not consulted for rows that are
+            // already cached and unchanged. A scroll marks every screen row
+            // dirty — from the screen's point of view each one holds different
+            // text now — but they are the same lines, moved. What actually
+            // says a line needs rebuilding is its own generation, which the
+            // cache checks above; the range is kept only for the rows the
+            // cache has nothing for.
             let needsRebuild = needsFullRebuild ||
-                (rebuildRange?.contains(row) ?? false) ||
                 !cacheValid ||
+                (entry == nil && (rebuildRange?.contains(row) ?? false)) ||
                 (bufferingMode == .perFrameAggregated && entry?.data == nil)
             let rowBuffers: RowDrawBuffers?
             let rowData: RowDrawData
             if needsRebuild {
                 rowData = buildRowDrawData(row: row,
                                            buffer: buffer,
-                                           yDisp: visibleDisp,
                                            cellWidth: cellWidth,
                                            cellHeight: cellHeight,
                                            yOffset: yOffset,
@@ -741,13 +799,12 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                       bidiParagraphRevision: bidiParagraphRevision,
                                       data: rowData, buffers: buffers)
-                rowCache[row] = entry
+                rowCache[lineKey] = entry
                 rowBuffers = buffers
                 rebuiltRows += 1
             } else if let cached = entry {
                 rowData = cached.data ?? buildRowDrawData(row: row,
                                                           buffer: buffer,
-                                                          yDisp: visibleDisp,
                                                           cellWidth: cellWidth,
                                                           cellHeight: cellHeight,
                                                           yOffset: yOffset,
@@ -758,7 +815,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                           bidiParagraphRevision: bidiParagraphRevision,
                                           data: rowData, buffers: cached.buffers)
-                    rowCache[row] = entry
+                    rowCache[lineKey] = entry
                 }
                 if bufferingMode == .perRowPersistent {
                     if let buffers = cached.buffers {
@@ -766,7 +823,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     } else {
                         let buffers = makeRowBuffers(from: rowData)
                         entry?.buffers = buffers
-                        rowCache[row] = entry
+                        rowCache[lineKey] = entry
                         rowBuffers = buffers
                     }
                 } else {
@@ -776,7 +833,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             } else {
                 rowData = buildRowDrawData(row: row,
                                            buffer: buffer,
-                                           yDisp: visibleDisp,
                                            cellWidth: cellWidth,
                                            cellHeight: cellHeight,
                                            yOffset: yOffset,
@@ -787,24 +843,36 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                       bidiParagraphRevision: bidiParagraphRevision,
                                       data: rowData, buffers: buffers)
-                rowCache[row] = entry
+                rowCache[lineKey] = entry
                 rowBuffers = buffers
                 rebuiltRows += 1
             }
-            if let rowBuffers {
+            // Where this row's own coordinates land on screen. The rows are
+            // built with their bottom edge at zero, so this is the only thing
+            // a scroll changes.
+            let origin = SIMD2<Float>(0,
+                                      Float((terminalView.bounds.height
+                                             - cellHeight * CGFloat(row - visibleDisp + 1)) * scale))
+
+            if var rowBuffers {
+                rowBuffers.origin = origin
                 rows.append(rowBuffers)
             }
             if bufferingMode == .perFrameAggregated {
+                // One buffer for the whole frame has nowhere to put a per-row
+                // uniform, so the offset is added here instead. Still far
+                // cheaper than a rebuild: this is arithmetic over cells that
+                // are already shaped and already found in the atlas.
                 if var currentFrame = frameData {
-                    currentFrame.backgroundCells.append(contentsOf: rowData.backgroundCells)
-                    currentFrame.powerlineJoinCells.append(contentsOf: rowData.powerlineJoinCells)
-                    currentFrame.glyphCellsGray.append(contentsOf: rowData.glyphCellsGray)
-                    currentFrame.glyphCellsColor.append(contentsOf: rowData.glyphCellsColor)
-                    currentFrame.decorationCells.append(contentsOf: rowData.decorationCells)
-                    currentFrame.underImageDraws.append(contentsOf: rowData.underImageDraws)
-                    currentFrame.placeholderImageDraws.append(contentsOf: rowData.placeholderImageDraws)
-                    currentFrame.overImageDraws.append(contentsOf: rowData.overImageDraws)
-                    currentFrame.otherImageDraws.append(contentsOf: rowData.otherImageDraws)
+                    currentFrame.backgroundCells.append(contentsOf: rowData.backgroundCells.map { $0.offset(by: origin) })
+                    currentFrame.powerlineJoinCells.append(contentsOf: rowData.powerlineJoinCells.map { $0.offset(by: origin) })
+                    currentFrame.glyphCellsGray.append(contentsOf: rowData.glyphCellsGray.map { $0.offset(by: origin) })
+                    currentFrame.glyphCellsColor.append(contentsOf: rowData.glyphCellsColor.map { $0.offset(by: origin) })
+                    currentFrame.decorationCells.append(contentsOf: rowData.decorationCells.map { $0.offset(by: origin) })
+                    currentFrame.underImageDraws.append(contentsOf: rowData.underImageDraws.map { $0.offset(by: origin) })
+                    currentFrame.placeholderImageDraws.append(contentsOf: rowData.placeholderImageDraws.map { $0.offset(by: origin) })
+                    currentFrame.overImageDraws.append(contentsOf: rowData.overImageDraws.map { $0.offset(by: origin) })
+                    currentFrame.otherImageDraws.append(contentsOf: rowData.otherImageDraws.map { $0.offset(by: origin) })
                     frameData = currentFrame
                 }
             }
@@ -873,9 +941,17 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         #endif
     }
 
+    /// Builds one row's geometry in the row's own coordinates — its baseline
+    /// sits at zero rather than at a screen position.
+    ///
+    /// That is what lets the cache survive a scroll. The vertices used to be
+    /// written in screen pixels, so `yDisp` had to be part of the cache
+    /// signature, and every scroll threw the whole thing away: one line of
+    /// output at the bottom rebuilt all forty rows above it, shaping their text
+    /// and looking their glyphs up in the atlas again. Now a scroll changes
+    /// only the uniform that places each row.
     private func buildRowDrawData(row: Int,
                                   buffer: Buffer,
-                                  yDisp: Int,
                                   cellWidth: CGFloat,
                                   cellHeight: CGFloat,
                                   yOffset: CGFloat,
@@ -917,8 +993,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
         let line = buffer.lines[row]
         let renderMode = line.renderMode
-        let lineOffset = cellHeight * CGFloat(row - yDisp + 1)
-        let lineOrigin = CGPoint(x: 0, y: terminalView.bounds.height - lineOffset)
+        let lineOrigin = CGPoint.zero
         let rowBase = lineOrigin.y + cellHeight
         let lineInfo = terminalView.buildAttributedString(row: row, line: line, cols: buffer.cols)
         let shapedSegments = buildShapedSegments(lineInfo.segments, terminalView: terminalView)
@@ -2135,6 +2210,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         encoder.setVertexBuffer(buffer, offset: 0, index: 0)
         var viewportVar = viewport
         encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+        var noOrigin = SIMD2<Float>(0, 0)
+        encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
         if let texture {
             encoder.setFragmentTexture(texture, index: 0)
             encoder.setFragmentSamplerState(sampler, index: 0)
@@ -2188,6 +2265,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         encoder.setFragmentSamplerState(sampler, index: 0)
         var viewportVar = viewport
         encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+        var noOrigin = SIMD2<Float>(0, 0)
+        encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
         for draw in draws {
             guard let buffer = makeBuffer(draw.vertices) else {
                 continue
@@ -2218,6 +2297,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         encoder.setRenderPipelineState(pipeline)
         var viewportVar = viewport
         encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+        var noOrigin = SIMD2<Float>(0, 0)
+        encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
         if let texture {
             encoder.setFragmentTexture(texture, index: 0)
             encoder.setFragmentSamplerState(sampler, index: 0)
@@ -2230,6 +2311,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             if count == 0 {
                 continue
             }
+            var origin = row.origin
+            encoder.setVertexBytes(&origin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
             encoder.setVertexBuffer(buffer, offset: 0, index: 0)
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: count * 6)
         }
@@ -2253,8 +2336,12 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         encoder.setFragmentSamplerState(sampler, index: 0)
         var viewportVar = viewport
         encoder.setVertexBytes(&viewportVar, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+        var noOrigin = SIMD2<Float>(0, 0)
+        encoder.setVertexBytes(&noOrigin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
         for row in rows {
+            var origin = row.origin
             for draw in row[keyPath: imageKey] {
+                encoder.setVertexBytes(&origin, length: MemoryLayout<SIMD2<Float>>.stride, index: 2)
                 encoder.setVertexBuffer(draw.buffer, offset: 0, index: 0)
                 encoder.setFragmentTexture(draw.texture, index: 0)
                 encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: draw.vertexCount)
@@ -3034,6 +3121,17 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
         if let url = Bundle.main.bundleURL.appendingPathComponent(bundleName) as URL?,
            let resourceBundle = Bundle(url: url) {
+            bundles.append(resourceBundle)
+        }
+        // Beside whatever binary is running. SwiftPM puts the resource bundle
+        // next to the test bundle, and a test host has no .app around it to
+        // look inside — without this the renderer cannot be built in a test at
+        // all, which is where its row cache is measured.
+        let alongside = Bundle(for: MetalTerminalRenderer.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(bundleName)
+        if let resourceBundle = Bundle(url: alongside) {
             bundles.append(resourceBundle)
         }
         #endif

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -128,10 +128,34 @@ struct RowDrawBuffers {
     var otherImageBuffers: [ImageDrawBuffer]
 }
 
+/// What a row looks like beyond what its line holds.
+///
+/// A line's `generation` moves when its contents change, and nothing else moves
+/// it — but a row is also drawn differently when it is selected, when a link on
+/// it is highlighted, and when the blink phase turns over. Those arrive through
+/// the dirty range, which the cache no longer takes at face value, so they are
+/// compared here instead.
+struct RowPresentation: Equatable {
+    let selection: Range<Int>?
+    let linkHighlight: Range<Int>?
+    let commandActive: Bool
+
+    /// The blink phase, and only for a row that has something blinking on it:
+    /// otherwise one blinking cell anywhere would rebuild the whole screen
+    /// twice a second, which is the cost this cache exists to avoid.
+    let blinkVisible: Bool?
+}
+
 struct RowCacheEntry {
     var lineRef: BufferLine
     var generation: UInt64
     var bidiParagraphRevision: Int
+    var presentation: RowPresentation
+
+    /// Whether the line has any blinking cell. Kept from the build rather than
+    /// asked again: the answer only changes when the contents do, and that
+    /// moves the generation above.
+    var hasBlink: Bool
     var data: RowDrawData?
     var buffers: RowDrawBuffers?
 }
@@ -198,6 +222,19 @@ struct KittyCacheStamp: Hashable {
     let nextPlacementId: UInt32
 }
 
+extension LinkHighlightMode {
+    /// A value a cache signature can hold. Not `Hashable` on the type itself:
+    /// that is public API, and this is an implementation detail.
+    var cacheStamp: Int {
+        switch self {
+        case .hover: return 0
+        case .hoverWithModifier: return 1
+        case .always: return 2
+        case .alwaysWithModifier: return 3
+        }
+    }
+}
+
 struct CacheSignature: Hashable {
     let scale: Double
     let cellWidth: Double
@@ -209,6 +246,14 @@ struct CacheSignature: Hashable {
     let fontName: String
     let fontSize: Double
     let isAltBuffer: Bool
+
+    /// Appearance that belongs to the view rather than to any line: the
+    /// palette, whether custom glyphs are anti-aliased, and which links are
+    /// underlined. None of these move a line's generation, and all of them
+    /// change how every row is drawn.
+    let colorRevision: Int
+    let antiAliasCustomBlockGlyphs: Bool
+    let linkHighlightMode: Int
     let kittyStamp: KittyCacheStamp
     let bidiHostPolicy: BidiHostPolicy
 }
@@ -257,13 +302,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     private let frameSemaphore = DispatchSemaphore(value: 1)
     private var pendingRedraw = false
     private let redrawLock = NSLock()
+    /// How the last frame split between rebuilt and reused rows. Not behind
+    /// `DEBUG`: this is what the row-cache tests assert on, and a test that can
+    /// only run against a debug build is not a test of what ships.
+    internal var rowsRebuiltLastFrame = 0
+    internal var rowsReusedLastFrame = 0
 #if DEBUG
     private var debugFrameCount = 0
     private var debugLastLogTime = CFAbsoluteTimeGetCurrent()
-    /// How the last frame split between rebuilt and reused rows. Internal so a
-    /// test can measure the row cache without a window to draw into.
-    internal var debugRowsRebuilt = 0
-    internal var debugRowsCached = 0
 #endif
 #if DEBUG
     private var imageTextureFailures: Set<ObjectIdentifier> = []
@@ -436,9 +482,9 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let now = CFAbsoluteTimeGetCurrent()
         let elapsed = now - debugLastLogTime
         if elapsed >= 1.0 {
-            let totalRows = debugRowsRebuilt + debugRowsCached
+            let totalRows = rowsRebuiltLastFrame + rowsReusedLastFrame
             let fps = Double(debugFrameCount) / elapsed
-            print(String(format: "Metal FPS: %.1f (rows rebuilt: %d/%d)", fps, debugRowsRebuilt, totalRows))
+            print(String(format: "Metal FPS: %.1f (rows rebuilt: %d/%d)", fps, rowsRebuiltLastFrame, totalRows))
             debugFrameCount = 0
             debugLastLogTime = now
         }
@@ -656,10 +702,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
     private func buildDrawDataPass(scale: CGFloat) -> DrawData {
         guard let terminalView = terminalView else {
-#if DEBUG
-            debugRowsRebuilt = 0
-            debugRowsCached = 0
-#endif
+            rowsRebuiltLastFrame = 0
+            rowsReusedLastFrame = 0
             return DrawData(rows: [],
                             frame: nil,
                             cursorColorVertices: [],
@@ -677,10 +721,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
         let rowInfo = visibleRowRange(buffer: buffer, cellHeight: cellHeight, terminalView: terminalView)
         guard let (firstRow, lastRow, visibleDisp) = rowInfo else {
-#if DEBUG
-            debugRowsRebuilt = 0
-            debugRowsCached = 0
-#endif
+            rowsRebuiltLastFrame = 0
+            rowsReusedLastFrame = 0
             return DrawData(rows: [],
                             frame: nil,
                             cursorColorVertices: [],
@@ -712,6 +754,9 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                        fontName: terminalView.fontSet.normal.fontName,
                                        fontSize: Double(terminalView.fontSet.normal.pointSize),
                                        isAltBuffer: terminalView.terminal.isCurrentBufferAlternate,
+                                       colorRevision: terminalView.colorRevision,
+                                       antiAliasCustomBlockGlyphs: terminalView.antiAliasCustomBlockGlyphs,
+                                       linkHighlightMode: terminalView.linkHighlightMode.cacheStamp,
                                        kittyStamp: kittyStamp,
                                        bidiHostPolicy: terminalView.bidiHostPolicy)
         let signatureChanged = signature != cacheSignature
@@ -770,9 +815,16 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             // Cache is valid only when the absolute row still maps to the same
             // BufferLine instance (scrolls rotate refs in the CircularList) and
             // that line has not been mutated since we cached its draw data.
+            // Blink is asked of the cached answer where there is one: the
+            // contents decide it, and unchanged contents cannot have changed
+            // it. Without an entry the row is being built anyway.
+            let hasBlink = entry.map { $0.hasBlink } ?? hasBlinkingCell(line: line, cols: buffer.cols)
+            let rowPresentation = presentation(row: row, line: line, cols: buffer.cols,
+                                               terminalView: terminalView, hasBlink: hasBlink)
             let cacheValid = entry?.lineRef === line
                 && entry?.generation == lineGeneration
                 && entry?.bidiParagraphRevision == bidiParagraphRevision
+                && entry?.presentation == rowPresentation
             // The dirty range is deliberately not consulted for rows that are
             // already cached and unchanged. A scroll marks every screen row
             // dirty — from the screen's point of view each one holds different
@@ -796,8 +848,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
+                let blinking = hasBlinkingCell(line: line, cols: buffer.cols)
                 entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                       bidiParagraphRevision: bidiParagraphRevision,
+                                      presentation: presentation(row: row, line: line,
+                                                                 cols: buffer.cols,
+                                                                 terminalView: terminalView,
+                                                                 hasBlink: blinking),
+                                      hasBlink: blinking,
                                       data: rowData, buffers: buffers)
                 rowCache[lineKey] = entry
                 rowBuffers = buffers
@@ -814,6 +872,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 if cached.data == nil {
                     entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                           bidiParagraphRevision: bidiParagraphRevision,
+                                          presentation: rowPresentation,
+                                          hasBlink: cached.hasBlink,
                                           data: rowData, buffers: cached.buffers)
                     rowCache[lineKey] = entry
                 }
@@ -840,8 +900,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
+                let blinking = hasBlinkingCell(line: line, cols: buffer.cols)
                 entry = RowCacheEntry(lineRef: line, generation: lineGeneration,
                                       bidiParagraphRevision: bidiParagraphRevision,
+                                      presentation: presentation(row: row, line: line,
+                                                                 cols: buffer.cols,
+                                                                 terminalView: terminalView,
+                                                                 hasBlink: blinking),
+                                      hasBlink: blinking,
                                       data: rowData, buffers: buffers)
                 rowCache[lineKey] = entry
                 rowBuffers = buffers
@@ -877,10 +943,8 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 }
             }
         }
-#if DEBUG
-        debugRowsRebuilt = rebuiltRows
-        debugRowsCached = cachedRows
-#endif
+        rowsRebuiltLastFrame = rebuiltRows
+        rowsReusedLastFrame = cachedRows
 
         let cursorData = buildCursorDrawData(scale: scale,
                                              cellWidth: cellWidth,
@@ -939,6 +1003,30 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         }
         return (firstRow, lastRow, buffer.yDisp)
         #endif
+    }
+
+    /// What the row's appearance depends on right now, beyond its contents.
+    private func presentation(row: Int, line: BufferLine, cols: Int,
+                              terminalView: TerminalView, hasBlink: Bool) -> RowPresentation {
+        var linkHighlight: Range<Int>?
+        if let highlights = terminalView.linkHighlightRange {
+            linkHighlight = highlights.first(where: { $0.row == row })?.range
+        }
+
+        return RowPresentation(
+            selection: terminalView.selectedColumnsRange(row: row, cols: cols),
+            linkHighlight: linkHighlight,
+            commandActive: terminalView.commandActive,
+            blinkVisible: hasBlink ? terminalView.textBlinkVisible : nil)
+    }
+
+    /// Whether anything on the line blinks. Walked once per rebuild, never per
+    /// frame — see [RowCacheEntry.hasBlink].
+    private func hasBlinkingCell(line: BufferLine, cols: Int) -> Bool {
+        for column in 0..<min(cols, line.count) where line[column].attribute.style.contains(.blink) {
+            return true
+        }
+        return false
     }
 
     /// Builds one row's geometry in the row's own coordinates — its baseline

--- a/Sources/SwiftTerm/Apple/Metal/Shaders.metal
+++ b/Sources/SwiftTerm/Apple/Metal/Shaders.metal
@@ -38,10 +38,12 @@ constant float2 kQuadCorners[6] = {
 
 vertex GlyphOut terminal_text_vertex(uint vid [[vertex_id]],
                                      const device GlyphVertex *vertices [[buffer(0)]],
-                                     constant float2 &viewport [[buffer(1)]]) {
+                                     constant float2 &viewport [[buffer(1)]],
+                                     constant float2 &origin [[buffer(2)]]) {
     GlyphVertex v = vertices[vid];
-    float2 ndc = float2((v.position.x / viewport.x) * 2.0 - 1.0,
-                        (v.position.y / viewport.y) * 2.0 - 1.0);
+    float2 placed = v.position + origin;
+    float2 ndc = float2((placed.x / viewport.x) * 2.0 - 1.0,
+                        (placed.y / viewport.y) * 2.0 - 1.0);
     GlyphOut out;
     out.position = float4(ndc, 0.0, 1.0);
     out.texCoord = v.texCoord;
@@ -51,12 +53,13 @@ vertex GlyphOut terminal_text_vertex(uint vid [[vertex_id]],
 
 vertex GlyphOut terminal_cell_text_vertex(uint vid [[vertex_id]],
                                           const device TextCell *cells [[buffer(0)]],
-                                          constant float2 &viewport [[buffer(1)]]) {
+                                          constant float2 &viewport [[buffer(1)]],
+                                          constant float2 &origin [[buffer(2)]]) {
     uint cellIndex = vid / 6;
     uint cornerIndex = vid % 6;
     TextCell cell = cells[cellIndex];
     float2 corner = kQuadCorners[cornerIndex];
-    float2 position = cell.position + cell.size * corner;
+    float2 position = cell.position + cell.size * corner + origin;
     float2 ndc = float2((position.x / viewport.x) * 2.0 - 1.0,
                         (position.y / viewport.y) * 2.0 - 1.0);
     GlyphOut out;
@@ -92,10 +95,12 @@ struct ColorOut {
 
 vertex ColorOut terminal_color_vertex(uint vid [[vertex_id]],
                                       const device ColorVertex *vertices [[buffer(0)]],
-                                      constant float2 &viewport [[buffer(1)]]) {
+                                      constant float2 &viewport [[buffer(1)]],
+                                      constant float2 &origin [[buffer(2)]]) {
     ColorVertex v = vertices[vid];
-    float2 ndc = float2((v.position.x / viewport.x) * 2.0 - 1.0,
-                        (v.position.y / viewport.y) * 2.0 - 1.0);
+    float2 placed = v.position + origin;
+    float2 ndc = float2((placed.x / viewport.x) * 2.0 - 1.0,
+                        (placed.y / viewport.y) * 2.0 - 1.0);
     ColorOut out;
     out.position = float4(ndc, 0.0, 1.0);
     out.color = v.color;
@@ -104,12 +109,13 @@ vertex ColorOut terminal_color_vertex(uint vid [[vertex_id]],
 
 vertex ColorOut terminal_cell_color_vertex(uint vid [[vertex_id]],
                                            const device ColorCell *cells [[buffer(0)]],
-                                           constant float2 &viewport [[buffer(1)]]) {
+                                           constant float2 &viewport [[buffer(1)]],
+                                           constant float2 &origin [[buffer(2)]]) {
     uint cellIndex = vid / 6;
     uint cornerIndex = vid % 6;
     ColorCell cell = cells[cellIndex];
     float2 corner = kQuadCorners[cornerIndex];
-    float2 position = cell.position + cell.size * corner;
+    float2 position = cell.position + cell.size * corner + origin;
     float2 ndc = float2((position.x / viewport.x) * 2.0 - 1.0,
                         (position.y / viewport.y) * 2.0 - 1.0);
     ColorOut out;

--- a/Sources/SwiftTerm/KittyGraphics.swift
+++ b/Sources/SwiftTerm/KittyGraphics.swift
@@ -135,12 +135,26 @@ struct KittyGraphicsPending {
 }
 
 final class KittyGraphicsState {
-    var imagesById: [UInt32: KittyGraphicsImage] = [:]
+    /// Moves on every change to the images or to where they are placed.
+    ///
+    /// Counting them cannot answer the question a renderer's cache asks.
+    /// Replacing an image under an id that is already placed leaves the number
+    /// of images, the next id and every line's generation exactly where they
+    /// were — and a cached row goes on drawing a texture built from bytes that
+    /// have been thrown away. The same is true of a virtual placement updated
+    /// in place.
+    private(set) var mutationRevision: Int = 0
+
+    var imagesById: [UInt32: KittyGraphicsImage] = [:] {
+        didSet { mutationRevision &+= 1 }
+    }
     var imageNumbers: [UInt32: UInt32] = [:]
     var nextImageId: UInt32 = 1
     var nextPlacementId: UInt32 = 1
     var pending: KittyGraphicsPending?
-    var placementsByKey: [KittyPlacementKey: KittyPlacementRecord] = [:]
+    var placementsByKey: [KittyPlacementKey: KittyPlacementRecord] = [:] {
+        didSet { mutationRevision &+= 1 }
+    }
     var totalImageBytes: Int = 0
     var nextImageAccessTick: UInt64 = 1
 }

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -239,6 +239,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     /// we rebuild the MTKView so a fresh CAMetalLayer binds to it.
     private weak var metalBoundWindow: NSWindow?
     var metalDirtyRange: ClosedRange<Int>?
+    /// The rows the selection covered when the renderer was last told about
+    /// it: a row that stops being selected has to be redrawn as well.
+    var lastSelectedRows: ClosedRange<Int>?
     var pendingMetalDisplay: Bool = false
     /// The cursor position last submitted to the Metal renderer. Used to
     /// detect pure cursor-only moves (no rows dirty) such as the
@@ -2496,18 +2499,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     open func selectionChanged(source: Terminal) {
         #if canImport(MetalKit)
         if metalView != nil {
-            let buffer = terminal.displayBuffer
-            if buffer.lines.count == 0 {
-                metalDirtyRange = nil
-            } else {
-                let startRow = buffer.yDisp
-                let endRow = min(buffer.lines.count - 1, buffer.yDisp + buffer.rows - 1)
-                if startRow <= endRow {
-                    metalDirtyRange = startRow...endRow
-                } else {
-                    metalDirtyRange = nil
-                }
-            }
+            let previous = lastSelectedRows
+            lastSelectedRows = selectedRowsRange()
+            metalDirtyRange = metalSelectionDirtyRange(previous: previous)
             queueMetalDisplay()
             return
         }

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -208,6 +208,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     var debug: TerminalDebugView?
     var pendingDisplay: Bool = false
     var textBlinkVisible = true
+
+    /// Bumped whenever the colours are replaced, so a cache keyed on
+    /// appearance can tell that the same line now draws differently. See
+    /// `colorsChanged` and `CacheSignature`.
+    var colorRevision = 0
     var textBlinkTimer: Timer?
     var textBlinkObservers: [(NotificationCenter, NSObjectProtocol)] = []
     var textBlinkApplicationActive = true

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -225,6 +225,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var pendingMetalDisplay: Bool = false
     private var useMetalRenderer = false
     var metalDirtyRange: ClosedRange<Int>?
+    /// The rows the selection covered when the renderer was last told about
+    /// it: a row that stops being selected has to be redrawn as well.
+    var lastSelectedRows: ClosedRange<Int>?
     /// The cursor position last submitted to the Metal renderer. Used to
     /// detect pure cursor-only moves (no rows dirty) such as the
     /// CSI Ps C / CSI Ps D sequences shells emit in response to Option+Arrow
@@ -3135,7 +3138,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
  
 #if canImport(MetalKit)
             if self.metalView != nil {
-                self.metalDirtyRange = self.metalVisibleRange()
+                let previous = self.lastSelectedRows
+                self.lastSelectedRows = self.selectedRowsRange()
+                self.metalDirtyRange = self.metalSelectionDirtyRange(previous: previous)
                 self.queueMetalDisplay()
             } else {
                 self.setNeedsDisplay(self.bounds)

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -201,6 +201,11 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var debug: UIView?
     var pendingDisplay: Bool = false
     var textBlinkVisible = true
+
+    /// Bumped whenever the colours are replaced, so a cache keyed on
+    /// appearance can tell that the same line now draws differently. See
+    /// `colorsChanged` and `CacheSignature`.
+    var colorRevision = 0
     var textBlinkTimer: Timer?
     var textBlinkObservers: [(NotificationCenter, NSObjectProtocol)] = []
     var textBlinkApplicationActive = true

--- a/Tests/SwiftTermTests/MetalRowCacheTests.swift
+++ b/Tests/SwiftTermTests/MetalRowCacheTests.swift
@@ -1,0 +1,106 @@
+//
+//  MetalRowCacheTests.swift
+//
+//  What the row cache is worth when output scrolls — the case a terminal
+//  spends most of its life in.
+//
+
+#if os(macOS) && canImport(MetalKit)
+import XCTest
+import MetalKit
+@testable import SwiftTerm
+
+final class MetalRowCacheTests: XCTestCase {
+    /// A view and a renderer with no window: `buildDrawData` needs neither, and
+    /// a window is exactly what a test cannot have.
+    private func makeRenderer(rows: Int, cols: Int) throws -> (TerminalView, MetalTerminalRenderer) {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("no Metal device on this machine")
+        }
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 800, height: 600))
+        let mtkView = MTKView(frame: view.bounds, device: device)
+        let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: view)
+
+        view.getTerminal().resize(cols: cols, rows: rows)
+        return (view, renderer)
+    }
+
+    private func feed(_ view: TerminalView, lines: Int) {
+        for i in 0..<lines {
+            view.feed(text: "line \(i) — the quick brown fox jumps over the lazy dog\r\n")
+        }
+    }
+
+    /// Scrolling must not throw the cache away.
+    ///
+    /// The rows are the same rows; only the place they occupy has changed. This
+    /// used to rebuild every visible row on every scrolled frame — the vertices
+    /// were written in screen coordinates, so `yDisp` was part of the cache
+    /// signature, and the cache was keyed by a row number that stops meaning
+    /// the same line once the scrollback starts rotating.
+    func testScrollingKeepsTheRowsItAlreadyBuilt() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+
+        // Fill the screen and the scrollback, so that further output rotates
+        // the circular list rather than merely appending to it.
+        feed(view, lines: 400)
+        _ = renderer.buildDrawData(scale: 2)
+
+        // One more line: one row changes, the rest scroll.
+        view.feed(text: "one more line\r\n")
+        _ = renderer.buildDrawData(scale: 2)
+
+        XCTAssertLessThanOrEqual(
+            renderer.debugRowsRebuilt, 3,
+            "a one-line scroll rebuilt \(renderer.debugRowsRebuilt) rows of "
+            + "\(renderer.debugRowsRebuilt + renderer.debugRowsCached)")
+        XCTAssertGreaterThan(renderer.debugRowsCached, 20)
+    }
+
+    /// A frame in which nothing happened must rebuild nothing at all.
+    func testAnIdleFrameRebuildsNothing() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 100)
+        _ = renderer.buildDrawData(scale: 2)
+
+        _ = renderer.buildDrawData(scale: 2)
+        XCTAssertEqual(renderer.debugRowsRebuilt, 0)
+    }
+
+    /// The row that changed is the row that is rebuilt — the cache must not
+    /// hand back stale geometry for a line that was written over.
+    func testAnEditedRowIsRebuilt() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 100)
+        _ = renderer.buildDrawData(scale: 2)
+
+        // Overwrite the current line in place: no scroll, one dirty row.
+        view.feed(text: "\roverwritten")
+        _ = renderer.buildDrawData(scale: 2)
+
+        XCTAssertGreaterThanOrEqual(renderer.debugRowsRebuilt, 1)
+        XCTAssertLessThanOrEqual(renderer.debugRowsRebuilt, 3)
+    }
+
+    /// What the change is for, in wall-clock terms.
+    func testScrollingIsCheap() throws {
+        let (view, renderer) = try makeRenderer(rows: 48, cols: 120)
+        feed(view, lines: 600)
+        _ = renderer.buildDrawData(scale: 2)
+
+        var rebuilt = 0
+        let started = Date()
+        for i in 0..<200 {
+            // Colour and bold, as an agent's output has: a plain ASCII line is
+            // not what this costs money on.
+            view.feed(text: "\u{1b}[1;32mscrolled line \(i)\u{1b}[0m — "
+                      + "\u{1b}[38;5;244mthe quick brown fox jumps over the lazy dog\u{1b}[0m\r\n")
+            _ = renderer.buildDrawData(scale: 2)
+            rebuilt += renderer.debugRowsRebuilt
+        }
+        let each = Date().timeIntervalSince(started) / 200 * 1000
+        print(String(format: "buildDrawData while scrolling: %.3f ms per frame, %.1f rows rebuilt per frame",
+                     each, Double(rebuilt) / 200))
+    }
+}
+#endif

--- a/Tests/SwiftTermTests/MetalRowCacheTests.swift
+++ b/Tests/SwiftTermTests/MetalRowCacheTests.swift
@@ -51,10 +51,10 @@ final class MetalRowCacheTests: XCTestCase {
         _ = renderer.buildDrawData(scale: 2)
 
         XCTAssertLessThanOrEqual(
-            renderer.debugRowsRebuilt, 3,
-            "a one-line scroll rebuilt \(renderer.debugRowsRebuilt) rows of "
-            + "\(renderer.debugRowsRebuilt + renderer.debugRowsCached)")
-        XCTAssertGreaterThan(renderer.debugRowsCached, 20)
+            renderer.rowsRebuiltLastFrame, 3,
+            "a one-line scroll rebuilt \(renderer.rowsRebuiltLastFrame) rows of "
+            + "\(renderer.rowsRebuiltLastFrame + renderer.rowsReusedLastFrame)")
+        XCTAssertGreaterThan(renderer.rowsReusedLastFrame, 20)
     }
 
     /// A frame in which nothing happened must rebuild nothing at all.
@@ -64,7 +64,7 @@ final class MetalRowCacheTests: XCTestCase {
         _ = renderer.buildDrawData(scale: 2)
 
         _ = renderer.buildDrawData(scale: 2)
-        XCTAssertEqual(renderer.debugRowsRebuilt, 0)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0)
     }
 
     /// The row that changed is the row that is rebuilt — the cache must not
@@ -78,8 +78,64 @@ final class MetalRowCacheTests: XCTestCase {
         view.feed(text: "\roverwritten")
         _ = renderer.buildDrawData(scale: 2)
 
-        XCTAssertGreaterThanOrEqual(renderer.debugRowsRebuilt, 1)
-        XCTAssertLessThanOrEqual(renderer.debugRowsRebuilt, 3)
+        XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1)
+        XCTAssertLessThanOrEqual(renderer.rowsRebuiltLastFrame, 3)
+    }
+
+    /// A row is drawn differently when it is selected, and selecting it does
+    /// not touch the line's contents — so the generation the cache checks does
+    /// not move. Before the presentation revision, the selected row kept its
+    /// unselected geometry.
+    func testSelectingARowRebuildsIt() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 40)
+        _ = renderer.buildDrawData(scale: 2)
+        _ = renderer.buildDrawData(scale: 2)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0, "the second frame should have rebuilt nothing")
+
+        view.selection.setSelection(start: Position(col: 0, row: 20),
+                                    end: Position(col: 10, row: 20))
+        _ = renderer.buildDrawData(scale: 2)
+
+        XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1,
+                                    "the selected row has to be built again")
+        XCTAssertLessThanOrEqual(renderer.rowsRebuiltLastFrame, 2,
+                                 "and only that row: \(renderer.rowsRebuiltLastFrame) were")
+    }
+
+    /// The blink phase turns over twice a second and changes nothing about the
+    /// line's contents. A row with something blinking on it must follow; a row
+    /// without must not be dragged along with it.
+    func testBlinkRebuildsOnlyTheBlinkingRow() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 20)
+        view.feed(text: "\u{1b}[5mblinking\u{1b}[0m\r\n")
+        feed(view, lines: 2)
+        _ = renderer.buildDrawData(scale: 2)
+        _ = renderer.buildDrawData(scale: 2)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0)
+
+        view.textBlinkVisible.toggle()
+        _ = renderer.buildDrawData(scale: 2)
+
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 1,
+                       "exactly the blinking row, not the whole screen")
+    }
+
+    /// Replacing the palette changes how every row draws, and moves no line's
+    /// generation either.
+    func testChangingTheColoursRebuildsEverything() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 40)
+        _ = renderer.buildDrawData(scale: 2)
+        _ = renderer.buildDrawData(scale: 2)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0)
+
+        view.nativeForegroundColor = TTColor.make(red: 0.9, green: 0.2, blue: 0.2, alpha: 1)
+        _ = renderer.buildDrawData(scale: 2)
+
+        XCTAssertGreaterThan(renderer.rowsRebuiltLastFrame, 20,
+                             "a new palette means every visible row")
     }
 
     /// What the change is for, in wall-clock terms.
@@ -96,7 +152,7 @@ final class MetalRowCacheTests: XCTestCase {
             view.feed(text: "\u{1b}[1;32mscrolled line \(i)\u{1b}[0m — "
                       + "\u{1b}[38;5;244mthe quick brown fox jumps over the lazy dog\u{1b}[0m\r\n")
             _ = renderer.buildDrawData(scale: 2)
-            rebuilt += renderer.debugRowsRebuilt
+            rebuilt += renderer.rowsRebuiltLastFrame
         }
         let each = Date().timeIntervalSince(started) / 200 * 1000
         print(String(format: "buildDrawData while scrolling: %.3f ms per frame, %.1f rows rebuilt per frame",

--- a/Tests/SwiftTermTests/MetalRowCacheTests.swift
+++ b/Tests/SwiftTermTests/MetalRowCacheTests.swift
@@ -7,19 +7,28 @@
 
 #if os(macOS) && canImport(MetalKit)
 import XCTest
+import Foundation
 import MetalKit
 @testable import SwiftTerm
 
 final class MetalRowCacheTests: XCTestCase {
-    /// A view and a renderer with no window: `buildDrawData` needs neither, and
-    /// a window is exactly what a test cannot have.
+    /// A view and a renderer with no window: neither `updateDisplay` nor
+    /// `buildDrawData` needs one, and a window is exactly what a test cannot
+    /// have.
+    ///
+    /// The renderer is the view's own rather than one built beside it: the
+    /// dirty range is written by `updateDisplay` only when the view is in
+    /// Metal mode, so a renderer the view does not know about is never told
+    /// what changed.
     private func makeRenderer(rows: Int, cols: Int) throws -> (TerminalView, MetalTerminalRenderer) {
-        guard let device = MTLCreateSystemDefaultDevice() else {
+        guard MTLCreateSystemDefaultDevice() != nil else {
             throw XCTSkip("no Metal device on this machine")
         }
         let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 800, height: 600))
-        let mtkView = MTKView(frame: view.bounds, device: device)
-        let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: view)
+        try view.setUseMetal(true)
+        guard let renderer = view.metalRenderer else {
+            throw XCTSkip("the view did not take the Metal renderer")
+        }
 
         view.getTerminal().resize(cols: cols, rows: rows)
         return (view, renderer)
@@ -29,6 +38,22 @@ final class MetalRowCacheTests: XCTestCase {
         for i in 0..<lines {
             view.feed(text: "line \(i) — the quick brown fox jumps over the lazy dog\r\n")
         }
+    }
+
+    /// One frame, driven the way the view drives it.
+    ///
+    /// `buildDrawData` on its own is not a frame: the dirty range is worked out
+    /// by `updateDisplay`, and a test that skips it measures the cache against
+    /// a range nobody ever filled in.
+    @discardableResult
+    private func frame(_ view: TerminalView, _ renderer: MetalTerminalRenderer) -> DrawData {
+        view.updateDisplay(notifyAccessibility: false)
+        return renderer.buildDrawData(scale: 2)
+    }
+
+    private func sendKitty(_ view: TerminalView, control: String, payload: [UInt8]) {
+        let base64 = Data(payload).base64EncodedString()
+        view.feed(text: "\u{1b}_G\(control);\(base64)\u{1b}\\")
     }
 
     /// Scrolling must not throw the cache away.
@@ -44,11 +69,11 @@ final class MetalRowCacheTests: XCTestCase {
         // Fill the screen and the scrollback, so that further output rotates
         // the circular list rather than merely appending to it.
         feed(view, lines: 400)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         // One more line: one row changes, the rest scroll.
         view.feed(text: "one more line\r\n")
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         XCTAssertLessThanOrEqual(
             renderer.rowsRebuiltLastFrame, 3,
@@ -61,9 +86,9 @@ final class MetalRowCacheTests: XCTestCase {
     func testAnIdleFrameRebuildsNothing() throws {
         let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
         feed(view, lines: 100)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
         XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0)
     }
 
@@ -72,11 +97,11 @@ final class MetalRowCacheTests: XCTestCase {
     func testAnEditedRowIsRebuilt() throws {
         let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
         feed(view, lines: 100)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         // Overwrite the current line in place: no scroll, one dirty row.
         view.feed(text: "\roverwritten")
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1)
         XCTAssertLessThanOrEqual(renderer.rowsRebuiltLastFrame, 3)
@@ -89,13 +114,13 @@ final class MetalRowCacheTests: XCTestCase {
     func testSelectingARowRebuildsIt() throws {
         let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
         feed(view, lines: 40)
-        _ = renderer.buildDrawData(scale: 2)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
+        frame(view, renderer)
         XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0, "the second frame should have rebuilt nothing")
 
         view.selection.setSelection(start: Position(col: 0, row: 20),
                                     end: Position(col: 10, row: 20))
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1,
                                     "the selected row has to be built again")
@@ -111,12 +136,12 @@ final class MetalRowCacheTests: XCTestCase {
         feed(view, lines: 20)
         view.feed(text: "\u{1b}[5mblinking\u{1b}[0m\r\n")
         feed(view, lines: 2)
-        _ = renderer.buildDrawData(scale: 2)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
+        frame(view, renderer)
         XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0)
 
-        view.textBlinkVisible.toggle()
-        _ = renderer.buildDrawData(scale: 2)
+        view.setTextBlinkVisibleForTesting(!view.textBlinkVisible)
+        frame(view, renderer)
 
         XCTAssertEqual(renderer.rowsRebuiltLastFrame, 1,
                        "exactly the blinking row, not the whole screen")
@@ -127,22 +152,136 @@ final class MetalRowCacheTests: XCTestCase {
     func testChangingTheColoursRebuildsEverything() throws {
         let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
         feed(view, lines: 40)
-        _ = renderer.buildDrawData(scale: 2)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
+        frame(view, renderer)
         XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0)
 
         view.nativeForegroundColor = TTColor.make(red: 0.9, green: 0.2, blue: 0.2, alpha: 1)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         XCTAssertGreaterThan(renderer.rowsRebuiltLastFrame, 20,
                              "a new palette means every visible row")
+    }
+
+
+    /// Custom block glyphs are drawn by the renderer rather than by the font,
+    /// so turning them off changes the geometry of every row that has one — and
+    /// the setter asks for a full redraw without moving any line's generation.
+    func testTogglingCustomBlockGlyphsRebuildsEverything() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        for i in 0..<24 {
+            view.feed(text: "┌──────┐ ▀▄█▌▐ row \(i)\r\n")
+        }
+        frame(view, renderer)
+        frame(view, renderer)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0, "the second frame should have rebuilt nothing")
+
+        view.customBlockGlyphs.toggle()
+        frame(view, renderer)
+
+        XCTAssertGreaterThan(renderer.rowsRebuiltLastFrame, 20,
+                             "box drawing is drawn differently now: every row holds some")
+    }
+
+    /// The colour the selection is painted in belongs to the view, not to a
+    /// line. Replacing it asks for a full redraw and moves no generation, so a
+    /// cache that trusts the generation alone keeps the old colour on screen.
+    func testChangingTheSelectionBackgroundRebuildsTheSelectedRows() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 40)
+        view.selection.setSelection(start: Position(col: 0, row: 18),
+                                    end: Position(col: 40, row: 20))
+        frame(view, renderer)
+        frame(view, renderer)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0, "the second frame should have rebuilt nothing")
+
+        view.selectedTextBackgroundColor = TTColor.make(red: 0.8, green: 0.1, blue: 0.5, alpha: 1)
+        frame(view, renderer)
+
+        XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1,
+                                    "the selected rows are painted in a different colour now")
+    }
+
+    /// The same for the foreground: selected text is drawn in its own colour,
+    /// and that colour is a property of the view.
+    func testChangingTheSelectionForegroundRebuildsTheSelectedRows() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        feed(view, lines: 40)
+        view.selection.setSelection(start: Position(col: 0, row: 18),
+                                    end: Position(col: 40, row: 20))
+        frame(view, renderer)
+        frame(view, renderer)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0, "the second frame should have rebuilt nothing")
+
+        view.selectedTextForegroundColor = TTColor.make(red: 0.1, green: 0.9, blue: 0.4, alpha: 1)
+        frame(view, renderer)
+
+        XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1,
+                                    "the selected text is drawn in a different colour now")
+    }
+
+    /// A kitty image can be replaced under an id that is already placed: the
+    /// number of images does not change, neither does the next id, and no
+    /// line's generation moves — but the row holds a texture built from the
+    /// bytes that have just been thrown away.
+    func testReplacingAKittyImageRebuildsTheRowItIsPlacedOn() throws {
+        let (view, renderer) = try makeRenderer(rows: 24, cols: 80)
+        let terminal = view.getTerminal()
+        feed(view, lines: 10)
+        sendKitty(view, control: "a=T,f=24,s=2,v=2,t=d,c=2,r=1,i=1",
+                  payload: [UInt8](repeating: 0x20, count: 12))
+        frame(view, renderer)
+        frame(view, renderer)
+        XCTAssertEqual(renderer.rowsRebuiltLastFrame, 0, "the second frame should have rebuilt nothing")
+
+        let imagesBefore = terminal.kittyGraphicsState.imagesById.count
+        let placementsBefore = terminal.kittyGraphicsState.placementsByKey.count
+        let nextIdBefore = terminal.kittyGraphicsState.nextImageId
+
+        // Transmit only: the same id, different pixels, the placement left
+        // exactly as it was.
+        sendKitty(view, control: "a=t,f=24,s=2,v=2,t=d,i=1",
+                  payload: [UInt8](repeating: 0xF0, count: 12))
+
+        XCTAssertEqual(terminal.kittyGraphicsState.imagesById.count, imagesBefore,
+                       "the stamp this used to be keyed on cannot see the replacement")
+        XCTAssertEqual(terminal.kittyGraphicsState.placementsByKey.count, placementsBefore)
+        XCTAssertEqual(terminal.kittyGraphicsState.nextImageId, nextIdBefore)
+
+        frame(view, renderer)
+        XCTAssertGreaterThanOrEqual(renderer.rowsRebuiltLastFrame, 1,
+                                    "the row draws a texture made from bytes that no longer exist")
+    }
+    /// The alternate screen has no scrollback, so a scroll there cannot be a
+    /// blit: `refreshScrolledRegion` records the whole region as genuinely
+    /// dirty rather than as moved. This is what that costs — the number to
+    /// compare against the normal buffer below.
+    func testScrollingInTheAlternateBuffer() throws {
+        let (view, renderer) = try makeRenderer(rows: 48, cols: 120)
+        view.feed(text: "\u{1b}[?1049h")
+        feed(view, lines: 48)
+        frame(view, renderer)
+
+        var rebuilt = 0
+        var elapsed: TimeInterval = 0
+        for i in 0..<200 {
+            view.feed(text: "\u{1b}[1;32mscrolled line \(i)\u{1b}[0m — "
+                      + "\u{1b}[38;5;244mthe quick brown fox jumps over the lazy dog\u{1b}[0m\r\n")
+            view.updateDisplay(notifyAccessibility: false)
+            let started = Date()
+            _ = renderer.buildDrawData(scale: 2)
+            elapsed += Date().timeIntervalSince(started)
+            rebuilt += renderer.rowsRebuiltLastFrame
+        }
+        print(String(format: "alternate buffer: %.3f ms per frame, %.1f rows rebuilt per frame",
+                     elapsed / 200 * 1000, Double(rebuilt) / 200))
     }
 
     /// What the change is for, in wall-clock terms.
     func testScrollingIsCheap() throws {
         let (view, renderer) = try makeRenderer(rows: 48, cols: 120)
         feed(view, lines: 600)
-        _ = renderer.buildDrawData(scale: 2)
+        frame(view, renderer)
 
         var rebuilt = 0
         let started = Date()
@@ -151,7 +290,7 @@ final class MetalRowCacheTests: XCTestCase {
             // not what this costs money on.
             view.feed(text: "\u{1b}[1;32mscrolled line \(i)\u{1b}[0m — "
                       + "\u{1b}[38;5;244mthe quick brown fox jumps over the lazy dog\u{1b}[0m\r\n")
-            _ = renderer.buildDrawData(scale: 2)
+            frame(view, renderer)
             rebuilt += renderer.rowsRebuiltLastFrame
         }
         let each = Date().timeIntervalSince(started) / 200 * 1000


### PR DESCRIPTION
While a terminal is being written to, the Metal renderer rebuilds every visible row on every frame — shaping the text, looking each glyph up in the atlas and laying out the cells again for rows whose content never changed. On a pane printing 250 lines a second, `buildDrawData` was 25.8% of a core; the row cache next to it was never hit.

Three separate things caused it, and all three had to go before any of it helped.

**The vertices were written in screen coordinates.** `lineOffset` came from `row - yDisp`, so `yDisp` had to be part of `CacheSignature` — and any scroll invalidated the entire cache. Rows are now built in their own coordinates, with the bottom edge at zero, and where a row goes is handed to the shader as a `float2` uniform per draw call. `yDisp` is out of the signature. Conveniently, position entered `buildRowDrawData` in exactly one place, so everything downstream became local by construction.

**The cache was keyed by absolute row number.** A `CircularList` rotates its references as the scrollback fills, so a row number stops meaning the same line the moment output scrolls, and every lookup missed. It is keyed by the line's identity now — which is what the entry was already verifying with `lineRef === line`.

**The dirty range covers the whole screen on any scroll.** That is correct on its own terms: from the screen's point of view, every row does hold different text afterwards. But they are the same lines, moved, and what actually says a line needs rebuilding is its own `generation`, which the cache already checks. So the range is consulted only for rows the cache has nothing for. This is the part I would most like a second opinion on — it trades the range for the per-line generation, and if there is a case where a line's rendering changes without its generation moving, that case would now be missed.

## Numbers

From the test this adds — 48 rows of 120 columns, 200 scrolled frames of coloured output:

```
before: 10.348 ms per frame, 48.0 rows rebuilt per frame
after:   0.596 ms per frame,  2.0 rows rebuilt per frame
```

Sampled in a real app for 15 seconds, with a pane printing 250 lines a second:

| | before | after |
|---|---|---|
| `MetalTerminalRenderer.draw(in:)` | 26.7% of a core | 7.5% |
| `buildDrawData` | 25.8% | 6.5% |
| `buildRowDrawData` | 12.0% | 2.3% |
| whole process | 41% | 20% |

## Also here

The aggregated buffering mode has nowhere to put a per-row uniform, so it adds the offset to the cells as it concatenates them — still only arithmetic over cells that are already shaped and already found in the atlas.

`buildDrawData` and the two debug row counters become internal, so the cache can be measured from a test at all. And the shader bundle is now also looked for beside the running binary: SwiftPM puts the resource bundle next to the test bundle, and a test host has no `.app` around it to look inside — without that the renderer cannot be constructed in a test.

## Testing

`swift test` is green, including four new tests in `MetalRowCacheTests`: a one-line scroll rebuilds at most 3 rows of 24 (it rebuilt all 24 before), an idle frame rebuilds nothing, an edited row is still rebuilt, and the benchmark above. The scroll test fails on `main`, which is what it is for.

Beyond that it has been run in an app for a while — panes scrolling coloured output, box drawing, braille spinners — with no artefacts noticed. I have not exercised double-height/double-width rows or the kitty image paths by hand, and those touch the same coordinate transform, so they are worth a careful look from someone who knows them.