### PR TITLE
Add color-scheme update notifications (DEC mode 2031)

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -10,6 +10,15 @@
 
 import Foundation
 
+/// The light/dark preference represented by the terminal's current color palette.
+///
+/// This is reported to applications through the color-scheme notification protocol:
+/// https://github.com/contour-terminal/contour/blob/master/docs/vt-extensions/color-palette-update-notifications.md
+public enum TerminalColorScheme: Equatable {
+    case dark
+    case light
+}
+
 /**
  * The terminal delegate is a protocol that must be implemented by a class
  * that would provide a user interface for the terminal, and it is used by the
@@ -587,6 +596,11 @@ open class Terminal {
     /// xterm's own default for this resource is false; we default to true here to match modern terminals
     /// (e.g. Ghostty) that enable it out of the box.
     public private(set) var alternateScrollMode: Bool = true
+    /// Whether the running application subscribed to unsolicited color-scheme updates with `CSI ? 2031 h`.
+    public private(set) var colorSchemeUpdatesEnabled: Bool = false
+
+    /// The light/dark preference represented by the current terminal palette.
+    public private(set) var colorScheme: TerminalColorScheme = .dark
     
     private var charset: [UInt8:String]? = nil
     private var gCharsets: [[UInt8:String]?] = [CharSets.defaultCharset, nil, nil, nil]
@@ -1149,6 +1163,7 @@ open class Terminal {
         setWraparound(true)
         bracketedPasteMode = false
         alternateScrollMode = true
+        colorSchemeUpdatesEnabled = false
 
         keyboardModeNormal = KeyboardModeState()
         keyboardModeAlt = KeyboardModeState()
@@ -3182,6 +3197,21 @@ open class Terminal {
     func reportColor (oscCode: Int, color: Color) {
         sendResponse(cc.OSC, "\(oscCode);\(color.formatAsXcolor ())", cc.ST)
     }
+
+    private func reportColorScheme () {
+        let value = colorScheme == .dark ? 1 : 2
+        sendResponse(cc.CSI, "?997;\(value)n")
+    }
+
+    /// Updates the palette's light/dark preference and notifies the running application if it subscribed with
+    /// `CSI ? 2031 h`. Call this after installing the new colors so an application can immediately re-query OSC
+    /// 10/11 and receive the updated foreground and background values.
+    public func updateColorScheme (_ colorScheme: TerminalColorScheme) {
+        self.colorScheme = colorScheme
+        if colorSchemeUpdatesEnabled {
+            reportColorScheme()
+        }
+    }
     
     // This handles both setting the foreground, but spill into background and cursor color
     // if more parameters are provided (ie, sending OSC 10 with #ffffff,#000000,#ff0000
@@ -4765,6 +4795,8 @@ open class Terminal {
                 res = bidiAutodetectDirection ? modeSet : modeReset
             case 1243: // swap left and right arrow keys on RTL paragraphs
                 res = bidiArrowKeySwap ? modeSet : modeReset
+            case 2031:
+                res = colorSchemeUpdatesEnabled ? modeSet : modeReset
             default:
                 break
             }
@@ -5011,6 +5043,9 @@ open class Terminal {
             case 85:
                 // Multiple session status, we reply single session
                 sendResponse (cc.CSI, "?83n")
+            case 996:
+                // Report the current dark/light palette preference.
+                reportColorScheme()
             default:
                 break
             }
@@ -5597,6 +5632,8 @@ open class Terminal {
                 break
             case 2026: // synchronized output (https://github.com/contour-terminal/vt-extensions)
                 endSynchronizedOutput ()
+            case 2031: // color-scheme update notifications
+                colorSchemeUpdatesEnabled = false
             default:
                 log ("Unhandled DEC Private Mode Reset (DECRST) with \(par)")
                 break
@@ -5849,6 +5886,8 @@ open class Terminal {
                 bracketedPasteMode = true
             case 2026: // synchronized output (https://github.com/contour-terminal/vt-extensions)
                 beginSynchronizedOutput ()
+            case 2031: // color-scheme update notifications
+                colorSchemeUpdatesEnabled = true
             default:
                 log ("Unhandled DEC Private Mode Set (DECSET) with \(par)")
                 break;

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -599,7 +599,9 @@ open class Terminal {
     /// Whether the running application subscribed to unsolicited color-scheme updates with `CSI ? 2031 h`.
     public private(set) var colorSchemeUpdatesEnabled: Bool = false
 
-    /// The light/dark preference represented by the current terminal palette.
+    /// The light/dark preference represented by the current terminal palette, as reported to applications that
+    /// query it (`CSI ? 996 n`). Defaults to `.dark`; hosts should call `updateColorScheme(_:)` once the initial
+    /// palette is installed so a light terminal never reports the wrong preference.
     public private(set) var colorScheme: TerminalColorScheme = .dark
     
     private var charset: [UInt8:String]? = nil

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -3203,11 +3203,23 @@ open class Terminal {
         sendResponse(cc.CSI, "?997;\(value)n")
     }
 
-    /// Updates the palette's light/dark preference and notifies the running application if it subscribed with
-    /// `CSI ? 2031 h`. Call this after installing the new colors so an application can immediately re-query OSC
-    /// 10/11 and receive the updated foreground and background values.
-    public func updateColorScheme (_ colorScheme: TerminalColorScheme) {
+    /// Updates the palette's light/dark preference and, when `notify` is set, notifies the running application if
+    /// it subscribed with `CSI ? 2031 h`. Call this after installing the new colors so an application can immediately
+    /// re-query OSC 10/11 and receive the updated foreground and background values.
+    ///
+    /// Pass `notify: false` to record the preference without announcing it: queries (`CSI ? 996 n`, `DECRQM 2031`)
+    /// then answer with the new value right away while the host defers the notification with `notifyColorScheme()`.
+    public func updateColorScheme (_ colorScheme: TerminalColorScheme, notify: Bool = true) {
         self.colorScheme = colorScheme
+        if notify {
+            notifyColorScheme()
+        }
+    }
+
+    /// Sends the current light/dark preference to the running application if it subscribed with `CSI ? 2031 h`.
+    /// Safe to repeat: applications treat the notification as a cue to re-query OSC 10/11, so a second one only
+    /// costs a round trip and rescues a query that timed out the first time.
+    public func notifyColorScheme () {
         if colorSchemeUpdatesEnabled {
             reportColorScheme()
         }

--- a/Tests/SwiftTermTests/ColorSchemeNotificationTests.swift
+++ b/Tests/SwiftTermTests/ColorSchemeNotificationTests.swift
@@ -48,6 +48,30 @@ final class ColorSchemeNotificationTests {
         #expect(response(from: delegate) == "\(esc)[?2031;1$y")
     }
 
+    @Test func silentUpdateRecordsWithoutNotifying() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.feed(text: "\(esc)[?2031h")
+        terminal.updateColorScheme(.light, notify: false)
+        #expect(delegate.sentData.isEmpty)
+
+        // Queries already see the new preference while the notification waits.
+        terminal.feed(text: "\(esc)[?996n")
+        #expect(response(from: delegate) == "\(esc)[?997;2n")
+
+        delegate.clearSentData()
+        terminal.notifyColorScheme()
+        #expect(response(from: delegate) == "\(esc)[?997;2n")
+    }
+
+    @Test func notifyIsSilentWithoutSubscription() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.updateColorScheme(.light, notify: false)
+        terminal.notifyColorScheme()
+        #expect(delegate.sentData.isEmpty)
+    }
+
     @Test func fullResetClearsSubscription() {
         let (terminal, delegate) = TerminalTestHarness.makeTerminal()
 

--- a/Tests/SwiftTermTests/ColorSchemeNotificationTests.swift
+++ b/Tests/SwiftTermTests/ColorSchemeNotificationTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import SwiftTerm
+
+final class ColorSchemeNotificationTests {
+    private let esc = "\u{1b}"
+
+    @Test func queryReportsCurrentColorScheme() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.updateColorScheme(.light)
+        #expect(delegate.sentData.isEmpty)
+
+        terminal.feed(text: "\(esc)[?996n")
+
+        #expect(response(from: delegate) == "\(esc)[?997;2n")
+    }
+
+    @Test func subscribedApplicationReceivesPaletteUpdates() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.feed(text: "\(esc)[?2031h")
+        terminal.updateColorScheme(.light)
+
+        #expect(terminal.colorSchemeUpdatesEnabled)
+        #expect(response(from: delegate) == "\(esc)[?997;2n")
+    }
+
+    @Test func unsubscribedApplicationDoesNotReceivePaletteUpdates() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.feed(text: "\(esc)[?2031h")
+        terminal.feed(text: "\(esc)[?2031l")
+        terminal.updateColorScheme(.light)
+
+        #expect(!terminal.colorSchemeUpdatesEnabled)
+        #expect(delegate.sentData.isEmpty)
+    }
+
+    @Test func modeQueryReportsSubscriptionState() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.feed(text: "\(esc)[?2031$p")
+        #expect(response(from: delegate) == "\(esc)[?2031;2$y")
+
+        delegate.clearSentData()
+        terminal.feed(text: "\(esc)[?2031h")
+        terminal.feed(text: "\(esc)[?2031$p")
+        #expect(response(from: delegate) == "\(esc)[?2031;1$y")
+    }
+
+    @Test func fullResetClearsSubscription() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+
+        terminal.updateColorScheme(.light)
+        terminal.feed(text: "\(esc)[?2031h")
+        terminal.resetToInitialState()
+        terminal.updateColorScheme(.dark)
+
+        #expect(!terminal.colorSchemeUpdatesEnabled)
+        #expect(delegate.sentData.isEmpty)
+
+        terminal.feed(text: "\(esc)[?996n")
+        #expect(response(from: delegate) == "\(esc)[?997;1n")
+    }
+
+    private func response(from delegate: TerminalTestDelegate) -> String {
+        String(decoding: delegate.sentData.last ?? [], as: UTF8.self)
+    }
+}


### PR DESCRIPTION
Implements the color-palette-update-notifications extension ([Contour spec](https://github.com/contour-terminal/contour/blob/master/docs/vt-extensions/color-palette-update-notifications.md)), which Ghostty, kitty, WezTerm and Contour already ship. Theme-aware TUIs use it to repaint when the terminal switches between light and dark at runtime; without it, apps like OpenCode and cursor-agent keep painting with the palette they sampled at boot, which can leave them unreadable after a system appearance change.

<img width="815" height="224" alt="SCR-20260824-jwde" src="https://github.com/user-attachments/assets/1d12cad0-3ef1-46e1-8d8f-f5c54f67fca8" />

<img width="1493" height="732" alt="SCR-20260824-jwje" src="https://github.com/user-attachments/assets/5bd0deed-29e8-4c5c-afe1-1da1f45bd4b7" />


**Emulator side (`Terminal.swift`)**
- `DECSET`/`DECRST` `?2031` toggles the subscription (`colorSchemeUpdatesEnabled`), cleared by a full reset.
- `DECRQM ?2031` reports the subscription state.
- `CSI ?996 n` reports the current preference as `CSI ?997;1n` (dark) or `CSI ?997;2n` (light).
- New `TerminalColorScheme` enum and a read-only `colorScheme` property.

**Host API**
- `updateColorScheme(_:notify:)` records the preference and, by default, sends `CSI ?997 n` to a subscribed application. Call it after installing a new palette so the application's follow-up OSC 10/11 query already sees the new colors.
- `notifyColorScheme()` re-sends the current preference. `notify: false` plus this call lets a host record the scheme immediately (so `?996 n` and `DECRQM` answer correctly) while deferring the announcement.

**Why the split matters for hosts.** Applications answer the notification by re-querying OSC 10/11 with a short timeout (cursor-agent 100ms, OpenTUI 250ms) and ignore further notifications while that query is pending. Since the reply is produced on the host's dispatch queue, a host that sends the notification while it is busy re-rendering after an appearance flip can strand the app on the old theme. Deferring the notification until the queue is responsive, and optionally re-sending once after those timeouts, avoids it. That timing policy is deliberately left to hosts; the library only exposes the two calls.

No view-layer changes. The emulation is platform-independent and available to the macOS, iOS and headless terminals alike; the `colorScheme` default is documented so hosts seed it once the initial palette is installed.

Tests: `ColorSchemeNotificationTests` covers the query, subscribe/unsubscribe, DECRQM, full reset, and the record-without-notify path (7 tests).

Related: #647 lists this extension as something another downstream implemented too; happy to reconcile if their shape differs.
