### PR TITLE
Expose bounded incremental recent buffer text

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1450,6 +1450,18 @@ extension TerminalView {
         renderOwner.bufferData(kind: kind, encoding: encoding)
     }
 
+    /// Returns recent complete logical lines without exposing mutable terminal storage.
+    public nonisolated func recentLogicalBufferText(
+        maximumUTF8Bytes: Int,
+        sinceAbsoluteRow: Int = 0,
+        kind: Terminal.BufferKind = .active
+    ) -> Terminal.RecentBufferText {
+        renderOwner.recentLogicalBufferText(
+            maximumUTF8Bytes: maximumUTF8Bytes,
+            sinceAbsoluteRow: sinceAbsoluteRow,
+            kind: kind)
+    }
+
     /// Returns the closest primary semantic-prompt row above the viewport.
     public nonisolated func previousSemanticPromptRow() -> Int? {
         renderOwner.semanticPromptRow(searchingUpward: true)

--- a/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
+++ b/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
@@ -252,6 +252,22 @@ final class TerminalRenderOwner: Sendable {
         }
     }
 
+    func recentLogicalBufferText(
+        maximumUTF8Bytes: Int,
+        sinceAbsoluteRow: Int,
+        kind: Terminal.BufferKind
+    ) -> Terminal.RecentBufferText {
+        guard let terminal = currentSession()?.terminal else {
+            return Terminal.RecentBufferText(text: "", nextAbsoluteRow: 0)
+        }
+        return terminal.terminalLock.withLock {
+            terminal.getRecentLogicalBufferText(
+                maximumUTF8Bytes: maximumUTF8Bytes,
+                sinceAbsoluteRow: sinceAbsoluteRow,
+                kind: kind)
+        }
+    }
+
     func stateSnapshot() -> TerminalViewStateSnapshot {
         guard let terminal = currentSession()?.terminal else {
             return TerminalViewStateSnapshot(

--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -7532,6 +7532,21 @@ open class Terminal {
         return l
     }
     
+    /// A bounded read of recent buffer text, with the position a follow-up read resumes from.
+    public struct RecentBufferText: Equatable, Sendable {
+        /// The recent complete logical lines, oldest first.
+        public let text: String
+        /// One past the newest row examined, counted from the first line the emulator ever
+        /// produced so the value survives scrollback trimming. Feed it back as
+        /// `sinceAbsoluteRow` to read only what has appeared since.
+        public let nextAbsoluteRow: Int
+
+        public init(text: String, nextAbsoluteRow: Int) {
+            self.text = text
+            self.nextAbsoluteRow = nextAbsoluteRow
+        }
+    }
+
     /// Specified the kind of buffer is being requested from the terminal
     public enum BufferKind: Sendable {
         /// The currently active buffer (can be either normal or alt)
@@ -7601,6 +7616,87 @@ open class Terminal {
             }
         }
         return result
+    }
+
+    /// Returns a UTF-8-bounded suffix of complete logical lines. Soft-wrapped
+    /// grid rows are joined, while real line breaks remain separators. An
+    /// incomplete oldest logical line is omitted instead of returned as a
+    /// misleading fragment.
+    public func getRecentLogicalBufferText(maximumUTF8Bytes: Int,
+                                           kind: BufferKind = .active) -> String
+    {
+        getRecentLogicalBufferText(
+            maximumUTF8Bytes: maximumUTF8Bytes,
+            sinceAbsoluteRow: 0,
+            kind: kind
+        ).text
+    }
+
+    /// The incremental form of `getRecentLogicalBufferText(maximumUTF8Bytes:kind:)`.
+    ///
+    /// The byte bound limits how much text is returned, but it cannot bound the number of rows
+    /// inspected: blank and short rows barely spend it. `sinceAbsoluteRow` supplies that bound.
+    /// The current screen is always read again because full-screen programs repaint it in place;
+    /// only stable scrollback rows are skipped.
+    ///
+    /// Absolute rows survive scrollback trimming. A cursor past the current buffer end is treated
+    /// as belonging to a buffer that was reset or switched, and the retained window is read again.
+    public func getRecentLogicalBufferText(
+        maximumUTF8Bytes: Int,
+        sinceAbsoluteRow: Int,
+        kind: BufferKind = .active
+    ) -> RecentBufferText {
+        let inspectedBuffer = bufferFromKind(kind: kind)
+        let endAbsoluteRow = inspectedBuffer.linesTop + inspectedBuffer.lines.count
+        guard maximumUTF8Bytes > 0, inspectedBuffer.lines.count > 0 else {
+            return RecentBufferText(text: "", nextAbsoluteRow: endAbsoluteRow)
+        }
+
+        let requested = sinceAbsoluteRow > endAbsoluteRow
+            ? inspectedBuffer.linesTop
+            : sinceAbsoluteRow
+        let floorAbsoluteRow = min(
+            max(requested, inspectedBuffer.linesTop),
+            inspectedBuffer.linesTop + inspectedBuffer.yBase
+        )
+        let floorRow = max(
+            0,
+            min(floorAbsoluteRow - inspectedBuffer.linesTop,
+                inspectedBuffer.lines.count - 1)
+        )
+
+        var logicalLinesNewestFirst: [[String]] = []
+        var currentRowsNewestFirst: [String] = []
+        var currentBytes = 0
+        var acceptedBytes = 0
+
+        for row in stride(from: inspectedBuffer.lines.count - 1, through: floorRow, by: -1) {
+            let bufferLine = inspectedBuffer.lines[row]
+            let text = bufferLine.translateToString(trimRight: true)
+            let bytes = text.utf8.count
+            let separatorBytes = logicalLinesNewestFirst.isEmpty ? 0 : 1
+            let remaining = maximumUTF8Bytes - acceptedBytes - separatorBytes
+
+            guard remaining >= 0,
+                  currentBytes <= remaining,
+                  bytes <= remaining - currentBytes else { break }
+
+            currentRowsNewestFirst.append(text)
+            currentBytes += bytes
+            guard !bufferLine.isWrapped else { continue }
+
+            logicalLinesNewestFirst.append(currentRowsNewestFirst)
+            acceptedBytes += separatorBytes + currentBytes
+            currentRowsNewestFirst.removeAll(keepingCapacity: true)
+            currentBytes = 0
+        }
+
+        return RecentBufferText(
+            text: logicalLinesNewestFirst.reversed().map { rowsNewestFirst in
+                rowsNewestFirst.reversed().joined()
+            }.joined(separator: "\n"),
+            nextAbsoluteRow: endAbsoluteRow
+        )
     }
     
     /// Returns the text between the specified range

--- a/Tests/SwiftTermTests/RecentBufferTextTests.swift
+++ b/Tests/SwiftTermTests/RecentBufferTextTests.swift
@@ -1,0 +1,109 @@
+#if os(macOS)
+import Foundation
+import XCTest
+
+@testable import SwiftTerm
+
+final class RecentBufferTextTests: XCTestCase {
+    private let queue = DispatchQueue(label: "SwiftTerm.RecentBufferTextTests")
+
+    private func terminal(
+        cols: Int = 80,
+        rows: Int = 24,
+        scrollback: Int = 100
+    ) -> Terminal {
+        HeadlessTerminal(
+            queue: queue,
+            options: TerminalOptions(cols: cols, rows: rows, scrollback: scrollback)
+        ) { _ in }.terminal
+    }
+
+    private func feedLines(_ terminal: Terminal, _ range: ClosedRange<Int>) {
+        for index in range {
+            terminal.feed(text: "line-\(index)\r\n")
+        }
+    }
+
+    func testJoinsSoftWrapsAndPreservesHardBreaks() {
+        let terminal = terminal(cols: 12, rows: 8)
+        let path = "/tmp/a-very-long-render-name.png"
+        terminal.feed(text: path + "\r\nnext")
+
+        let text = terminal.getRecentLogicalBufferText(maximumUTF8Bytes: 4_096)
+
+        XCTAssertTrue(text.contains(path))
+        XCTAssertTrue(text.contains("\nnext"))
+    }
+
+    func testOmitsAnOversizedPartialLogicalLine() {
+        let terminal = terminal(cols: 8, rows: 6)
+        terminal.feed(text: "/tmp/this-logical-line-is-larger-than-the-budget.png")
+
+        let text = terminal.getRecentLogicalBufferText(maximumUTF8Bytes: 16)
+
+        XCTAssertLessThanOrEqual(text.utf8.count, 16)
+        XCTAssertFalse(text.contains(".png"))
+        XCTAssertFalse(text.contains("budget"))
+    }
+
+    func testIncrementalReadSkipsStableScrollback() {
+        let terminal = terminal(cols: 40, rows: 5, scrollback: 2_000)
+        feedLines(terminal, 1...300)
+        let first = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: 0)
+
+        feedLines(terminal, 301...301)
+        let second = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: first.nextAbsoluteRow)
+
+        XCTAssertTrue(second.text.contains("line-301"))
+        XCTAssertFalse(second.text.contains("line-100"))
+        XCTAssertLessThanOrEqual(
+            second.text.split(separator: "\n", omittingEmptySubsequences: false).count,
+            8)
+    }
+
+    func testIncrementalReadAlwaysIncludesCurrentScreen() {
+        let terminal = terminal(cols: 40, rows: 5, scrollback: 2_000)
+        feedLines(terminal, 1...300)
+        let first = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: 0)
+
+        terminal.feed(text: "\u{1b}[H/tmp/painted-in-place.png")
+        let second = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: first.nextAbsoluteRow)
+
+        XCTAssertTrue(second.text.contains("/tmp/painted-in-place.png"))
+    }
+
+    func testCursorPastCurrentBufferReadsTheRetainedWindow() {
+        let terminal = terminal(cols: 40, rows: 5, scrollback: 2_000)
+        feedLines(terminal, 1...300)
+
+        let read = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: 10_000_000)
+
+        XCTAssertTrue(read.text.contains("line-1\n"))
+    }
+
+    func testCursorAdvancesByProducedRows() {
+        let terminal = terminal(cols: 40, rows: 5, scrollback: 2_000)
+        feedLines(terminal, 1...10)
+        let first = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: 0)
+
+        feedLines(terminal, 11...13)
+        let second = terminal.getRecentLogicalBufferText(
+            maximumUTF8Bytes: 256 * 1024,
+            sinceAbsoluteRow: first.nextAbsoluteRow)
+
+        XCTAssertEqual(second.nextAbsoluteRow - first.nextAbsoluteRow, 3)
+    }
+}
+#endif


### PR DESCRIPTION
Follow-up to #647.

Hosts that need recent terminal context currently have to copy and rescan the full grid buffer, including soft-wrap boundaries. This adds a bounded text read that returns complete logical lines, joins soft-wrapped rows, preserves hard line breaks, and never splits the oldest returned logical line to satisfy the byte limit.

The incremental overload also returns an absolute row cursor. A later read can skip stable scrollback while still rereading the visible screen, where full-screen applications can repaint cells in place. A cursor from a reset or switched buffer falls back to the retained window.

`TerminalView` exposes the same operation through `TerminalRenderOwner`, so the read remains inside the terminal lock without exposing mutable buffer storage.

Verification:

- `swift test`
- `swift build -Xswiftc -strict-concurrency=complete`