### PR TITLE
Preserve valid selections while output is streaming

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1220,17 +1220,12 @@ extension TerminalView {
     func configureFeedSender() {
         let owner = renderOwner
         let signal = frameSignal
-        let crossThreadState = crossThreadState
         let diagnosticsState = diagnosticsState
         feedSender.configure(
             feedBytes: { bytes in
                 signal.markDirty()
                 let parse = Profiling.begin(.ioParse, "bytes=%d", bytes.count)
-                _ = owner.feed(
-                    bytes: bytes[...],
-                    allowMouseReporting: crossThreadState.withLock {
-                        $0.allowMouseReporting
-                    })
+                _ = owner.feed(bytes: bytes[...])
                 parse.end()
                 diagnosticsState.withLock { diagnostics in
                     diagnostics.bytesFed += bytes.count
@@ -1240,11 +1235,7 @@ extension TerminalView {
             },
             feedText: { text in
                 signal.markDirty()
-                _ = owner.feed(
-                    text: text,
-                    allowMouseReporting: crossThreadState.withLock {
-                        $0.allowMouseReporting
-                    })
+                _ = owner.feed(text: text)
                 diagnosticsState.withLock { diagnostics in
                     diagnostics.bytesFed += text.utf8.count
                     diagnostics.batches += 1
@@ -4141,10 +4132,9 @@ extension TerminalView {
     {
         terminal.terminalLock.preconditionLocked()
         search.invalidate()
-        // Preserve manual selection while output is streaming when mouse reporting is disabled.
-        if allowMouseReporting {
-            selection.active = false
-        }
+        // Buffer mutation keeps registered selections aligned with scrolling
+        // and scrollback trimming. Do not discard a user's selection merely
+        // because more output arrived.
     }
     
     func feedFinish (synchronizedOutputActive: Bool)

--- a/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
+++ b/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
@@ -177,14 +177,11 @@ final class TerminalRenderOwner: Sendable {
     /// Feeds one parser batch while this owner retains all mutable terminal
     /// services. The caller can wake the frame driver before and after this
     /// transaction without retaining a view.
-    func feed (bytes: ArraySlice<UInt8>, allowMouseReporting: Bool) -> Bool? {
+    func feed (bytes: ArraySlice<UInt8>) -> Bool? {
         guard let session = currentSession() else { return nil }
         let terminal = session.terminal
         return terminal.terminalLock.withLock {
             session.search.invalidate()
-            if allowMouseReporting {
-                session.selection.active = false
-            }
             terminal.withManagedFeed {
                 terminal.feed(buffer: bytes)
             }
@@ -194,14 +191,11 @@ final class TerminalRenderOwner: Sendable {
 
     /// Feeds one borrowed parser batch. The parse finishes before this method
     /// returns, so the caller can release the source storage after the call.
-    func feed(borrowedBytes: Span<UInt8>, allowMouseReporting: Bool) -> Bool? {
+    func feed(borrowedBytes: Span<UInt8>) -> Bool? {
         guard let session = currentSession() else { return nil }
         let terminal = session.terminal
         return terminal.terminalLock.withLock {
             session.search.invalidate()
-            if allowMouseReporting {
-                session.selection.active = false
-            }
             terminal.withManagedFeed {
                 terminal.feedBorrowed(borrowedBytes)
             }
@@ -209,15 +203,12 @@ final class TerminalRenderOwner: Sendable {
         }
     }
 
-    /// Text variant of ``feed(bytes:allowMouseReporting:)``.
-    func feed (text: String, allowMouseReporting: Bool) -> Bool? {
+    /// Text variant of ``feed(bytes:)``.
+    func feed (text: String) -> Bool? {
         guard let session = currentSession() else { return nil }
         let terminal = session.terminal
         return terminal.terminalLock.withLock {
             session.search.invalidate()
-            if allowMouseReporting {
-                session.selection.active = false
-            }
             terminal.withManagedFeed {
                 terminal.feed(text: text)
             }

--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -53,7 +53,6 @@ private final class LocalProcessTerminalViewProcessAdapter:
 {
     private let renderOwner: TerminalRenderOwner
     private let frameSignal: FrameDriverSignal
-    private let crossThreadState: Locked<TerminalViewCrossThreadState>
     private let diagnosticsState: Locked<TerminalView.Diagnostics>
     private let outputHandler: LockedVoidCallback
     private let windowSize = Locked(winsize())
@@ -62,13 +61,11 @@ private final class LocalProcessTerminalViewProcessAdapter:
 
     init(renderOwner: TerminalRenderOwner,
          frameSignal: FrameDriverSignal,
-         crossThreadState: Locked<TerminalViewCrossThreadState>,
          diagnosticsState: Locked<TerminalView.Diagnostics>,
          outputHandler: LockedVoidCallback,
          terminationHandler: @escaping @MainActor @Sendable (Int32?) -> Void) {
         self.renderOwner = renderOwner
         self.frameSignal = frameSignal
-        self.crossThreadState = crossThreadState
         self.diagnosticsState = diagnosticsState
         self.outputHandler = outputHandler
         self.terminationHandler = terminationHandler
@@ -98,9 +95,7 @@ private final class LocalProcessTerminalViewProcessAdapter:
     func dataReceived(slice: ArraySlice<UInt8>) {
         frameSignal.markDirty()
         let parse = Profiling.begin(.ioParse, "bytes=%d", slice.count)
-        _ = renderOwner.feed(
-            bytes: slice,
-            allowMouseReporting: crossThreadState.withLock { $0.allowMouseReporting })
+        _ = renderOwner.feed(bytes: slice)
         parse.end()
         diagnosticsState.withLock { diagnostics in
             diagnostics.bytesFed += slice.count
@@ -113,9 +108,7 @@ private final class LocalProcessTerminalViewProcessAdapter:
     func dataReceivedBorrowed(_ bytes: Span<UInt8>) {
         frameSignal.markDirty()
         let parse = Profiling.begin(.ioParse, "bytes=%d", bytes.count)
-        _ = renderOwner.feed(
-            borrowedBytes: bytes,
-            allowMouseReporting: crossThreadState.withLock { $0.allowMouseReporting })
+        _ = renderOwner.feed(borrowedBytes: bytes)
         parse.end()
         diagnosticsState.withLock { diagnostics in
             diagnostics.bytesFed += bytes.count
@@ -185,7 +178,6 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate {
         let adapter = LocalProcessTerminalViewProcessAdapter(
             renderOwner: renderOwner,
             frameSignal: frameSignal,
-            crossThreadState: crossThreadState,
             diagnosticsState: diagnosticsState,
             outputHandler: processOutputHandler,
             terminationHandler: { [weak self] exitCode in

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1487,14 +1487,8 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// line-feed event.
     @available(*, deprecated, message: "Use notifyUpdateChanges and TerminalViewDelegate.rangeChanged(source:startY:endY:) for display updates, or use a separate Terminal(delegate:) for each line-feed event.")
     nonisolated open func linefeed(source: Terminal) {
-        // Preserve manual selection while output is streaming when mouse reporting is disabled.
-        onMain { [weak self] in
-            guard let self, self.allowMouseReporting else { return }
-            self.withTerminal { _ in
-                guard self.selection.active else { return }
-                self.selection.selectNone()
-            }
-        }
+        // SelectionService adjusts registered selections when the buffer
+        // scrolls or trims, so ordinary output does not invalidate them.
     }
     
     /// This vaiable controls whether mouse events are sent to the application running under the

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -1720,14 +1720,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     /// line-feed event.
     @available(*, deprecated, message: "Use notifyUpdateChanges and TerminalViewDelegate.rangeChanged(source:startY:endY:) for display updates, or use a separate Terminal(delegate:) for each line-feed event.")
     nonisolated open func linefeed(source: Terminal) {
-        // Preserve manual selection while output is streaming when mouse reporting is disabled.
-        onMain { [weak self] in
-            guard let self, self.allowMouseReporting else { return }
-            self.withTerminal { _ in
-                guard self.selection.active else { return }
-                self.selection.selectNone()
-            }
-        }
+        // SelectionService adjusts registered selections when the buffer
+        // scrolls or trims, so ordinary output does not invalidate them.
     }
     
     func updateScroller ()

--- a/Tests/SwiftTermTests/SelectionRedrawTests.swift
+++ b/Tests/SwiftTermTests/SelectionRedrawTests.swift
@@ -80,5 +80,25 @@ struct SelectionRedrawTests {
 
         #expect(!view.renderOwner.inspection().selectionActive)
     }
+
+    /// Incoming output must not discard a selection whose buffer coordinates remain valid.
+    @Test func ordinaryOutputPreservesSelection() async throws {
+        let (view, _, driver) = makeView()
+        defer { driver.invalidate() }
+
+        view.feed(text: "hello world\r\nsecond line")
+        await drain()
+        view.selection.startSelection(row: 0, col: 0)
+        view.selection.dragExtend(bufferPosition: Position(col: 5, row: 0))
+        let selectedText = view.selection.getSelectedText()
+        #expect(view.allowMouseReporting)
+        #expect(view.selection.active)
+
+        view.feed(text: "\r\nthird line")
+        await drain()
+
+        #expect(view.selection.active)
+        #expect(view.selection.getSelectedText() == selectedText)
+    }
 }
 #endif

--- a/Tests/SwiftTermTests/TerminalSnapshotTests.swift
+++ b/Tests/SwiftTermTests/TerminalSnapshotTests.swift
@@ -62,7 +62,7 @@ struct TerminalSnapshotTests {
 
         owner.withSnapshotForDrawing(viewState: FrameViewState(view: view)) { _, _ in
             DispatchQueue.global(qos: .userInitiated).async {
-                _ = owner.feed(text: "x", allowMouseReporting: false)
+                _ = owner.feed(text: "x")
                 completed.signal()
             }
 


### PR DESCRIPTION
Follow-up to #647.

`TerminalView` currently clears an active selection before every feed whenever mouse reporting is allowed. That makes ordinary process output erase a manual selection even when its buffer coordinates are still valid.

The terminal core already registers each `SelectionService`, moves its anchors when rows move, and clears it when a scroll operation can no longer represent the selected text. This change lets that existing buffer mutation logic decide whether the selection survives. Search results are still invalidated before parsing.

The same rule now applies to regular feeds, borrowed local-process feeds, and the deprecated line-feed delegate hooks on both Apple views.

Verification:

- `swift test`
- `swift build -Xswiftc -strict-concurrency=complete`
- generic iOS device build with code signing disabled