### PR TITLE
Defer hidden normal-buffer reflow while alternate screen is active

### DIFF
--- a/Sources/SwiftTerm/Terminal.swift
+++ b/Sources/SwiftTerm/Terminal.swift
@@ -1092,6 +1092,12 @@ open class Terminal {
             return
         }
         semanticNoteAlternateScreenSwitch()
+
+        // A full-screen program can sit over thousands of normal-buffer scrollback lines. While
+        // that alternate screen is active, window resizes update only what is visible and leave
+        // this buffer at its prior grid; otherwise every drag tick reflows hidden history. Pay
+        // that cost once, at the final grid, only when the normal buffer becomes visible again.
+        resizeNormalBufferToCurrentGridIfNeeded()
         normalBuffer.x = altBuffer.x
         normalBuffer.y = altBuffer.y
         
@@ -1121,6 +1127,16 @@ open class Terminal {
         _buffer = altBuffer
         clearKittyImages(in: altBuffer, isAlternateBuffer: true)
     }
+
+    private func resizeNormalBufferToCurrentGridIfNeeded() {
+        guard normalBuffer.cols != cols || normalBuffer.rows != rows else { return }
+
+        let oldCols = normalBuffer.cols
+        let dy = normalBuffer.savedY - normalBuffer.y
+        normalBuffer.resize(newCols: cols, newRows: rows)
+        normalBuffer.savedY = normalBuffer.y + dy
+        normalBuffer.setupTabStops(index: oldCols, tabStopWidth: tabStopWidth)
+    }
     
     func setupTabStops (index: Int = -1)
     {
@@ -1129,13 +1145,14 @@ open class Terminal {
     }
     
     func resizeBuffers(newColumns: Int, newRows: Int) {
-        // correct the savedY cursor to follow changes to y
-        let dy = normalBuffer.savedY - normalBuffer.y
-        normalBuffer.resize (newCols: newColumns, newRows: newRows)
-        normalBuffer.savedY = normalBuffer.y + dy
-        
+        if buffer !== altBuffer {
+            // Correct the savedY cursor to follow changes to y. When the alternate buffer is
+            // active, defer this potentially large normal-buffer reflow until it is visible.
+            let dy = normalBuffer.savedY - normalBuffer.y
+            normalBuffer.resize(newCols: newColumns, newRows: newRows)
+            normalBuffer.savedY = normalBuffer.y + dy
+        }
         altBuffer.resize (newCols: newColumns, newRows: newRows)
-
     }
     public func setup (isReset: Bool = false)
     {
@@ -7143,7 +7160,9 @@ open class Terminal {
         self._rows = newRows
         options.cols = newCols
         options.rows = newRows
-        normalBuffer.setupTabStops (index: oldCols, tabStopWidth: tabStopWidth)
+        if normalBuffer.cols == newCols {
+            normalBuffer.setupTabStops(index: oldCols, tabStopWidth: tabStopWidth)
+        }
         altBuffer.setupTabStops (index: oldCols, tabStopWidth: tabStopWidth)
         refresh (startRow: 0, endRow: self.rows - 1)
     }

--- a/Tests/SwiftTermTests/DeferredNormalBufferReflowTests.swift
+++ b/Tests/SwiftTermTests/DeferredNormalBufferReflowTests.swift
@@ -1,0 +1,72 @@
+#if os(macOS)
+import Foundation
+import XCTest
+
+@testable import SwiftTerm
+
+final class DeferredNormalBufferReflowTests: XCTestCase {
+    private let queue = DispatchQueue(label: "SwiftTerm.DeferredNormalBufferReflowTests")
+
+    private func terminal(cols: Int = 80, rows: Int = 24) -> Terminal {
+        HeadlessTerminal(
+            queue: queue,
+            options: TerminalOptions(cols: cols, rows: rows, scrollback: 10_000)
+        ) { _ in }.terminal
+    }
+
+    private func seedNormalBuffer(_ terminal: Terminal) {
+        for index in 1...200 {
+            terminal.feed(text: "normal-buffer-line-\(index)-with-reflow-content\r\n")
+        }
+    }
+
+    func testAlternateScreenDefersNormalBufferResizeUntilReturn() {
+        let terminal = terminal()
+        seedNormalBuffer(terminal)
+        let originalLineCount = terminal.normalBuffer.lines.count
+        terminal.feed(text: "\u{1b}[?1049h")
+
+        terminal.resize(cols: 100, rows: 30)
+        terminal.resize(cols: 60, rows: 18)
+        terminal.resize(cols: 120, rows: 40)
+
+        XCTAssertEqual(terminal.altBuffer.cols, 120)
+        XCTAssertEqual(terminal.altBuffer.rows, 40)
+        XCTAssertEqual(terminal.normalBuffer.cols, 80)
+        XCTAssertEqual(terminal.normalBuffer.rows, 24)
+        XCTAssertEqual(terminal.normalBuffer.lines.count, originalLineCount)
+
+        terminal.feed(text: "\u{1b}[?1049l")
+
+        XCTAssertEqual(terminal.normalBuffer.cols, 120)
+        XCTAssertEqual(terminal.normalBuffer.rows, 40)
+        XCTAssertTrue(terminal.normalBuffer.lines.getArray().compactMap { $0 }.contains {
+            $0.translateToString(trimRight: true).contains("normal-buffer-line-200")
+        })
+        XCTAssertTrue(terminal.normalBuffer.tabStops[80])
+        XCTAssertTrue(terminal.normalBuffer.tabStops[112])
+    }
+
+    func testDeferredReflowMatchesAVisibleNormalBufferResize() {
+        let direct = terminal()
+        let deferred = terminal()
+        seedNormalBuffer(direct)
+        seedNormalBuffer(deferred)
+
+        direct.resize(cols: 120, rows: 40)
+
+        deferred.feed(text: "\u{1b}[?1049h")
+        deferred.resize(cols: 120, rows: 40)
+        deferred.feed(text: "\u{1b}[?1049l")
+
+        XCTAssertEqual(
+            direct.getBufferAsData(kind: .normal),
+            deferred.getBufferAsData(kind: .normal))
+        XCTAssertEqual(direct.normalBuffer.yBase, deferred.normalBuffer.yBase)
+        XCTAssertEqual(direct.normalBuffer.x, deferred.normalBuffer.x)
+        XCTAssertEqual(direct.normalBuffer.y, deferred.normalBuffer.y)
+        XCTAssertEqual(direct.normalBuffer.savedX, deferred.normalBuffer.savedX)
+        XCTAssertEqual(deferred.normalBuffer.savedY, deferred.normalBuffer.y)
+    }
+}
+#endif


### PR DESCRIPTION
Follow-up to #647.

Every resize currently reflows both terminal buffers. When a full-screen application owns the alternate screen, that means each live-resize update can reflow thousands of hidden normal-buffer scrollback rows that cannot be displayed.

This keeps the alternate buffer at the live grid size but leaves the hidden normal buffer at its previous dimensions. When the terminal returns to the normal screen, SwiftTerm reflows it once at the final grid size and updates its saved cursor and tab stops through the same resize rules used by the immediate path.

The regression coverage exercises repeated alternate-screen resizes, preservation of scrollback content and tab stops, and parity with a visible normal-buffer resize.

Verification:

- `swift test`
- `swift build -Xswiftc -strict-concurrency=complete`