### PR TITLE
Fix implicit-link boundaries and link cursor flicker

### DIFF
--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1660,7 +1660,30 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     
     public override func cursorUpdate(with event: NSEvent)
     {
-        NSCursor.iBeam.set ()
+        let hit = calculateMouseHit(with: event).grid
+        let hasCommandModifier = commandActive || event.modifierFlags.contains(.command)
+        linkCursor(at: hit, hasCommandModifier: hasCommandModifier).set()
+    }
+
+    func linkCursor(at position: Position, hasCommandModifier: Bool) -> NSCursor
+    {
+        let match: Terminal.LinkMatch?
+        switch linkHighlightMode {
+        case .hover, .hoverWithModifier:
+            // Reuse the hover lookup so cursor updates do not run the implicit-link
+            // regular expression twice.
+            match = updateHoverLink(at: position, commandOverride: hasCommandModifier)
+        case .always, .alwaysWithModifier:
+            // Implicit links are never visible in these modes.
+            match = withTerminal { terminal in
+                terminal.linkMatch(at: .buffer(position), mode: .explicitOnly)
+            }
+        }
+        guard let match,
+              linkVisibleForClick(match: match, hasCommandModifier: hasCommandModifier) else {
+            return .iBeam
+        }
+        return .pointingHand
     }
     
     func makeFirstResponder ()
@@ -3637,7 +3660,11 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         }
     }
 
-    func updateHoverLink(at position: Position, commandOverride: Bool? = nil)
+    @discardableResult
+    func updateHoverLink(
+        at position: Position,
+        commandOverride: Bool? = nil
+    ) -> Terminal.LinkMatch?
     {
         let hoverModes: [LinkHighlightMode] = [.hover, .hoverWithModifier]
         guard hoverModes.contains(linkHighlightMode) else {
@@ -3647,7 +3674,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
                 invalidateLinkHighlight(oldRange: oldRange, newRange: nil)
                 frameDriver.markDirty()
             }
-            return
+            return nil
         }
         let effectiveCommandActive = commandOverride ?? commandActive
         if linkHighlightMode == .hoverWithModifier && !effectiveCommandActive {
@@ -3657,7 +3684,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
                 invalidateLinkHighlight(oldRange: oldRange, newRange: nil)
                 frameDriver.markDirty()
             }
-            return
+            return nil
         }
         let match = withTerminal { terminal in
             terminal.linkMatch(at: .buffer(position), mode: .explicitAndImplicit)
@@ -3669,6 +3696,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
             invalidateLinkHighlight(oldRange: oldRange, newRange: newRange)
             frameDriver.markDirty()
         }
+        return match
     }
 
     func currentMouseHit() -> Position?

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -7803,7 +7803,6 @@ open class Terminal {
         let pathChars = #"[\w\-.~:\/?#@!$&*+;=%]"#
         let noTrailingPunctuation = #"(?<![,.])"#
         let noTrailingColon = #"(?<!:)"#
-        let trailingSpacesAtEOL = #"(?: +(?= *$))?"#
         let dottedPathLookahead = #"(?=[\w\-.~:\/?#@!$&*+;=%]*\.)"#
         let nonDottedPathLookahead = #"(?![\w\-.~:\/?#@!$&*+;=%]*\.)"#
         let dottedPathSpaceSegments = #"(?:(?<!:) (?!\w+:\/\/)[\w\-.~:\/?#@!$&*+;=%]*[\/.])*"#
@@ -7839,13 +7838,11 @@ open class Terminal {
             pathChars + "+" +
             dottedPathSpaceSegments +
             noTrailingColon +
-            trailingSpacesAtEOL +
             "|" +
             nonDottedPathLookahead +
             pathChars + "+" +
             anyPathSpaceSegments +
             noTrailingColon +
-            trailingSpacesAtEOL +
             ")"
 
         // Ghostty uses (?<!\$\d*) here, which is unsupported by ICU.
@@ -7856,8 +7853,7 @@ open class Terminal {
             bareRelativePathPrefix +
             pathChars + "+" +
             dottedPathSpaceSegments +
-            noTrailingColon +
-            trailingSpacesAtEOL
+            noTrailingColon
 
         let regex = schemeURLBranch + "|" + rootedOrRelativePathBranch + "|" + bareRelativePathBranch
         return try? NSRegularExpression(pattern: regex, options: [])

--- a/Tests/SwiftTermTests/GhosttyImplicitLinkDetectionTests.swift
+++ b/Tests/SwiftTermTests/GhosttyImplicitLinkDetectionTests.swift
@@ -76,7 +76,7 @@ final class GhosttyImplicitLinkDetectionTests: TerminalDelegate {
             ("IPv6 address https://[2001:db8::1]:8080/path", "https://[2001:db8::1]:8080/path"),
             ("IPv6 address https://[2001:db8::1]:8080(foo)", "https://[2001:db8::1]:8080"),
             ("../example.py", "../example.py"),
-            ("../example.py ", "../example.py "),
+            ("../example.py ", "../example.py"),
             ("first time ../example.py contributor ", "../example.py"),
             ("src/config/url.zig", "src/config/url.zig"),
             ("app/folder/file.rb:1", "app/folder/file.rb:1"),
@@ -90,7 +90,7 @@ final class GhosttyImplicitLinkDetectionTests: TerminalDelegate {
             ("  - shared/src/foo/SomeItem.m:12, shared/src/", "shared/src/foo/SomeItem.m:12"),
             ("foo.local/share", "foo.local/share"),
             ("2024/report.txt", "2024/report.txt"),
-            ("./spaces-end.   ", "./spaces-end.   "),
+            ("./spaces-end.   ", "./spaces-end."),
             ("./space middle", "./space middle")
         ]
 

--- a/Tests/SwiftTermTests/MacDefaultLinkTests.swift
+++ b/Tests/SwiftTermTests/MacDefaultLinkTests.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import AppKit
 import Foundation
 import Testing
 
@@ -6,6 +7,19 @@ import Testing
 
 @Suite("Mac default link handling")
 struct MacDefaultLinkTests {
+
+    @Test @MainActor func usesPointingHandForVisibleCommandLink() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        view.linkHighlightMode = .hoverWithModifier
+        view.terminal.feed(text: "https://example.com")
+        let position = Position(col: 5, row: 0)
+
+        #expect(view.linkCursor(at: position, hasCommandModifier: true) === NSCursor.pointingHand)
+        #expect(view.linkCursor(at: position, hasCommandModifier: false) === NSCursor.iBeam)
+
+        view.linkHighlightMode = .always
+        #expect(view.linkCursor(at: position, hasCommandModifier: false) === NSCursor.iBeam)
+    }
     @Test func keepsExplicitURL() throws {
         let expected = try #require(URL(string: "https://example.com/path"))
 


### PR DESCRIPTION
## Summary
- stop including end-of-line padding spaces in implicit filesystem-path matches
- make AppKit cursor updates preserve the pointing hand over visible Command-links instead of resetting to the I-beam
- perform one lock-protected link lookup per cursor update and skip implicit matching when it cannot be visible
- add focused regressions

Terminal emulators pad every row with blank cells. Treating those cells as part of a link makes the hover underline and click target extend to the right edge. Separately, SwiftTerm's unconditional I-beam in `cursorUpdate(with:)` competed with host link-hover handling and caused rapid cursor flicker.

The application-specific ` at ` path boundary has been removed. A host-provided link resolver/policy would be a better follow-up for cases that need filesystem- or session-specific validation, since SwiftTerm may display remote filesystems where local probing is not authoritative.

## Tests
- `swift test --filter GhosttyImplicitLinkDetectionTests`
- `swift test --filter MacDefaultLinkTests`
- `swift test` (986 tests passed)
