### PR TITLE
Make hasText open so an embedder can answer for itself

### DIFF
--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -2039,7 +2039,13 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         true
     }
     
-    public var hasText: Bool {
+    /// Whether the delete key has anything to act on.
+    ///
+    /// `open` rather than `public` because the answer belongs to the embedder: this
+    /// reports the input-session shadow, which is empty at an ordinary shell prompt,
+    /// while `deleteBackward()` — already `open` — sends a backspace in that same state.
+    /// A host that knows its far side always has something to delete can say so.
+    open var hasText: Bool {
         return !textInputStorage.isEmpty
     }
 


### PR DESCRIPTION
Per @migueldeicaza's request on #659: the smaller change, so embedders are unblocked while the multi-char keyboard scenario behind c1b7251 gets tested.

```diff
+    /// Whether the delete key has anything to act on.
+    ///
+    /// `open` rather than `public` because the answer belongs to the embedder: this
+    /// reports the input-session shadow, which is empty at an ordinary shell prompt,
+    /// while `deleteBackward()` — already `open` — sends a backspace in that same state.
+    /// A host that knows its far side always has something to delete can say so.
-    public var hasText: Bool {
+    open var hasText: Bool {
         return !textInputStorage.isEmpty
     }
```

No behaviour change: the default answer is untouched, and `deleteBackward()` is already `open`, so this is what lets the pair be overridden together — today `hasText` is `public`, so a subclass cannot override it at all and the compiler rejects the attempt.

`#659` stays open for the question of what the default *should* be; this doesn't presuppose an answer to it.

Verified with `xcodebuild -scheme SwiftTerm -destination 'platform=iOS Simulator,...' build` on `main` at b202ea5 — builds clean.