### PR TITLE
Make the OSC 9;4 progress bar visible and smooth

### DIFF
--- a/Sources/SwiftTerm/Apple/TerminalProgressBarView.swift
+++ b/Sources/SwiftTerm/Apple/TerminalProgressBarView.swift
@@ -21,12 +21,18 @@ final class TerminalProgressBarView: ProgressBarBaseView {
     private let barLayer = CALayer()
     private let indeterminateAnimationKey = "terminalProgressIndeterminate"
 
+    /// Thickness of the bar, in points. Ghostty uses 2; one more point reads
+    /// better against terminal content without stealing a row.
+    static let preferredHeight: CGFloat = 3
+
     private let barWidthRatio: CGFloat = 0.25
     private let indeterminateDuration: CFTimeInterval = 1.2
     private let determinateDuration: CFTimeInterval = 0.2
 
     private var state: Terminal.ProgressReportState = .remove
     private var progress: UInt8?
+    /// Bounds the running indeterminate animation was built for.
+    private var animatedBounds: CGRect = .zero
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -51,6 +57,10 @@ final class TerminalProgressBarView: ProgressBarBaseView {
         layer.addSublayer(trackLayer)
         layer.addSublayer(barLayer)
 #endif
+        // Anchored at its leading edge so growth is a width change alone, which
+        // is the one property the determinate animation has to interpolate.
+        barLayer.anchorPoint = .zero
+        barLayer.position = .zero
         #if os(iOS) || os(visionOS) || os(tvOS)
         isUserInteractionEnabled = false
         #endif
@@ -87,11 +97,18 @@ final class TerminalProgressBarView: ProgressBarBaseView {
         updateForCurrentState(animated: true)
     }
 
+    /// Ghostty's rule: an explicit percentage wins, a paused report with no
+    /// percentage reads as complete, everything else is indeterminate.
+    private var effectiveProgress: UInt8? {
+        if let progress { return progress }
+        return state == .pause ? 100 : nil
+    }
+
     private func updateForCurrentState(animated: Bool) {
         guard !isHidden else { return }
         trackLayer.frame = bounds
-        if let progress {
-            updateDeterminate(progress: progress, animated: animated)
+        if let effectiveProgress {
+            updateDeterminate(progress: effectiveProgress, animated: animated)
         } else {
             updateIndeterminate()
         }
@@ -102,37 +119,62 @@ final class TerminalProgressBarView: ProgressBarBaseView {
         stopIndeterminateAnimation()
 
         let width = bounds.width * CGFloat(progress) / 100
-        let targetFrame = CGRect(x: 0, y: 0, width: width, height: bounds.height)
+        let previousWidth = barLayer.bounds.width
 
         CATransaction.begin()
-        if animated {
-            CATransaction.setAnimationDuration(determinateDuration)
-            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
-        } else {
-            CATransaction.setDisableActions(true)
-        }
-        barLayer.frame = targetFrame
+        CATransaction.setDisableActions(true)
+        barLayer.position = .zero
+        barLayer.bounds = CGRect(x: 0, y: 0, width: width, height: bounds.height)
         CATransaction.commit()
+
+        guard animated, previousWidth != width else { return }
+
+        // Reports arrive far faster than one ease lasts (a 1%-per-100ms loop is
+        // typical), and an ease-in-out restarted on every one of them keeps
+        // dropping back to zero velocity — monotonic, but visibly pulsing.
+        // An additive animation instead animates the *delta* to zero, so the
+        // ones still in flight sum with it and the motion stays continuous.
+        // This is what SwiftUI does for Ghostty when it retargets mid-animation.
+        let animation = CABasicAnimation(keyPath: "bounds.size.width")
+        animation.fromValue = previousWidth - width
+        animation.toValue = 0
+        animation.isAdditive = true
+        animation.duration = determinateDuration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        barLayer.add(animation, forKey: nil)
     }
 
     private func updateIndeterminate() {
         trackLayer.isHidden = false
 
         let width = bounds.width * barWidthRatio
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        barLayer.frame = CGRect(x: 0, y: 0, width: width, height: bounds.height)
-        CATransaction.commit()
-
         guard width > 0, bounds.width > width else {
             stopIndeterminateAnimation()
             return
         }
 
+        // Applications repeat the indeterminate report continuously; restarting
+        // the slide on every one of them makes it stutter in place instead of
+        // sweeping, so it keeps running until the geometry or the state changes.
+        if barLayer.animation(forKey: indeterminateAnimationKey) != nil,
+           animatedBounds == bounds {
+            return
+        }
+
         stopIndeterminateAnimation()
+        // Additive width animations from the determinate state may still be in
+        // flight; they have no key of their own to remove.
+        barLayer.removeAllAnimations()
+        animatedBounds = bounds
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        barLayer.position = .zero
+        barLayer.bounds = CGRect(x: 0, y: 0, width: width, height: bounds.height)
+        CATransaction.commit()
+
         let animation = CABasicAnimation(keyPath: "position.x")
-        animation.fromValue = width / 2
-        animation.toValue = bounds.width - width / 2
+        animation.fromValue = 0
+        animation.toValue = bounds.width - width
         animation.duration = indeterminateDuration
         animation.autoreverses = true
         animation.repeatCount = .infinity
@@ -141,6 +183,8 @@ final class TerminalProgressBarView: ProgressBarBaseView {
     }
 
     private func stopIndeterminateAnimation() {
+        animatedBounds = .zero
+        barLayer.position = .zero
         barLayer.removeAnimation(forKey: indeterminateAnimationKey)
     }
 

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -416,7 +416,6 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private var markedTextOverlay: DictationOverlayTextView?
     private var progressBarView: TerminalProgressBarView?
     private var progressReportTimer: Timer?
-    private var lastProgressValue: UInt8?
     private enum UIShutdownState {
         case active
         case stopping
@@ -745,11 +744,11 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
 
     /// Inserts the Metal view into the view hierarchy with the correct
     /// z-order: below the caret (which is hidden while Metal owns the
-    /// cursor), with the scroller above it. When there is no caret view
-    /// and `replacing` is non-nil, the new view takes the old one's
-    /// z-position instead. Actually removing the old view is the caller's
-    /// responsibility — the rebind path defers removal until after the new
-    /// view has drawn its first frame so the hierarchy is never empty.
+    /// cursor), with the scroller and the progress bar above it. When there
+    /// is no caret view and `replacing` is non-nil, the new view takes the
+    /// old one's z-position instead. Actually removing the old view is the
+    /// caller's responsibility — the rebind path defers removal until after
+    /// the new view has drawn its first frame so the hierarchy is never empty.
     private func insertMetalView(_ newView: NSView, replacing oldView: NSView?) {
         if let caretView = caretView {
             addSubview(newView, positioned: .below, relativeTo: caretView)
@@ -762,6 +761,11 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         }
         if let scroller = scroller {
             addSubview(scroller, positioned: .above, relativeTo: newView)
+        }
+        // The Metal surface is opaque and covers the whole view, so the
+        // progress bar has to be lifted back to the top of the stack.
+        if let progressBarView {
+            addSubview(progressBarView, positioned: .above, relativeTo: nil)
         }
     }
 
@@ -963,34 +967,17 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private func setupProgressBar() {
         let bar = TerminalProgressBarView(frame: .zero)
         bar.isHidden = true
-        if let scroller {
-            addSubview(bar, positioned: .above, relativeTo: scroller)
-        } else {
-            addSubview(bar)
-        }
+        // Topmost: the bar overlays the terminal content, the scroller and
+        // any renderer surface, the same way Ghostty overlays its own.
+        addSubview(bar, positioned: .above, relativeTo: nil)
         progressBarView = bar
         updateProgressBarFrame()
     }
 
     private func updateProgressBarFrame() {
         guard let progressBarView else { return }
-        let height: CGFloat = 2
+        let height = TerminalProgressBarView.preferredHeight
         progressBarView.frame = CGRect(x: 0, y: bounds.height - height, width: bounds.width, height: height)
-    }
-
-    private func resolveProgress(for report: Terminal.ProgressReport) -> UInt8? {
-        switch report.state {
-        case .remove:
-            return nil
-        case .set:
-            return report.progress ?? 0
-        case .error:
-            return report.progress ?? lastProgressValue
-        case .indeterminate:
-            return nil
-        case .pause:
-            return report.progress ?? lastProgressValue ?? 100
-        }
     }
 
     @MainActor
@@ -1007,7 +994,6 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private func clearProgressReport() {
         progressReportTimer?.invalidate()
         progressReportTimer = nil
-        lastProgressValue = nil
         progressBarView?.apply(state: .remove, progress: nil)
     }
 
@@ -1018,11 +1004,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
             return
         }
 
-        let resolvedProgress = resolveProgress(for: report)
-        if let resolvedProgress {
-            lastProgressValue = resolvedProgress
-        }
-        progressBarView?.apply(state: report.state, progress: resolvedProgress)
+        progressBarView?.apply(state: report.state, progress: report.progress)
         resetProgressReportTimer()
     }
 

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -257,7 +257,6 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var terminal: Terminal!
     private var progressBarView: TerminalProgressBarView?
     private var progressReportTimer: Timer?
-    private var lastProgressValue: UInt8?
     
     /// Tracks the selection state of the terminal, and can be used to set it
     /// programmatically (see `SelectionService`).
@@ -525,28 +524,13 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
                 bar.topAnchor.constraint(equalTo: frameLayoutGuide.topAnchor),
                 bar.leadingAnchor.constraint(equalTo: frameLayoutGuide.leadingAnchor),
                 bar.trailingAnchor.constraint(equalTo: frameLayoutGuide.trailingAnchor),
-                bar.heightAnchor.constraint(equalToConstant: 2)
+                bar.heightAnchor.constraint(equalToConstant: TerminalProgressBarView.preferredHeight)
             ])
         } else {
             bar.autoresizingMask = [.flexibleWidth, .flexibleBottomMargin]
-            bar.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 2)
+            bar.frame = CGRect(x: 0, y: 0, width: bounds.width, height: TerminalProgressBarView.preferredHeight)
         }
         progressBarView = bar
-    }
-
-    private func resolveProgress(for report: Terminal.ProgressReport) -> UInt8? {
-        switch report.state {
-        case .remove:
-            return nil
-        case .set:
-            return report.progress ?? 0
-        case .error:
-            return report.progress ?? lastProgressValue
-        case .indeterminate:
-            return nil
-        case .pause:
-            return report.progress ?? lastProgressValue ?? 100
-        }
     }
 
     private func resetProgressReportTimer() {
@@ -561,7 +545,6 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     private func clearProgressReport() {
         progressReportTimer?.invalidate()
         progressReportTimer = nil
-        lastProgressValue = nil
         progressBarView?.apply(state: .remove, progress: nil)
     }
 
@@ -571,11 +554,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             return
         }
 
-        let resolvedProgress = resolveProgress(for: report)
-        if let resolvedProgress {
-            lastProgressValue = resolvedProgress
-        }
-        progressBarView?.apply(state: report.state, progress: resolvedProgress)
+        progressBarView?.apply(state: report.state, progress: report.progress)
         resetProgressReportTimer()
     }
     

--- a/Tests/SwiftTermTests/MetalToggleTests.swift
+++ b/Tests/SwiftTermTests/MetalToggleTests.swift
@@ -100,6 +100,23 @@ struct MetalToggleTests {
         }
     }
 
+    /// The OSC 9;4 progress bar is an overlay: the opaque Metal surface covers
+    /// the whole view, so the bar has to stay the topmost subview across a
+    /// renderer swap or it is simply never seen (which is how it shipped).
+    @Test func progressBarStaysOnTopOfTheRendererSurface() throws {
+        let view = makeView()
+        defer { view.frameDriver.invalidate() }
+
+        #expect(view.subviews.last is TerminalProgressBarView)
+
+        if MetalToggleTests.metalIsUsable {
+            try view.setUseMetal(true)
+            #expect(view.subviews.last is TerminalProgressBarView)
+            try view.setUseMetal(false)
+            #expect(view.subviews.last is TerminalProgressBarView)
+        }
+    }
+
     /// `requestRedraw` is the documented replacement for `setNeedsDisplay` and
     /// has to be safe in both renderer states, including from another thread.
     @Test(.enabled(if: MetalToggleTests.metalIsUsable)) func requestRedrawIsSafeInEitherState() throws {


### PR DESCRIPTION
The progress bar added in `13aff25` never appeared when the Metal renderer was on, and stuttered when it did appear. Running a script that emits OSC 9;4 showed nothing at all in an app that defaults to Metal.

There were three separate causes.

**The bar was hidden behind the Metal surface.** `insertMetalView` inserts the Metal view below the caret. The caret sits above the progress bar, so the opaque, full-bounds Metal surface covered the bar completely, and only the scroller was raised back afterwards. `setupProgressBar` also added the bar below the caret that `setupOptions` had already installed. The bar is now added topmost and raised again after any renderer swap.

**The pulse animation restarted on every report.** Applications repeat `9;4;3` continuously, often ten times a second. Each report tore down the slide animation and started a new one, so the bar juddered in place instead of sweeping. It now keeps running until the bounds or the state change.

**The percentage bar jerked forward and back.** Setting `barLayer.frame` inside a `CATransaction` creates an implicit animation that starts from the layer's previous model value, not from where the bar currently is. With reports arriving faster than the animation lasts, each one snapped the bar forward and eased again. Restarting an ease-in-out at that rate also drops the bar to zero velocity many times a second. The bar layer is now anchored at its leading edge, and the width is carried by an additive animation, so animations still in flight sum with each new one and the motion stays continuous. This is what SwiftUI does when it retargets, which is why Ghostty's bar looks smooth.

Two smaller changes came with it. The per-view progress retention is gone, replaced by Ghostty's rule applied in the bar view: an explicit percentage wins, a paused report with no percentage reads as complete, and everything else is indeterminate. Bar thickness is now one shared constant used by both hosts instead of a literal in each.

**Testing.** The full suite passes. A new test in `MetalToggleTests` pins the bar as the topmost subview, since that is the failure that made the feature invisible. I also checked the parser against the exact bytes cargo emits, including the `ESC \` terminator and the `9;4;0;` clear form, and measured the bar's pixel width over time through a real PTY with Metal on: the width increases monotonically and the speed holds steady within sampling noise.
