### PR TITLE
Expose color-scheme updates through TerminalView

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1450,6 +1450,25 @@ extension TerminalView {
         renderOwner.bufferData(kind: kind, encoding: encoding)
     }
 
+    /// Records the light/dark preference represented by the current palette and optionally
+    /// notifies an application that subscribed with `CSI ? 2031 h`.
+    ///
+    /// Call this after installing the palette so the application's follow-up OSC 10/11 query
+    /// sees the new colors. Pass `notify: false` to record the preference without announcing it,
+    /// then call ``notifyColorScheme()`` when the host is ready for the application to re-query.
+    public nonisolated func updateColorScheme(
+        _ colorScheme: TerminalColorScheme,
+        notify: Bool = true
+    ) {
+        renderOwner.updateColorScheme(colorScheme, notify: notify)
+    }
+
+    /// Re-sends the current light/dark preference when the application subscribed with
+    /// `CSI ? 2031 h`.
+    public nonisolated func notifyColorScheme() {
+        renderOwner.notifyColorScheme()
+    }
+
     /// Returns the closest primary semantic-prompt row above the viewport.
     public nonisolated func previousSemanticPromptRow() -> Int? {
         renderOwner.semanticPromptRow(searchingUpward: true)

--- a/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
+++ b/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
@@ -252,6 +252,20 @@ final class TerminalRenderOwner: Sendable {
         }
     }
 
+    func updateColorScheme(_ colorScheme: TerminalColorScheme, notify: Bool) {
+        guard let terminal = currentSession()?.terminal else { return }
+        terminal.terminalLock.withLock {
+            terminal.updateColorScheme(colorScheme, notify: notify)
+        }
+    }
+
+    func notifyColorScheme() {
+        guard let terminal = currentSession()?.terminal else { return }
+        terminal.terminalLock.withLock {
+            terminal.notifyColorScheme()
+        }
+    }
+
     func stateSnapshot() -> TerminalViewStateSnapshot {
         guard let terminal = currentSession()?.terminal else {
             return TerminalViewStateSnapshot(

--- a/Tests/SwiftTermTests/ColorSchemeNotificationTests.swift
+++ b/Tests/SwiftTermTests/ColorSchemeNotificationTests.swift
@@ -1,6 +1,10 @@
 import Testing
 @testable import SwiftTerm
 
+#if os(macOS)
+import AppKit
+#endif
+
 final class ColorSchemeNotificationTests {
     private let esc = "\u{1b}"
 
@@ -91,3 +95,59 @@ final class ColorSchemeNotificationTests {
         String(decoding: delegate.sentData.last ?? [], as: UTF8.self)
     }
 }
+
+#if os(macOS)
+@Suite(.serialized)
+@MainActor
+struct ColorSchemeViewAPITests {
+    private final class RecordingDelegate: TerminalViewDelegate {
+        var sentData: [[UInt8]] = []
+
+        func send(source: TerminalView, data: ArraySlice<UInt8>) {
+            sentData.append(Array(data))
+        }
+
+        func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+        func setTerminalTitle(source: TerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        func scrolled(source: TerminalView, position: Double) {}
+        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+        func bell(source: TerminalView) {}
+        func clipboardCopy(source: TerminalView, content: Data) {}
+        func clipboardRead(source: TerminalView) -> Data? { nil }
+        func iTermContent(source: TerminalView, content: ArraySlice<UInt8>) {}
+        func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+    }
+
+    @Test func viewCanRecordThenNotifyColorScheme() async {
+        let view = TerminalView(
+            frame: CGRect(x: 0, y: 0, width: 400, height: 200))
+        let delegate = RecordingDelegate()
+        view.terminalDelegate = delegate
+
+        view.feed(text: "\u{1b}[?2031h")
+        view.updateColorScheme(.light, notify: false)
+        #expect(delegate.sentData.isEmpty)
+
+        view.feed(text: "\u{1b}[?996n")
+        await waitForPayload(count: 1, from: delegate)
+        #expect(response(from: delegate) == "\u{1b}[?997;2n")
+
+        delegate.sentData.removeAll()
+        view.notifyColorScheme()
+        await waitForPayload(count: 1, from: delegate)
+        #expect(response(from: delegate) == "\u{1b}[?997;2n")
+    }
+
+    private func waitForPayload(count: Int, from delegate: RecordingDelegate) async {
+        let deadline = ContinuousClock.now + .seconds(1)
+        while delegate.sentData.count < count, ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+    }
+
+    private func response(from delegate: RecordingDelegate) -> String {
+        String(decoding: delegate.sentData.last ?? [], as: UTF8.self)
+    }
+}
+#endif


### PR DESCRIPTION
#651 added color-scheme state and notification methods to `Terminal`. Apps embedding SwiftTerm's AppKit or UIKit views cannot safely call those methods directly: the views do not expose the mutable terminal, and their `withTerminal` helper is internal.

This adds `updateColorScheme(_:notify:)` and `notifyColorScheme()` to the shared `TerminalView` extension. Both calls go through `TerminalRenderOwner` and the terminal lock, following the same boundary used by the other public view commands. Palette installation and notification timing remain host decisions.

Verification:

- `swift test` (998 tests)
- `swift build --target SwiftTerm -Xswiftc -strict-concurrency=complete`
- generic iOS sample build
