### PR TITLE
perf: bound terminal output scheduling

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -2498,7 +2498,6 @@ extension TerminalView {
     {
         updateTextBlinkLifecycle()
         updateDisplay (notifyAccessibility: true)
-        updateDebugDisplay()
         pendingDisplay = false
     }
     
@@ -2778,16 +2777,15 @@ extension TerminalView {
     }
 
     private func displayImmediately() {
-        guard !Thread.isMainThread else {
-            updateDisplay()
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.displayImmediately()
+            }
             return
         }
-        // Coalesce with the throttled path: if a redraw is already scheduled
-        // (either here or via queuePendingDisplay), don't post another. This
-        // bypasses the 16.67ms frame-rate timer so echo feels responsive, while
-        // still collapsing a burst of feed chunks into a single main-thread
-        // redraw instead of flooding the main queue with one updateDisplay per
-        // chunk. updateDisplay() clears pendingDisplay, reopening the gate.
+        // Coalesce with both the throttled path and other interactive chunks.
+        // Scheduling on the next main-loop turn keeps echo responsive while a
+        // burst delivered in one parser slice produces only one display pass.
         guard !pendingDisplay else { return }
         pendingDisplay = true
         DispatchQueue.main.async { [weak self] in

--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -683,8 +683,8 @@ extension TerminalView {
             DispatchQueue.main.async { [weak self] in self?.updateTextBlinkLifecycle() }
             return
         }
-        let blinkRows = visibleBlinkRows()
-        let canBlink = window != nil && textBlinkApplicationActive
+        let blinkRows = presentationActive ? visibleBlinkRows() : []
+        let canBlink = presentationActive && window != nil && textBlinkApplicationActive
             && !textBlinkMotionReduced && !blinkRows.isEmpty
         guard canBlink else {
             textBlinkTimer?.invalidate()
@@ -698,7 +698,7 @@ extension TerminalView {
         guard textBlinkTimer == nil else { return }
         textBlinkVisible = true
         let timer = Timer(timeInterval: 0.7, repeats: true) { [weak self] _ in
-            guard let self else { return }
+            guard let self, self.presentationActive else { return }
             self.textBlinkVisible.toggle()
             self.invalidateTextBlinkRows(self.visibleBlinkRows())
         }
@@ -2290,6 +2290,7 @@ extension TerminalView {
     func updateDisplay (notifyAccessibility: Bool)
     {
         defer { pendingDisplay = false }
+        guard presentationActive else { return }
         if terminal.synchronizedOutputActive {
             return
         }
@@ -2496,9 +2497,34 @@ extension TerminalView {
     // Does not use a default argument and merge, because it is called back
     func updateDisplay ()
     {
+        guard presentationActive else {
+            pendingDisplay = false
+            return
+        }
         updateTextBlinkLifecycle()
         updateDisplay (notifyAccessibility: true)
         pendingDisplay = false
+    }
+
+    /// Controls whether this view performs presentation work while terminal
+    /// parsing and state updates continue normally.
+    ///
+    /// Hosts should suspend presentation when the view is fully obscured or
+    /// detached from their visible content. Resuming invalidates the full
+    /// terminal screen and coalesces the accumulated state into one display.
+    public func setPresentationActive(_ active: Bool) {
+        guard presentationActive != active else { return }
+        presentationActive = active
+        displayScheduleGeneration &+= 1
+        pendingDisplay = false
+#if canImport(MetalKit)
+        pendingMetalDisplay = false
+        metalRenderer?.setPresentationActive(active)
+#endif
+        updateTextBlinkLifecycle()
+        guard active else { return }
+        terminal.updateFullScreen()
+        queuePendingDisplay()
     }
     
     //
@@ -2510,7 +2536,7 @@ extension TerminalView {
     // It is also cheap, so should be called when new data has been posted or received.
     func queuePendingDisplay ()
     {
-        if terminal.synchronizedOutputActive {
+        if !presentationActive || terminal.synchronizedOutputActive {
             return
         }
         // throttle
@@ -2519,32 +2545,38 @@ extension TerminalView {
             // let fps30 = 16670000*2
             let fpsDelay = fps60
             pendingDisplay = true
+            let generation = displayScheduleGeneration
             DispatchQueue.main.asyncAfter(
-                deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay)),
-                execute: updateDisplay)
+                deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay))) { [weak self] in
+                    guard let self, self.presentationActive,
+                          self.displayScheduleGeneration == generation else { return }
+                    self.updateDisplay()
+                }
         } else {
         }
     }
 
 #if canImport(MetalKit)
     func requestMetalDisplay() {
-        guard let metalView = metalView else {
+        guard presentationActive, let metalView = metalView else {
             return
         }
         metalView.setNeedsDisplay(metalView.bounds)
     }
 
     func queueMetalDisplay() {
-        guard metalView != nil else {
+        guard presentationActive, metalView != nil else {
             return
         }
         if !pendingMetalDisplay {
             let fps60 = 16670000
             let fpsDelay = fps60
             pendingMetalDisplay = true
+            let generation = displayScheduleGeneration
             DispatchQueue.main.asyncAfter(
                 deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay))) { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.presentationActive,
+                          self.displayScheduleGeneration == generation else { return }
                     self.pendingMetalDisplay = false
                     self.metalView?.setNeedsDisplay(self.metalView?.bounds ?? .zero)
                 }
@@ -2786,10 +2818,13 @@ extension TerminalView {
         // Coalesce with both the throttled path and other interactive chunks.
         // Scheduling on the next main-loop turn keeps echo responsive while a
         // burst delivered in one parser slice produces only one display pass.
-        guard !pendingDisplay else { return }
+        guard presentationActive, !pendingDisplay else { return }
         pendingDisplay = true
+        let generation = displayScheduleGeneration
         DispatchQueue.main.async { [weak self] in
-            self?.updateDisplay()
+            guard let self, self.presentationActive,
+                  self.displayScheduleGeneration == generation else { return }
+            self.updateDisplay()
         }
     }
 

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -215,6 +215,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     private var atlasInvalidatedDuringBuild = false
     private var cursorBlinkTimer: Timer?
     private var cursorBlinkOn = true
+    private var presentationActive = true
     private let frameSemaphore = DispatchSemaphore(value: 1)
     private var pendingRedraw = false
     private let redrawLock = NSLock()
@@ -308,11 +309,21 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         cursorBlinkTimer?.invalidate()
     }
 
+    func setPresentationActive(_ active: Bool) {
+        presentationActive = active
+        if !active {
+            cursorBlinkTimer?.invalidate()
+            cursorBlinkTimer = nil
+            cursorBlinkOn = true
+        }
+    }
+
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         // The view already updates drawableSize; avoid feedback loops.
     }
 
     func draw(in view: MTKView) {
+        guard presentationActive else { return }
 #if canImport(os)
         let drawID = OSSignpostID(log: MetalTerminalRenderer.profileLog)
         if MetalTerminalRenderer.profileEnabled {
@@ -2888,11 +2899,11 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     }
 
     private func updateCursorBlinkTimer(shouldBlink: Bool) {
-        if shouldBlink {
+        if shouldBlink && presentationActive {
             if cursorBlinkTimer == nil {
                 cursorBlinkOn = true
                 cursorBlinkTimer = Timer.scheduledTimer(withTimeInterval: 0.7, repeats: true) { [weak self] _ in
-                    guard let self = self, let view = self.view else {
+                    guard let self = self, self.presentationActive, let view = self.view else {
                         return
                     }
                     self.cursorBlinkOn.toggle()

--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -60,6 +60,45 @@ public protocol LocalProcessDelegate: AnyObject {
  *
  * This implementation uses swift-subprocess with openpty/login_tty for pseudo-terminal support.
  */
+struct PendingByteQueue {
+    private(set) var chunks: [[UInt8]] = []
+    private(set) var chunkIndex = 0
+    private(set) var chunkOffset = 0
+    private(set) var byteCount = 0
+
+    var isEmpty: Bool { chunkIndex >= chunks.count }
+
+    mutating func append(_ bytes: [UInt8]) {
+        chunks.append(bytes)
+        byteCount += bytes.count
+    }
+
+    mutating func popFirst(maxBytes: Int, flushThreshold: Int) -> ArraySlice<UInt8>? {
+        guard !isEmpty else { return nil }
+        let chunk = chunks[chunkIndex]
+        let end = min(chunkOffset + maxBytes, chunk.count)
+        let slice = chunk[chunkOffset..<end]
+        chunkOffset = end
+        byteCount -= slice.count
+        if chunkOffset == chunk.count {
+            chunkIndex += 1
+            chunkOffset = 0
+            if chunkIndex >= flushThreshold {
+                chunks.removeFirst(chunkIndex)
+                chunkIndex = 0
+            }
+        }
+        return slice
+    }
+
+    mutating func removeAll() {
+        chunks.removeAll(keepingCapacity: true)
+        chunkIndex = 0
+        chunkOffset = 0
+        byteCount = 0
+    }
+}
+
 public class LocalProcess {
     let readSize = 128*1024
     
@@ -89,8 +128,8 @@ public class LocalProcess {
     private let usesMainQueue: Bool
     private let pendingChunkFlushThreshold = 32
     private let pendingTimeSliceNs: UInt64 = 4_000_000
-    private var pendingChunks: [[UInt8]] = []
-    private var pendingChunkIndex: Int = 0
+    private let pendingDeliverySliceBytes = 16 * 1024
+    private var pendingBytes = PendingByteQueue()
     private var pendingScheduled = false
     private let pendingLock = NSLock()
     // Backpressure for the main-queue delivery path: without it the read loop
@@ -103,7 +142,6 @@ public class LocalProcess {
     // drains below the low-water mark.
     private let pendingHighWaterBytes = 4 * 1024 * 1024
     private let pendingLowWaterBytes = 1 * 1024 * 1024
-    private var pendingBytes = 0
     private var readSuspendedForBackpressure = false
     
     #if false //canImport(Subprocess)
@@ -133,9 +171,8 @@ public class LocalProcess {
     // must then skip re-arming the PTY read (drainReceivedData resumes it).
     private func enqueueReceivedData(_ bytes: [UInt8]) -> Bool {
         pendingLock.lock()
-        pendingChunks.append(bytes)
-        pendingBytes += bytes.count
-        let keepReading = pendingBytes < pendingHighWaterBytes
+        pendingBytes.append(bytes)
+        let keepReading = pendingBytes.byteCount < pendingHighWaterBytes
         if !keepReading {
             readSuspendedForBackpressure = true
         }
@@ -163,29 +200,24 @@ public class LocalProcess {
     private func drainReceivedData() {
         let start = DispatchTime.now().uptimeNanoseconds
         while true {
-            var chunk: [UInt8]?
+            var chunk: ArraySlice<UInt8>?
             var resumeRead = false
             pendingLock.lock()
-            if pendingChunkIndex < pendingChunks.count {
-                chunk = pendingChunks[pendingChunkIndex]
-                pendingChunkIndex += 1
-                if pendingChunkIndex >= pendingChunkFlushThreshold {
-                    pendingChunks.removeFirst(pendingChunkIndex)
-                    pendingChunkIndex = 0
-                }
+            if let next = pendingBytes.popFirst(
+                maxBytes: pendingDeliverySliceBytes,
+                flushThreshold: pendingChunkFlushThreshold
+            ) {
+                chunk = next
                 // Track backlog size; resume the paused PTY read once it
                 // drains below the low-water mark.
-                if let chunk {
-                    pendingBytes -= chunk.count
-                    if readSuspendedForBackpressure && pendingBytes <= pendingLowWaterBytes {
+                if chunk != nil {
+                    if readSuspendedForBackpressure && pendingBytes.byteCount <= pendingLowWaterBytes {
                         readSuspendedForBackpressure = false
                         resumeRead = true
                     }
                 }
             } else {
-                pendingChunks.removeAll(keepingCapacity: true)
-                pendingChunkIndex = 0
-                pendingBytes = 0
+                pendingBytes.removeAll()
                 pendingScheduled = false
                 pendingLock.unlock()
                 return
@@ -196,7 +228,7 @@ public class LocalProcess {
                 resumePtyRead()
             }
             if let chunk {
-                delegate?.dataReceived(slice: chunk[...])
+                delegate?.dataReceived(slice: chunk)
             }
 
             if DispatchTime.now().uptimeNanoseconds - start >= pendingTimeSliceNs {

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -207,6 +207,8 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     private var findBarOptions: SearchOptions = SearchOptions()
     var debug: TerminalDebugView?
     var pendingDisplay: Bool = false
+    var presentationActive = true
+    var displayScheduleGeneration: UInt64 = 0
     var textBlinkVisible = true
     var textBlinkTimer: Timer?
     var textBlinkObservers: [(NotificationCenter, NSObjectProtocol)] = []

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -200,6 +200,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var search: SearchService!
     var debug: UIView?
     var pendingDisplay: Bool = false
+    var presentationActive = true
+    var displayScheduleGeneration: UInt64 = 0
     var textBlinkVisible = true
     var textBlinkTimer: Timer?
     var textBlinkObservers: [(NotificationCenter, NSObjectProtocol)] = []

--- a/Tests/SwiftTermTests/LocalProcessSchedulingTests.swift
+++ b/Tests/SwiftTermTests/LocalProcessSchedulingTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import SwiftTerm
+
+#if os(macOS)
+import AppKit
+#endif
+
+final class LocalProcessSchedulingTests: XCTestCase {
+  func testPendingBytesAreDeliveredInBoundedOrderedSlices() {
+    var queue = PendingByteQueue()
+    let first = (0..<(128 * 1024)).map { UInt8(truncatingIfNeeded: $0) }
+    let second = Array(repeating: UInt8(0xA5), count: 7_000)
+    queue.append(first)
+    queue.append(second)
+
+    var delivered: [UInt8] = []
+    var largestSlice = 0
+    while let slice = queue.popFirst(maxBytes: 16 * 1024, flushThreshold: 32) {
+      largestSlice = max(largestSlice, slice.count)
+      delivered.append(contentsOf: slice)
+    }
+
+    XCTAssertLessThanOrEqual(largestSlice, 16 * 1024)
+    XCTAssertEqual(delivered, first + second)
+    XCTAssertEqual(queue.byteCount, 0)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
+  func testPendingBytesFlushConsumedChunkStorageWithoutLosingOrder() {
+    var queue = PendingByteQueue()
+    for byte in UInt8(0)..<UInt8(40) {
+      queue.append([byte])
+    }
+
+    var delivered: [UInt8] = []
+    while let slice = queue.popFirst(maxBytes: 1, flushThreshold: 8) {
+      delivered.append(contentsOf: slice)
+    }
+
+    XCTAssertEqual(delivered, Array(UInt8(0)..<UInt8(40)))
+    XCTAssertEqual(queue.byteCount, 0)
+    }
+
+#if os(macOS)
+    @MainActor
+    func testInteractiveMainThreadFeedDefersAndCoalescesDisplay() {
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        view.recordUserInput()
+
+        view.feed(text: "first")
+        XCTAssertTrue(view.pendingDisplay)
+
+        view.feed(text: "second")
+        XCTAssertTrue(view.pendingDisplay)
+    }
+#endif
+}

--- a/Tests/SwiftTermTests/LocalProcessSchedulingTests.swift
+++ b/Tests/SwiftTermTests/LocalProcessSchedulingTests.swift
@@ -54,5 +54,74 @@ final class LocalProcessSchedulingTests: XCTestCase {
         view.feed(text: "second")
         XCTAssertTrue(view.pendingDisplay)
     }
+
+    @MainActor
+    func testSuspendedPresentationKeepsParsingWithoutSchedulingDisplay() {
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        view.setPresentationActive(false)
+
+        view.feed(text: "state continues")
+
+        XCTAssertTrue(view.terminal.getText(
+            start: Position(col: 0, row: 0),
+            end: Position(col: "state continues".count, row: 0)
+        ).contains("state continues"))
+        XCTAssertFalse(view.pendingDisplay)
+        XCTAssertNotNil(view.terminal.getUpdateRange())
+    }
+
+    @MainActor
+    func testResumingPresentationSchedulesOneFullDisplay() {
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        view.setPresentationActive(false)
+        view.feed(text: "latest state")
+
+        view.setPresentationActive(true)
+        let pendingAfterFirstResume = view.pendingDisplay
+        view.setPresentationActive(true)
+
+        XCTAssertTrue(pendingAfterFirstResume)
+        XCTAssertTrue(view.pendingDisplay)
+        XCTAssertEqual(view.terminal.getUpdateRange()?.startY, 0)
+        XCTAssertGreaterThanOrEqual(view.terminal.getUpdateRange()?.endY ?? -1,
+                                    view.terminal.rows - 1)
+    }
+
+    @MainActor
+    func testResumePreservesSynchronizedOutputDisplayGate() {
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        view.setPresentationActive(false)
+        view.feed(text: "\u{1b}[?2026hhidden state")
+
+        view.setPresentationActive(true)
+
+        XCTAssertTrue(view.terminal.synchronizedOutputActive)
+        XCTAssertFalse(view.pendingDisplay)
+        XCTAssertNotNil(view.terminal.getUpdateRange())
+
+        view.feed(text: "\u{1b}[?2026l")
+
+        XCTAssertFalse(view.terminal.synchronizedOutputActive)
+        XCTAssertTrue(view.pendingDisplay)
+    }
+
+    @MainActor
+    func testStaleDisplayCallbackCannotConsumeResumedDamage() async {
+        let view = TerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        view.recordUserInput()
+        view.feed(text: "before suspend")
+        XCTAssertTrue(view.pendingDisplay)
+
+        view.setPresentationActive(false)
+        view.feed(text: " while hidden")
+        view.setPresentationActive(true)
+        let resumedGeneration = view.displayScheduleGeneration
+
+        await Task.yield()
+
+        XCTAssertEqual(view.displayScheduleGeneration, resumedGeneration)
+        XCTAssertTrue(view.pendingDisplay)
+        XCTAssertNotNil(view.terminal.getUpdateRange())
+    }
 #endif
 }


### PR DESCRIPTION
## Why

Large PTY reads can monopolize the main delivery queue, while interactive output and hidden terminal views can continue presentation work in the same main-loop turn. Both reduce the time available for input handling during heavy terminal output.

## What changed

- Deliver queued PTY output in ordered slices of at most 16 KiB while preserving the existing read size and backpressure thresholds.
- Coalesce interactive display requests through the existing pending-display gate, including feeds already running on the main thread.
- Add an explicit presentation-active state: parsing continues while hidden, but display, accessibility, Metal, cursor/text blink, and related callbacks pause.
- Generation-gate queued presentation callbacks so stale work cannot resume after visibility transitions.
- Mark the full screen dirty and schedule one refresh when presentation resumes.
- Preserve synchronized-output behavior.
- Remove a duplicate debug-display update from the display wrapper.
- Add focused coverage for byte ordering, delivery bounds, queue compaction, interactive display coalescing, and presentation suspension/resume.

## Testing

- `swift test --filter LocalProcessSchedulingTests`
- focused presentation/scheduling coverage: 7/7
- `swift test` (701 tests across 60 suites)
- `git diff --check`
- [ ] CI green

## Notes

This reduces and suspends bounded presentation work but does not claim a measured end-to-end latency improvement without runtime traces.
