### PR TITLE
Retry frames refused by the Metal renderer

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -218,6 +218,16 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
     private let frameSemaphore = DispatchSemaphore(value: 1)
     private var pendingRedraw = false
     private let redrawLock = NSLock()
+    /// Whether a retry for a refused frame is already in flight, so a burst of
+    /// refusals coalesces into a single pending retry.
+    private var refusedFrameRetryScheduled = false
+    /// Backoff for retrying a refused frame. Starts at one 60 Hz frame and
+    /// doubles up to `maxRefusedFrameRetryDelay`, so a view that cannot
+    /// present for a long time (zero-sized, off-screen) settles into a cheap
+    /// poll instead of spinning at frame rate. Reset once a frame is submitted.
+    private static let minRefusedFrameRetryDelay: TimeInterval = 1.0 / 60
+    private static let maxRefusedFrameRetryDelay: TimeInterval = 0.5
+    private var refusedFrameRetryDelay = MetalTerminalRenderer.minRefusedFrameRetryDelay
 #if DEBUG
     private var debugFrameCount = 0
     private var debugLastLogTime = CFAbsoluteTimeGetCurrent()
@@ -326,6 +336,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 #endif
         if frameSemaphore.wait(timeout: .now()) != .success {
             markPendingRedraw()
+            scheduleRefusedFrameRetry(for: view)
             return
         }
         guard let terminalView = terminalView else {
@@ -376,6 +387,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         guard let drawable, let passDescriptor else {
             markPendingRedraw()
             frameSemaphore.signal()
+            scheduleRefusedFrameRetry(for: view)
             return
         }
 #if canImport(os)
@@ -422,9 +434,17 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 os_signpost(.end, log: MetalTerminalRenderer.profileLog, name: "Metal.Encode", signpostID: encodeID)
             }
 #endif
+            // Same trap as the drawable/semaphore refusals below: this frame is
+            // dropped, and without a pending marker plus a retry the requested
+            // redraw is simply lost.
+            markPendingRedraw()
             frameSemaphore.signal()
+            scheduleRefusedFrameRetry(for: view)
             return
         }
+        // A frame is about to be submitted, so its completion handler will
+        // consume any pending redraw: drop back to the fast retry interval.
+        resetRefusedFrameRetryBackoff()
         let frameSemaphore = self.frameSemaphore
         commandBuffer.addCompletedHandler { [weak self, weak view] _ in
             frameSemaphore.signal()
@@ -570,6 +590,59 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         pendingRedraw = false
         redrawLock.unlock()
         return needsRedraw
+    }
+
+    private var hasPendingRedraw: Bool {
+        redrawLock.lock()
+        defer { redrawLock.unlock() }
+        return pendingRedraw
+    }
+
+    /// Re-requests a frame that `draw(in:)` refused to render.
+    ///
+    /// `pendingRedraw` is otherwise consumed only by the completion handler of
+    /// a *submitted* command buffer. Every refusal path returns without
+    /// submitting one, so the pending request has no consumer and the view
+    /// stops presenting until something external invalidates it again. For an
+    /// on-demand `MTKView` (`isPaused`, `enableSetNeedsDisplay`) driven by
+    /// terminal output, that "something" may never arrive: further output
+    /// re-enters the same refusal, and so does client-side invalidation.
+    ///
+    /// Retries coalesce (one in flight at a time) and back off up to
+    /// `maxRefusedFrameRetryDelay`, so a view that cannot present for a long
+    /// time — zero-sized, off-screen, or waiting on a lost completion — settles
+    /// into a cheap poll rather than spinning at frame rate.
+    private func scheduleRefusedFrameRetry(for view: MTKView) {
+        redrawLock.lock()
+        if refusedFrameRetryScheduled {
+            redrawLock.unlock()
+            return
+        }
+        refusedFrameRetryScheduled = true
+        let delay = refusedFrameRetryDelay
+        refusedFrameRetryDelay = min(
+            delay * 2,
+            MetalTerminalRenderer.maxRefusedFrameRetryDelay
+        )
+        redrawLock.unlock()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak view] in
+            guard let self else { return }
+            self.redrawLock.lock()
+            self.refusedFrameRetryScheduled = false
+            self.redrawLock.unlock()
+            // Peek rather than consume: the redraw stays outstanding until a
+            // frame is actually submitted, and the completion handler of that
+            // frame is what clears it.
+            guard let view, self.hasPendingRedraw else { return }
+            view.setNeedsDisplay(view.bounds)
+        }
+    }
+
+    private func resetRefusedFrameRetryBackoff() {
+        redrawLock.lock()
+        refusedFrameRetryDelay = MetalTerminalRenderer.minRefusedFrameRetryDelay
+        redrawLock.unlock()
     }
 
     /// Worst case before the working set is stable: a few grows


### PR DESCRIPTION
# Metal renderer stops presenting after a refused frame

## Summary

`MetalTerminalRenderer.draw(in:)` can permanently stop presenting frames. The view keeps accepting input and terminal output, the `Terminal` and PTY stay healthy, but nothing is ever drawn again — the pane is simply black until the client rebuilds the renderer.

## Mechanism

`pendingRedraw` is consumed in exactly one place: the completion handler of a submitted command buffer.

```swift
commandBuffer.addCompletedHandler { [weak self, weak view] _ in
    frameSemaphore.signal()
    ...
    if self.consumePendingRedraw() { ...setNeedsDisplay... }
}
```

But every path that *refuses* a frame returns before a command buffer exists:

1. `frameSemaphore.wait(timeout: .now()) != .success` → `markPendingRedraw()`, return.
2. `guard let drawable, let passDescriptor else` → `markPendingRedraw()`, signal, return.
3. `makeCommandBuffer()` / `makeRenderCommandEncoder(descriptor:)` returning nil → signal, return — this one does not even mark a pending redraw, so the requested frame is lost outright.

In all three cases the pending request has no consumer. Because the view is on-demand (`isPaused = true`, `enableSetNeedsDisplay = true`, `autoResizeDrawable = false`), nothing re-drives it on its own.

Recovery then depends entirely on an external invalidation — but for a terminal that invalidation re-enters the same refusal. Further output calls `queueMetalDisplay()` → `setNeedsDisplay` → `draw(in:)` → refused again. `drawMetalFrameNow()` is no better: it calls `metalView.draw()`, which lands on the same early return. So from the embedding app's side the renderer is unrecoverable, and there is no public signal ("was a frame presented?") to detect the state and react.

Case 1 is the most durable: if a completion handler is ever missed or delayed, the semaphore stays held, and from then on *every* draw takes the first early return.

## Proposed fix

Re-request the frame from the refusal paths themselves instead of relying on a completion handler that, by construction, does not exist there.

The attached patch:

- schedules a retry from all three refusal paths, and marks a pending redraw in case 3, which currently drops it silently;
- coalesces retries (one in flight at a time) and backs off from one 60 Hz frame up to 500 ms, so a view that genuinely cannot present (zero-sized, off-screen, waiting on a lost completion) settles into a cheap poll rather than spinning at frame rate;
- resets the backoff whenever a frame is actually submitted;
- peeks at `pendingRedraw` in the retry rather than consuming it, so the flag stays owned by the submitted-frame completion handler and the existing invariant is unchanged.

Builds clean against current `main` (`swift build`); the diagnosis was originally made against `v1.18.0`, where the code is identical.

## How this was found

[Pine](https://github.com/batonogov/pine), a macOS editor embedding SwiftTerm, saw terminal panes go black while their shells kept running — every child shell alive on its own tty, typing accepted, nothing rendered, and no repaint request from the app able to recover it. That pointed at presentation rather than the PTY, and the refusal paths above are the only way the renderer can go quiet without any error surfacing.

As a stopgap Pine added a user-invoked command that rebuilds the renderer via `setUseMetal(false/true)`, which does recover the pane — further evidence that the terminal state itself is intact and only presentation is stuck.

I could not construct a deterministic reproducer for the semaphore case from outside the library — the window between a dropped completion and the next draw is not observable through the public API — so this is a code-level diagnosis rather than a test-backed one. Happy to adjust the shape of the fix (e.g. a bounded number of retries, or surfacing a "frame presented" signal so clients can react themselves) if you would rather solve it differently.
