### PR TITLE
Report hasText as true so the delete key keeps its auto-repeat

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -2040,7 +2040,15 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     }
     
     public var hasText: Bool {
-        return !textInputStorage.isEmpty
+        // A terminal always has something a backspace could act on: what a backspace
+        // *means* is the remote's decision, not this view's. Answering from
+        // `textInputStorage` — which is cleared on every Enter and never holds what the
+        // far side echoed — made this `false` at an ordinary shell prompt, where
+        // `deleteBackward()` sends a backspace regardless (see its own comment there).
+        // The system reads `hasText` to decide whether the delete key has anything to
+        // act on, so reporting `false` cost that key its auto-repeat: holding backspace
+        // deleted one character and stopped.
+        return true
     }
 
     func isAutoPeriodReplacement(_ text: String) -> Bool {


### PR DESCRIPTION
### The problem

`TerminalView.hasText` reports `false` whenever the input-session shadow is empty:

```swift
public var hasText: Bool {
    return !textInputStorage.isEmpty
}
```

`textInputStorage` is cleared on every Enter and never holds anything the far side echoed, so at an ordinary shell prompt it is empty — even with a full command line on screen.

`hasText` is a `UIKeyInput` requirement, and the system uses it to decide whether the delete key has anything to act on. Reporting `false` is what stops **key repeat: holding backspace deletes one character and stops**, on the software keyboard and on a hardware one.

### Why this looks like an inconsistency rather than a judgement call

`deleteBackward()` already treats the empty-storage case as "send a backspace to the terminal", and says so in its own comment:

```swift
if rangeStartIndex == 0 {
    // This is the case when the user hits backspace, but there is no text in the
    // text input buffer.  This happens for example when text has been pasted.
    // In that scenario, we should just send the backspace character to the terminal
    pendingAutoPeriodDeleteWasSpace = false
    self.sendBackspaceKey()
```

So in exactly the state where `hasText` answers "nothing to delete", `deleteBackward()` deletes anyway. The view tells the system it has no text and then acts as though it does — and the only visible consequence is the lost repeat.

For a terminal the honest answer is that there is always something to delete: what a backspace *means* is the remote's decision, not the view's.

### The change

```diff
     public var hasText: Bool {
-        return !textInputStorage.isEmpty
+        // A terminal always has something a backspace could act on: what it means is the
+        // remote's decision, not this view's. Reporting the input-session shadow here made
+        // `hasText` false at a shell prompt — where `deleteBackward()` sends a backspace
+        // regardless — which cost the delete key its key repeat.
+        return true
     }
```

### Reproducing

Any `TerminalView` attached to a shell. Type a few characters at a prompt, then press and hold backspace: one character is deleted. Tapping repeatedly deletes normally, so it is specifically the repeat that is missing. `hasText` returns `false` throughout.

### If you would rather not change the default

Marking it `open` instead would let a subclass answer for itself and is enough to unblock downstream use. It is the smaller change, though it leaves the inconsistency above in place for every other embedder. Note `deleteBackward()` is already `open` while `hasText` is `public`, so the pair cannot currently be overridden together.

Happy to take this either way, or to add a test if there is a pattern you would like it to follow.

---

Found while building [Drover](https://github.com/cunderw/drover), an iOS SSH client that embeds SwiftTerm. Verified against `main` at b202ea5 and against v1.18.0, which is the version Drover pins.
