### PR TITLE
Keep LocalProcess alive until its exact child is reaped

### DIFF
--- a/Sources/SwiftTerm/LocalProcess.swift
+++ b/Sources/SwiftTerm/LocalProcess.swift
@@ -27,6 +27,7 @@ private struct LocalProcessSessionState {
     var childfd: Int32 = -1
     var shellPid: pid_t = 0
     var running = false
+    var terminationRequested = false
     var pipeline: TerminalIOPipeline?
     var writeChannel: DispatchIO?
     var loggingDirectory: String?
@@ -223,7 +224,8 @@ public class LocalProcess {
     {
         guard let sendState = session.withLock({ state
             -> (channel: DispatchIO, debug: Bool)? in
-            guard state.running, let channel = state.writeChannel else {
+            guard state.running, !state.terminationRequested,
+                  let channel = state.writeChannel else {
                 return nil
             }
             return (channel, state.debugIO)
@@ -290,7 +292,6 @@ public class LocalProcess {
             if let expectedPipeline, state.pipeline !== expectedPipeline {
                 return nil
             }
-            state.running = false
             guard cancelProcessMonitor else { return nil }
             defer { state.childMonitor = nil }
             return state.childMonitor
@@ -346,6 +347,7 @@ public class LocalProcess {
             state.childfd = -1
             state.shellPid = 0
             state.running = false
+            state.terminationRequested = false
 #if os(macOS)
             state.childMonitor = nil
 #endif
@@ -358,6 +360,17 @@ public class LocalProcess {
         resources.cancelMonitor()
         resources.writeChannel?.close(flags: [])
         stopPipeline(resources.pipeline)
+        let pid = resources.pid
+        guard pid > 0 else { return }
+        kill(pid, SIGTERM)
+
+        // The exit source no longer owns reaping after deinit. A detached waiter captures only
+        // the PID so LocalProcess and its delegate can be released immediately without leaving
+        // a zombie behind.
+        DispatchQueue.global(qos: .utility).async {
+            var status: Int32 = 0
+            while waitpid(pid, &status, 0) == -1 && errno == EINTR {}
+        }
     }
 
     func processTerminated ()
@@ -372,21 +385,45 @@ public class LocalProcess {
 #else
             let result = LocalProcessExitOutcome(pid: state.shellPid)
 #endif
-            state.shellPid = 0
-            state.running = false
-#if os(macOS)
-            state.childMonitor = nil
-#endif
             return result
         }
         guard let outcome else { return }
-        var n: Int32 = 0
-        waitpid(outcome.pid, &n, WNOHANG)
+
+        var waitStatus: Int32 = 0
+        var waitedPID: pid_t
+        repeat {
+            waitedPID = waitpid(outcome.pid, &waitStatus, 0)
+        } while waitedPID == -1 && errno == EINTR
+
+        // Reaping destroys the kernel event the source watches. Cancel before libdispatch tries
+        // to re-arm that vanished knote, but only after waitpid has completed its one job.
         outcome.cancelMonitor()
+
+        let isCurrent = session.withLock { state -> Bool in
+            guard state.shellPid == outcome.pid else { return false }
+            state.shellPid = 0
+            state.running = false
+            state.terminationRequested = false
+#if os(macOS)
+            state.childMonitor = nil
+#endif
+            return true
+        }
+        guard isCurrent else { return }
+
+        let exitCode = waitedPID == outcome.pid
+            ? Self.exitCode(fromWaitStatus: waitStatus)
+            : nil
         let delegate = delegateReference.withLock { $0.value }
         deliveryContext.perform {
-            delegate?.processTerminated(self, exitCode: n)
+            delegate?.processTerminated(self, exitCode: exitCode)
         }
+    }
+
+    /// Darwin exposes the wait-status helpers as C macros, which Swift cannot import.
+    static func exitCode(fromWaitStatus status: Int32) -> Int32? {
+        guard status & 0x7f == 0 else { return nil }
+        return (status >> 8) & 0xff
     }
     
     /**
@@ -552,6 +589,7 @@ public class LocalProcess {
             // keeps that early callback correct.
             session.withLock { state in
                 state.running = true
+                state.terminationRequested = false
                 state.childfd = childfd
                 state.shellPid = shellPid
             }
@@ -616,11 +654,20 @@ public class LocalProcess {
         slaveFd = -1
         #endif
 
-        let resources = takeResourcesForShutdown()
-        resources.cancelMonitor()
+        let resources = session.withLock { state
+            -> (writeChannel: DispatchIO?, pipeline: TerminalIOPipeline?, pid: pid_t)? in
+            guard state.shellPid != 0, !state.terminationRequested else { return nil }
+            state.terminationRequested = true
+            let result = (state.writeChannel, state.pipeline, state.shellPid)
+            state.writeChannel = nil
+            state.pipeline = nil
+            state.childfd = -1
+            return result
+        }
+        guard let resources else { return }
         resources.writeChannel?.close(flags: [])
         stopPipeline(resources.pipeline)
-        if resources.pid != 0 {
+        if resources.pid > 0 {
             kill(resources.pid, SIGTERM)
         }
     }

--- a/Tests/SwiftTermTests/LocalProcessLifecycleTests.swift
+++ b/Tests/SwiftTermTests/LocalProcessLifecycleTests.swift
@@ -1,0 +1,135 @@
+#if os(macOS)
+import Darwin
+import Foundation
+import XCTest
+
+@testable import SwiftTerm
+
+final class LocalProcessLifecycleTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        signal(SIGCHLD, SIG_DFL)
+    }
+
+    func testForkptyPublishesExactPIDAndNormalizedExitCode() {
+        let terminated = expectation(description: "process terminated")
+        let delegate = LifecycleDelegate()
+        delegate.onTermination = { terminated.fulfill() }
+        let process = LocalProcess(
+            delegate: delegate,
+            dispatchQueue: DispatchQueue(label: "SwiftTerm.LocalProcessLifecycle.exit"))
+
+        process.startProcess(
+            executable: "/bin/sh",
+            args: ["-c", "exit 7"],
+            environment: nil,
+            execName: "sh")
+
+        let pid = process.shellPid
+        XCTAssertGreaterThan(pid, 0)
+        wait(for: [terminated], timeout: 5)
+        XCTAssertEqual(delegate.exitCode, 7)
+        XCTAssertFalse(process.running)
+        XCTAssertEqual(process.shellPid, 0)
+        XCTAssertEqual(kill(pid, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
+    }
+
+    func testTerminateSignalsAndReapsExactChildBeforeRelaunch() {
+        let firstTermination = expectation(description: "first child terminated")
+        let secondTermination = expectation(description: "replacement child terminated")
+        let delegate = LifecycleDelegate()
+        var terminationCount = 0
+        delegate.onTermination = {
+            terminationCount += 1
+            if terminationCount == 1 {
+                firstTermination.fulfill()
+            } else {
+                secondTermination.fulfill()
+            }
+        }
+        let process = LocalProcess(
+            delegate: delegate,
+            dispatchQueue: DispatchQueue(label: "SwiftTerm.LocalProcessLifecycle.relaunch"))
+
+        process.startProcess(
+            executable: "/bin/sleep",
+            args: ["30"],
+            environment: nil,
+            execName: "sleep")
+        let firstPID = process.shellPid
+        XCTAssertEqual(kill(firstPID, SIGSTOP), 0)
+        process.terminate()
+        process.startProcess(
+            executable: "/usr/bin/true",
+            environment: nil,
+            execName: "true")
+
+        XCTAssertEqual(process.shellPid, firstPID)
+        XCTAssertEqual(kill(firstPID, SIGCONT), 0)
+        wait(for: [firstTermination], timeout: 5)
+        XCTAssertEqual(kill(firstPID, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
+
+        process.startProcess(
+            executable: "/usr/bin/true",
+            environment: nil,
+            execName: "true")
+        wait(for: [secondTermination], timeout: 5)
+        XCTAssertEqual(terminationCount, 2)
+    }
+
+    func testDeinitTerminatesAndReapsChild() {
+        let delegate = LifecycleDelegate()
+        weak var releasedProcess: LocalProcess?
+        var pid: pid_t = 0
+
+        autoreleasepool {
+            let process = LocalProcess(
+                delegate: delegate,
+                dispatchQueue: DispatchQueue(label: "SwiftTerm.LocalProcessLifecycle.deinit"))
+            process.startProcess(
+                executable: "/bin/sleep",
+                args: ["30"],
+                environment: nil,
+                execName: "sleep")
+            pid = process.shellPid
+            releasedProcess = process
+        }
+
+        XCTAssertNil(releasedProcess)
+        let deadline = Date().addingTimeInterval(5)
+        while kill(pid, 0) == 0, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        XCTAssertEqual(kill(pid, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
+    }
+}
+
+private final class LifecycleDelegate: LocalProcessDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedExitCode: Int32?
+    var onTermination: (() -> Void)?
+
+    var exitCode: Int32? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedExitCode
+    }
+
+    func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+        lock.lock()
+        storedExitCode = exitCode
+        let callback = onTermination
+        lock.unlock()
+        callback?()
+    }
+
+    func dataReceived(slice: ArraySlice<UInt8>) {}
+
+    func getWindowSize() -> winsize {
+        winsize(ws_row: 24, ws_col: 80, ws_xpixel: 640, ws_ypixel: 480)
+    }
+}
+#endif

--- a/Tests/SwiftTermTests/TerminalIOPipelineTests.swift
+++ b/Tests/SwiftTermTests/TerminalIOPipelineTests.swift
@@ -163,6 +163,7 @@ final class TerminalIOPipelineTests {
         process.startProcess(executable: "/bin/cat", args: [path])
 
         #expect(capture.waitForCallbackReturn(timeout: 5))
+        #expect(capture.waitForTermination(timeout: 5))
         #expect(!process.running)
         process.terminate()
     }
@@ -525,12 +526,18 @@ private final class TerminatingLocalProcessCapture: LocalProcessDelegate {
     private let process = Locked(WeakTestLocalProcessReference())
     private let condition = NSCondition()
     private var callbackReturned = false
+    private var terminated = false
 
     func attach(_ process: LocalProcess) {
         self.process.withLock { $0.value = process }
     }
 
-    func processTerminated(_ source: LocalProcess, exitCode: Int32?) {}
+    func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+        condition.lock()
+        terminated = true
+        condition.broadcast()
+        condition.unlock()
+    }
 
     func dataReceived(slice: ArraySlice<UInt8>) {
         let process = process.withLock { $0.value }
@@ -550,6 +557,19 @@ private final class TerminatingLocalProcessCapture: LocalProcessDelegate {
         let limit = Date().addingTimeInterval(timeout)
         condition.lock()
         while !callbackReturned {
+            if !condition.wait(until: limit) {
+                condition.unlock()
+                return false
+            }
+        }
+        condition.unlock()
+        return true
+    }
+
+    func waitForTermination(timeout: TimeInterval) -> Bool {
+        let limit = Date().addingTimeInterval(timeout)
+        condition.lock()
+        while !terminated {
             if !condition.wait(until: limit) {
                 condition.unlock()
                 return false


### PR DESCRIPTION
Follow-up to #647.

`LocalProcess.terminate()` currently clears process state and cancels its exit source before the child has been reaped. That allows a relaunch to begin while the previous PID is still live, and the nonblocking `waitpid` in the exit callback can miss the exact child.

This keeps the session active after `SIGTERM` until a blocking `waitpid` has reaped that PID. Sends are rejected once termination starts, relaunch remains blocked until cleanup completes, exit status is normalized before delivery, and deinitialization transfers the PID to a detached reaper so releasing `LocalProcess` cannot leave a zombie. The existing I/O pipeline shutdown behavior is unchanged.

Verification:

- `swift test`
- `swift build -Xswiftc -strict-concurrency=complete`