### PR TITLE
retry transient CoreText glyph failures without caching partial rows

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -402,12 +402,31 @@ struct FrameDrawData {
     var otherImageDraws: [ImageDraw]
 }
 
+private enum GlyphEntryResult {
+    case drawable(ResolvedGlyph)
+    case skip
+    case transientFailure
+}
+
+private struct RowBuildResult {
+    let data: RowDrawData
+    let hadTransientFailure: Bool
+}
+
+private struct CursorBuildResult {
+    var colorVertices: [ColorVertex] = []
+    var glyphVerticesGray: [GlyphVertex] = []
+    var glyphVerticesColor: [GlyphVertex] = []
+    var hadTransientFailure = false
+}
+
 struct DrawData {
     var rows: [RowDrawBuffers]
     var frame: FrameDrawData?
     var cursorColorVertices: [ColorVertex]
     var cursorGlyphVerticesGray: [GlyphVertex]
     var cursorGlyphVerticesColor: [GlyphVertex]
+    var hadTransientFailure: Bool
 }
 
 struct KittyImageSignature: Hashable {
@@ -887,6 +906,9 @@ final class MetalTerminalRenderer {
     private let redrawState: MetalRedrawState
     private let cursorBlinkController: MetalCursorBlinkController
     private let frameSemaphore = DispatchSemaphore(value: 1)
+    private static let maxTransientGlyphRetries = 3
+    // Only the render owner updates this, after a completed draw-data build.
+    private var consecutiveTransientGlyphRetries = 0
     private let redrawLock = NSLock()
     private var activeProfileCounters = MetalProfileCounters()
     private var totalProfileCounters = MetalProfileCounters()
@@ -979,6 +1001,11 @@ final class MetalTerminalRenderer {
 
     var debugRowCacheCounts: (rebuilt: Int, cached: Int) {
         (debugRowsRebuilt, debugRowsCached)
+    }
+
+    var forceContextCreationFailureForTesting: Bool {
+        get { rasterizer.forceContextCreationFailureForTesting }
+        set { rasterizer.forceContextCreationFailureForTesting = newValue }
     }
 #endif
 #if DEBUG
@@ -1173,6 +1200,18 @@ final class MetalTerminalRenderer {
         updateCursorBlinkTimer(shouldBlink: shouldBlink)
         let buildInterval = Profiling.begin(.metalBuildDrawData)
         let drawData = buildDrawData(snapshot: snapshot, context: renderContext)
+        defer {
+            // Only the retained atlas pass counts. Request even if encoding
+            // fails; submitted frames still release their permit on completion.
+            if drawData.hadTransientFailure {
+                if consecutiveTransientGlyphRetries < Self.maxTransientGlyphRetries {
+                    consecutiveTransientGlyphRetries += 1
+                    self.redrawState.requestRedraw()
+                }
+            } else {
+                consecutiveTransientGlyphRetries = 0
+            }
+        }
         buildInterval.end()
 #if canImport(os)
         if MetalTerminalRenderer.profileEnabled {
@@ -1443,7 +1482,8 @@ final class MetalTerminalRenderer {
                             frame: nil,
                             cursorColorVertices: [],
                             cursorGlyphVerticesGray: [],
-                            cursorGlyphVerticesColor: [])
+                            cursorGlyphVerticesColor: [],
+                            hadTransientFailure: false)
         }
         let bufferingMode = context.metalBufferingMode
         if cacheBufferingMode != bufferingMode {
@@ -1514,6 +1554,7 @@ final class MetalTerminalRenderer {
 
         var rebuiltRows = 0
         var cachedRows = 0
+        var hadTransientFailure = false
         for absoluteRow in visibleRange {
             guard let snapshotRow = snapshot.row(atAbsolute: absoluteRow) else {
                 continue
@@ -1523,50 +1564,40 @@ final class MetalTerminalRenderer {
             let cacheValid = entry?.sourceIdentity == sourceIdentity &&
                 entry?.sourceGeneration == snapshotRow.sourceGeneration &&
                 entry?.revision == snapshotRow.revision
-            let needsRebuild = needsFullRebuild ||
-                !cacheValid ||
-                (bufferingMode == .perFrameAggregated && entry?.data == nil)
+            let needsRebuild = needsFullRebuild || !cacheValid || entry?.data == nil
             let rowBuffers: RowDrawBuffers?
             let rowData: RowDrawData
             if needsRebuild {
                 let rowInterval = Profiling.begin(.metalRowBuild)
                 defer { rowInterval.end() }
-                rowData = buildRowDrawData(row: snapshotRow,
-                                           absoluteRow: absoluteRow,
-                                           snapshot: snapshot,
-                                           context: context,
-                                           yDisp: visibleDisp,
-                                           cellWidth: cellWidth,
-                                           cellHeight: cellHeight,
-                                           yOffset: yOffset,
-                                           viewWidthPx: viewWidthPx,
-                                           scale: scale)
+                let result = buildRowDrawData(row: snapshotRow,
+                                              absoluteRow: absoluteRow,
+                                              snapshot: snapshot,
+                                              context: context,
+                                              yDisp: visibleDisp,
+                                              cellWidth: cellWidth,
+                                              cellHeight: cellHeight,
+                                              yOffset: yOffset,
+                                              viewWidthPx: viewWidthPx,
+                                              scale: scale)
+                rowData = result.data
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                entry = RowCacheEntry(sourceIdentity: sourceIdentity,
-                                      sourceGeneration: snapshotRow.sourceGeneration,
-                                      revision: snapshotRow.revision,
-                                      data: rowData, buffers: buffers)
-                rowCache[absoluteRow] = entry
-                rowBuffers = buffers
-                rebuiltRows += 1
-            } else if let cached = entry {
-                rowData = cached.data ?? buildRowDrawData(row: snapshotRow,
-                                                          absoluteRow: absoluteRow,
-                                                          snapshot: snapshot,
-                                                          context: context,
-                                                          yDisp: visibleDisp,
-                                                          cellWidth: cellWidth,
-                                                          cellHeight: cellHeight,
-                                                          yOffset: yOffset,
-                                                          viewWidthPx: viewWidthPx,
-                                                          scale: scale)
-                if cached.data == nil {
+                if result.hadTransientFailure {
+                    hadTransientFailure = true
+                    // Render partial data this frame, but never retain it,
+                    // even after the automatic redraw budget is exhausted.
+                    rowCache.removeValue(forKey: absoluteRow)
+                } else {
                     entry = RowCacheEntry(sourceIdentity: sourceIdentity,
                                           sourceGeneration: snapshotRow.sourceGeneration,
                                           revision: snapshotRow.revision,
-                                          data: rowData, buffers: cached.buffers)
+                                          data: rowData, buffers: buffers)
                     rowCache[absoluteRow] = entry
                 }
+                rowBuffers = buffers
+                rebuiltRows += 1
+            } else if let cached = entry, let cachedData = cached.data {
+                rowData = cachedData
                 if bufferingMode == .perRowPersistent {
                     if let buffers = cached.buffers {
                         rowBuffers = buffers
@@ -1624,7 +1655,8 @@ final class MetalTerminalRenderer {
                         frame: frameData,
                         cursorColorVertices: cursorData.colorVertices,
                         cursorGlyphVerticesGray: cursorData.glyphVerticesGray,
-                        cursorGlyphVerticesColor: cursorData.glyphVerticesColor)
+                        cursorGlyphVerticesColor: cursorData.glyphVerticesColor,
+                        hadTransientFailure: hadTransientFailure || cursorData.hadTransientFailure)
     }
 
     private func visibleRowRange(snapshot: TerminalSnapshot) -> (Int, Int, Int)? {
@@ -1648,7 +1680,8 @@ final class MetalTerminalRenderer {
                                   cellHeight: CGFloat,
                                   yOffset: CGFloat,
                                   viewWidthPx: CGFloat,
-                                  scale: CGFloat) -> RowDrawData {
+                                  scale: CGFloat) -> RowBuildResult {
+        var hadTransientFailure = false
         var backgroundCells: [ColorCell] = []
         var powerlineJoinCells: [ColorCell] = []
         var glyphCellsGray: [TextCell] = []
@@ -2036,13 +2069,19 @@ final class MetalTerminalRenderer {
                             fullFontToken: fullFontToken,
                             rasterFontToken: rasterFontToken,
                             glyph: glyph)
-                        guard let resolvedGlyph = glyphEntry(
-                            rasterFontToken: rasterFontToken,
-                            font: scaledFont,
-                            fittingFont: glyphRun.font,
-                            renderingScale: scale,
-                            metricsFont: &metricsFont,
-                            glyph: glyph) else {
+                        let resolvedGlyph: ResolvedGlyph
+                        switch glyphEntry(rasterFontToken: rasterFontToken,
+                                          font: scaledFont,
+                                          fittingFont: glyphRun.font,
+                                          renderingScale: scale,
+                                          metricsFont: &metricsFont,
+                                          glyph: glyph) {
+                        case .drawable(let result):
+                            resolvedGlyph = result
+                        case .skip:
+                            continue
+                        case .transientFailure:
+                            hadTransientFailure = true
                             continue
                         }
                         let entry = resolvedGlyph.entry
@@ -2277,16 +2316,18 @@ final class MetalTerminalRenderer {
             }
         }
 
-        return RowDrawData(backgroundCells: backgroundCells,
-                           powerlineJoinCells: powerlineJoinCells,
-                           glyphCellsGray: glyphCellsGray,
-                           glyphCellsColor: glyphCellsColor,
-                           decorationCells: decorationCells,
-                           belowBackgroundImageDraws: belowBackgroundImageDraws,
-                           underImageDraws: underImageDraws,
-                           placeholderImageDraws: placeholderImageDraws,
-                           overImageDraws: overImageDraws,
-                           otherImageDraws: otherImageDraws)
+        return RowBuildResult(
+            data: RowDrawData(backgroundCells: backgroundCells,
+                              powerlineJoinCells: powerlineJoinCells,
+                              glyphCellsGray: glyphCellsGray,
+                              glyphCellsColor: glyphCellsColor,
+                              decorationCells: decorationCells,
+                              belowBackgroundImageDraws: belowBackgroundImageDraws,
+                              underImageDraws: underImageDraws,
+                              placeholderImageDraws: placeholderImageDraws,
+                              overImageDraws: overImageDraws,
+                              otherImageDraws: otherImageDraws),
+            hadTransientFailure: hadTransientFailure)
     }
 
     private func buildShapedSegments(_ segments: [ViewLineSegment],
@@ -2506,7 +2547,7 @@ final class MetalTerminalRenderer {
                             fittingFont: CTFont,
                             renderingScale: CGFloat,
                             metricsFont: inout GlyphMetricsFont?,
-                            glyph: CGGlyph) -> ResolvedGlyph? {
+                            glyph: CGGlyph) -> GlyphEntryResult {
         let key = GlyphKey(rasterFontToken: rasterFontToken, glyph: glyph)
         if ProfilingStats.enabled {
             activeProfileCounters.glyphAtlasLookups += 1
@@ -2516,7 +2557,7 @@ final class MetalTerminalRenderer {
             if ProfilingStats.enabled {
                 activeProfileCounters.glyphAtlasHits += 1
             }
-            return ResolvedGlyph(entry: cached, metricsFromMiss: nil)
+            return .drawable(ResolvedGlyph(entry: cached, metricsFromMiss: nil))
         case .permanentEmpty:
             if ProfilingStats.enabled {
                 activeProfileCounters.glyphAtlasMisses += 1
@@ -2525,7 +2566,7 @@ final class MetalTerminalRenderer {
                     activeProfileCounters.negativeCacheHighWater,
                     glyphBitmapResultCache.emptyHighWaterCount)
             }
-            return nil
+            return .skip
         case .miss:
             if ProfilingStats.enabled {
                 activeProfileCounters.glyphAtlasMisses += 1
@@ -2540,7 +2581,7 @@ final class MetalTerminalRenderer {
                                            glyph: glyph)
         if metrics.inkBounds.width <= 0 || metrics.inkBounds.height <= 0 {
             cachePermanentEmpty(key)
-            return nil
+            return .skip
         }
 
         if ProfilingStats.enabled {
@@ -2556,12 +2597,12 @@ final class MetalTerminalRenderer {
             }
         case .empty:
             cachePermanentEmpty(key)
-            return nil
+            return .skip
         case .transientFailure:
             if ProfilingStats.enabled {
                 activeProfileCounters.transientRasterizationFailures += 1
             }
-            return nil
+            return .transientFailure
         }
         let atlasKind: GlyphAtlasKind = bitmap.isColor ? .color : .grayscale
         let atlas = atlasKind == .color ? colorAtlas : grayscaleAtlas
@@ -2569,7 +2610,7 @@ final class MetalTerminalRenderer {
         let maybeRegion = atlas.ensureRegion(width: bitmap.width, height: bitmap.height)
         handleAtlasChange(atlas, previousSize: previousSize)
         guard let region = maybeRegion else {
-            return nil
+            return .skip
         }
         atlas.write(region: region, pixels: bitmap.pixels, width: bitmap.width, height: bitmap.height)
         let entry = GlyphEntry(region: region,
@@ -2578,7 +2619,7 @@ final class MetalTerminalRenderer {
                                isColor: bitmap.isColor,
                                atlasKind: atlasKind)
         glyphBitmapResultCache.storeDrawable(entry, for: key)
-        return ResolvedGlyph(entry: entry, metricsFromMiss: metrics)
+        return .drawable(ResolvedGlyph(entry: entry, metricsFromMiss: metrics))
     }
 
     private func glyphSlotFit(resolvedGlyph: ResolvedGlyph,
@@ -3329,24 +3370,22 @@ final class MetalTerminalRenderer {
                                      cellHeight: CGFloat,
                                      yDisp: Int,
                                      firstRow: Int,
-                                     lastRow: Int) -> (colorVertices: [ColorVertex],
-                                                       glyphVerticesGray: [GlyphVertex],
-                                                       glyphVerticesColor: [GlyphVertex]) {
+                                     lastRow: Int) -> CursorBuildResult {
         guard let cursor = snapshot.cursor, !cursor.hidden else {
-            return ([], [], [])
+            return CursorBuildResult()
         }
         let cursorRow = cursor.absoluteRow
         if cursorRow < firstRow || cursorRow > lastRow {
-            return ([], [], [])
+            return CursorBuildResult()
         }
         if cursor.visualCol < 0 || cursor.visualCol >= snapshot.cols {
-            return ([], [], [])
+            return CursorBuildResult()
         }
         let cursorStyle = snapshot.cursorStyle
         let hasFocus = context.cursorHasFocus
         let blinkOn = redrawState.cursorBlinkOn
         if hasFocus && isBlinkStyle(cursorStyle) && !blinkOn {
-            return ([], [], [])
+            return CursorBuildResult()
         }
         let lineOffset = cellHeight * CGFloat(cursorRow - yDisp + 1)
         let lineOrigin = CGPoint(x: 0, y: context.viewBounds.height - lineOffset)
@@ -3370,6 +3409,7 @@ final class MetalTerminalRenderer {
         var colorVertices: [ColorVertex] = []
         var glyphVerticesGray: [GlyphVertex] = []
         var glyphVerticesColor: [GlyphVertex] = []
+        var hadTransientFailure = false
 
         if !hasFocus {
             // Core Graphics centers its 3-point stroke on the cell boundary.
@@ -3395,7 +3435,7 @@ final class MetalTerminalRenderer {
                                                           x1: CGFloat(x1),
                                                           y1: CGFloat(y1 - stroke),
                                                           color: cursorColor))
-            return (colorVertices, [], [])
+            return CursorBuildResult(colorVertices: colorVertices)
         }
 
         switch cursorStyle {
@@ -3406,7 +3446,7 @@ final class MetalTerminalRenderer {
                                                           x1: CGFloat(x0 + barWidth),
                                                           y1: CGFloat(y1),
                                                           color: cursorColor))
-            return (colorVertices, [], [])
+            return CursorBuildResult(colorVertices: colorVertices)
         case .blinkUnderline, .steadyUnderline:
             let underlineHeight = max(1, 2 * scale)
             colorVertices.append(contentsOf: quadVertices(x0: CGFloat(x0),
@@ -3414,7 +3454,7 @@ final class MetalTerminalRenderer {
                                                           x1: CGFloat(x1),
                                                           y1: CGFloat(y0 + underlineHeight),
                                                           color: cursorColor))
-            return (colorVertices, [], [])
+            return CursorBuildResult(colorVertices: colorVertices)
         case .blinkBlock, .steadyBlock:
             colorVertices.append(contentsOf: quadVertices(x0: CGFloat(x0),
                                                           y0: CGFloat(y0),
@@ -3425,7 +3465,7 @@ final class MetalTerminalRenderer {
 
         let caretTextColor = renderData.textColor
         if !snapshot.style.textBlinkVisible && renderData.cellAttribute.style.contains(.blink) {
-            return (colorVertices, [], [])
+            return CursorBuildResult(colorVertices: colorVertices)
         }
         if PowerlineRenderer.shouldRender(codePoint: UInt32(renderData.code),
                                           customGlyphsEnabled: renderData.customBlockGlyphs) {
@@ -3459,7 +3499,10 @@ final class MetalTerminalRenderer {
                                                                            color: colorToSIMD(caretTextColor)))
                 }
             }
-            return (colorVertices, glyphVerticesGray, glyphVerticesColor)
+            return CursorBuildResult(colorVertices: colorVertices,
+                                     glyphVerticesGray: glyphVerticesGray,
+                                     glyphVerticesColor: glyphVerticesColor,
+                                     hadTransientFailure: hadTransientFailure)
         }
         let attributes = renderData.attributes.isEmpty
             ? [.font: renderData.normalFont] : renderData.attributes
@@ -3472,7 +3515,7 @@ final class MetalTerminalRenderer {
             attributes: attributes)
         let ctline = CTLineCreateWithAttributedString(attributedString)
         guard let runs = CTLineGetGlyphRuns(ctline) as? [CTRun] else {
-            return (colorVertices, [], [])
+            return CursorBuildResult(colorVertices: colorVertices)
         }
         let yOffset = context.baselineOffset
         let textColorSIMD = colorToSIMD(caretTextColor)
@@ -3505,13 +3548,19 @@ final class MetalTerminalRenderer {
                 recordProfileGlyphIdentityAlias(fullFontToken: fullFontToken,
                                                 rasterFontToken: rasterFontToken,
                                                 glyph: glyph)
-                guard let resolvedGlyph = glyphEntry(
-                    rasterFontToken: rasterFontToken,
-                    font: scaledFont,
-                    fittingFont: ctFont,
-                    renderingScale: scale,
-                    metricsFont: &metricsFont,
-                    glyph: glyph) else {
+                let resolvedGlyph: ResolvedGlyph
+                switch glyphEntry(rasterFontToken: rasterFontToken,
+                                  font: scaledFont,
+                                  fittingFont: ctFont,
+                                  renderingScale: scale,
+                                  metricsFont: &metricsFont,
+                                  glyph: glyph) {
+                case .drawable(let result):
+                    resolvedGlyph = result
+                case .skip:
+                    continue
+                case .transientFailure:
+                    hadTransientFailure = true
                     continue
                 }
                 let entry = resolvedGlyph.entry
@@ -3567,7 +3616,10 @@ final class MetalTerminalRenderer {
             }
         }
 
-        return (colorVertices, glyphVerticesGray, glyphVerticesColor)
+        return CursorBuildResult(colorVertices: colorVertices,
+                                 glyphVerticesGray: glyphVerticesGray,
+                                 glyphVerticesColor: glyphVerticesColor,
+                                 hadTransientFailure: hadTransientFailure)
     }
 
     private func texture(for image: SnapshotImage) -> MTLTexture? {

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -4076,10 +4076,8 @@ final class MetalTerminalRenderer {
 
     /// Whether a shader library can be built here at all.
     ///
-    /// Exposed for tests: under `swift test` the SwiftTerm resource bundle is
-    /// not next to the test binary, so Metal cannot be enabled and any test
-    /// that needs it must skip rather than fail. Cheap and cached — building
-    /// the library once is the only honest way to answer this.
+    /// Exposed for tests that optionally exercise Metal. Cheap and cached —
+    /// building the library once is the only honest way to answer this.
     static let shaderLibraryIsAvailable: Bool = {
         guard let device = MTLCreateSystemDefaultDevice() else { return false }
         return (try? makeLibrary(device: device)) != nil
@@ -4190,6 +4188,16 @@ final class MetalTerminalRenderer {
         if let url = Bundle.main.bundleURL.appendingPathComponent(bundleName) as URL?,
            let resourceBundle = Bundle(url: url) {
             bundles.append(resourceBundle)
+        }
+        // SwiftPM puts resources beside the .xctest bundle, which may be
+        // loaded by a separate runner. Never search arbitrary app siblings.
+        for bundle in [Bundle.main, Bundle(for: MetalTerminalRenderer.self)]
+            where bundle.bundleURL.pathExtension == "xctest" {
+            let url = bundle.bundleURL.deletingLastPathComponent()
+                .appendingPathComponent(bundleName)
+            if let resourceBundle = Bundle(url: url) {
+                bundles.append(resourceBundle)
+            }
         }
         #endif
         bundles.append(Bundle(for: MetalTerminalRenderer.self))

--- a/Tests/SwiftTermTests/MetalTransientGlyphRecoveryTests.swift
+++ b/Tests/SwiftTermTests/MetalTransientGlyphRecoveryTests.swift
@@ -1,0 +1,221 @@
+#if os(macOS) && canImport(MetalKit) && DEBUG
+import AppKit
+import Metal
+import Testing
+@testable import SwiftTerm
+
+@MainActor
+@Suite(.serialized, .enabled(if: MTLCreateSystemDefaultDevice() != nil))
+struct MetalTransientGlyphRecoveryTests {
+    @MainActor
+    private final class Fixture {
+        let view: TerminalView
+        let target: TerminalMetalLayerView
+        let renderer: MetalTerminalRenderer
+        let snapshot = TerminalSnapshot()
+        let redraws = Locked(0)
+
+        init(mode: MetalBufferingMode, text: String, font: NSFont? = nil) throws {
+            let bounds = CGRect(x: 0, y: 0, width: 240, height: 90)
+            let font = try #require(font ?? NSFont(name: "Menlo-Regular", size: 16))
+            view = TerminalView(frame: bounds, font: font,
+                                options: TerminalOptions(cols: 12, rows: 3))
+            view.metalBufferingMode = mode
+            view.caretViewTracksFocus = false
+            view.customBlockGlyphs = true
+            target = TerminalMetalLayerView(frame: bounds)
+            target.renderContentsScale = view.metalRenderingScaleFactor()
+            target.renderDrawableSize = CGSize(
+                width: bounds.width * target.renderContentsScale,
+                height: bounds.height * target.renderContentsScale)
+            target.metalLayer.framebufferOnly = false
+            renderer = try MetalTerminalRenderer(target: target)
+            renderer.waitForCompletionAfterCommit = true
+            renderer.capturesRenderedTexture = true
+            let redraws = redraws
+            renderer.requestRedraw = { redraws.withLock { $0 += 1 } }
+            try feed("\u{1b}[?25l" + text)
+        }
+
+        var redrawCount: Int { redraws.withLock { $0 } }
+
+        func feed(_ text: String) throws {
+            view.feed(text: text)
+            let state = FrameViewState(view: view)
+            let result = view.withTerminal { terminal in
+                snapshot.refresh(terminal: terminal, viewState: state,
+                                 selection: SnapshotSelectionState(selection: view.selection))
+            }
+            try #require(result == .refreshed)
+            try #require(!snapshot.rows.isEmpty)
+        }
+
+        func render() throws -> [UInt8] {
+            let context = try #require(snapshot.renderContext)
+            let before = renderer.completedRenders
+            renderer.prepareSnapshotForImmediateDraw(snapshot: snapshot, context: context)
+            let frame = try #require(target.acquireDrawableFrame())
+            renderer.render(frame: frame)
+            try #require(renderer.completedRenders == before + 1)
+            try #require(renderer.waitForIdle())
+            let texture = try #require(renderer.lastRenderedTexture)
+            var pixels = [UInt8](repeating: 0, count: texture.width * texture.height * 4)
+            pixels.withUnsafeMutableBytes {
+                texture.getBytes($0.baseAddress!, bytesPerRow: texture.width * 4,
+                                 from: MTLRegionMake2D(0, 0, texture.width, texture.height),
+                                 mipmapLevel: 0)
+            }
+            return pixels
+        }
+    }
+
+    @Test(arguments: [MetalBufferingMode.perRowPersistent, .perFrameAggregated])
+    func transientRowIsRebuiltWithoutASnapshotChange(mode: MetalBufferingMode) throws {
+        let fixture = try Fixture(mode: mode, text: "A")
+        defer { _ = fixture.view.updateUiClosed() }
+        let original = try fixture.render()
+        try fixture.feed("B")
+        let revisions = fixture.snapshot.rows.map(\.revision)
+        let generations = fixture.snapshot.rows.map(\.sourceGeneration)
+        let rowCount = fixture.snapshot.rows.count
+
+        fixture.renderer.forceContextCreationFailureForTesting = true
+        let partial = try fixture.render()
+        let preservedHealthyGlyph = partial == original
+        #expect(preservedHealthyGlyph)
+        #expect(fixture.redrawCount == 1)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 1)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == rowCount - 1)
+
+        fixture.renderer.forceContextCreationFailureForTesting = false
+        let recovered = try fixture.render()
+        let missingGlyphRecovered = recovered != partial
+        #expect(missingGlyphRecovered)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 1)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == rowCount - 1)
+        #expect(fixture.redrawCount == 1)
+
+        let cached = try fixture.render()
+        let completeRowWasPreserved = cached == recovered
+        #expect(completeRowWasPreserved)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == rowCount)
+        #expect(fixture.snapshot.rows.map(\.revision) == revisions)
+        #expect(fixture.snapshot.rows.map(\.sourceGeneration) == generations)
+    }
+
+    @Test(arguments: [MetalBufferingMode.perRowPersistent, .perFrameAggregated])
+    func retriesAreBoundedButExternalFramesCanStillRecover(mode: MetalBufferingMode) throws {
+        let fixture = try Fixture(mode: mode, text: "A")
+        defer { _ = fixture.view.updateUiClosed() }
+        fixture.renderer.forceContextCreationFailureForTesting = true
+        let rowCount = fixture.snapshot.rows.count
+        let revisions = fixture.snapshot.rows.map(\.revision)
+        var partial: [UInt8] = []
+
+        for attempt in 1...5 {
+            partial = try fixture.render()
+            #expect(fixture.redrawCount == min(attempt, 3))
+            #expect(fixture.renderer.debugRowCacheCounts.rebuilt == (attempt == 1 ? rowCount : 1))
+            // An abandoned frame before the build must not reset the budget.
+            fixture.renderer.render()
+            #expect(fixture.redrawCount == min(attempt, 3))
+        }
+
+        fixture.renderer.forceContextCreationFailureForTesting = false
+        let recovered = try fixture.render()
+        let missingGlyphRecovered = recovered != partial
+        #expect(missingGlyphRecovered)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 1)
+        #expect(fixture.redrawCount == 3)
+        #expect(fixture.snapshot.rows.map(\.revision) == revisions)
+        _ = try fixture.render()
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == rowCount)
+
+        // Use a new, uncached glyph so the next failure starts a new episode.
+        try fixture.feed("B")
+        fixture.renderer.forceContextCreationFailureForTesting = true
+        _ = try fixture.render()
+        #expect(fixture.redrawCount == 4)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 1)
+    }
+
+    @Test(arguments: [MetalBufferingMode.perRowPersistent, .perFrameAggregated])
+    func stableEmptyGlyphsDoNotRequestRedraws(mode: MetalBufferingMode) throws {
+        let fixture = try Fixture(mode: mode, text: "   \r\u{1b}[2 q\u{1b}[?25h")
+        defer { _ = fixture.view.updateUiClosed() }
+        let cursor = try #require(fixture.snapshot.cursor)
+        try #require(!cursor.hidden)
+        try #require(cursor.character == " ")
+        try #require(fixture.snapshot.cursorStyle == .steadyBlock)
+        let context = try #require(fixture.snapshot.renderContext)
+        try #require(context.cursorHasFocus)
+        fixture.renderer.forceContextCreationFailureForTesting = true
+
+        for _ in 0..<4 {
+            _ = try fixture.render()
+            #expect(fixture.redrawCount == 0)
+        }
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == fixture.snapshot.rows.count)
+    }
+
+    @Test(arguments: [MetalBufferingMode.perRowPersistent, .perFrameAggregated])
+    func oversizedAtlasGlyphDoesNotRequestRedraws(mode: MetalBufferingMode) throws {
+        // Stretch only horizontally to exceed every atlas limit without
+        // allocating a huge square bitmap or changing process-wide atlas caps.
+        let font = CTFontCreateWithName("Menlo-Regular" as CFString, 16, nil)
+        var matrix = CGAffineTransform(scaleX: 4096, y: 1)
+        let oversizedFont = CTFontCreateCopyWithAttributes(font, 16, &matrix, nil)
+        var character: UniChar = 0x57
+        var glyph: CGGlyph = 0
+        try #require(CTFontGetGlyphsForCharacters(oversizedFont, &character, &glyph, 1))
+        let metrics = GlyphMetrics.measure(font: oversizedFont, glyph: glyph)
+        let fixture = try Fixture(mode: mode, text: "W", font: oversizedFont as NSFont)
+        defer { _ = fixture.view.updateUiClosed() }
+        let device = try #require(fixture.target.renderDevice)
+        try #require(metrics.inkBounds.width > CGFloat(GlyphAtlas.maxTextureDimension(of: device)))
+        try #require(fixture.snapshot.cols > 0)
+        let row = try #require(fixture.snapshot.rows.first)
+        try #require(row.text(at: 0, cell: row.line.packedView(at: 0)) == "W")
+
+        _ = try fixture.render()
+        #expect(fixture.redrawCount == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == fixture.snapshot.rows.count)
+        fixture.renderer.forceContextCreationFailureForTesting = true
+        _ = try fixture.render()
+        #expect(fixture.redrawCount == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == fixture.snapshot.rows.count)
+    }
+
+    @Test(arguments: [MetalBufferingMode.perRowPersistent, .perFrameAggregated])
+    func cursorFailureRequestsARedrawWithoutEvictingRows(mode: MetalBufferingMode) throws {
+        // The row uses the custom box-drawing path, but the block cursor shapes
+        // this character with Core Text, so only the cursor can hit the fault.
+        let fixture = try Fixture(mode: mode, text: "\u{2500}\r")
+        defer { _ = fixture.view.updateUiClosed() }
+        _ = try fixture.render()
+        try fixture.feed("\u{1b}[2 q\u{1b}[?25h")
+        let cursor = try #require(fixture.snapshot.cursor)
+        try #require(!cursor.hidden && cursor.character == "\u{2500}")
+        try #require(fixture.snapshot.cursorStyle == .steadyBlock)
+        let revisions = fixture.snapshot.rows.map(\.revision)
+        fixture.renderer.forceContextCreationFailureForTesting = true
+
+        let partial = try fixture.render()
+        #expect(fixture.redrawCount == 1)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 0)
+        #expect(fixture.renderer.debugRowCacheCounts.cached == fixture.snapshot.rows.count)
+
+        fixture.renderer.forceContextCreationFailureForTesting = false
+        let recovered = try fixture.render()
+        let cursorGlyphRecovered = recovered != partial
+        #expect(cursorGlyphRecovered)
+        #expect(fixture.redrawCount == 1)
+        #expect(fixture.renderer.debugRowCacheCounts.rebuilt == 0)
+        #expect(fixture.snapshot.rows.map(\.revision) == revisions)
+    }
+}
+#endif


### PR DESCRIPTION
A transient CoreText failure can leave an incomplete row cached even after rasterization recovers. Preserve that failure through row and cursor construction so a later frame can rebuild the missing glyphs without requiring new terminal output.

Only complete rows enter the cache. Automatic redraws are limited to three consecutive attempts; a later external redraw can still recover after that budget is exhausted. Empty glyphs, unsupported custom glyphs, and atlas-capacity refusals keep their existing skip behavior, without flushing healthy glyphs or atlases.

## Validation

Renderer pixel-readback and cache assertions cover unchanged-snapshot recovery in both buffering modes, retry limits/reset, stable skips, and cursor-only failures. SwiftPM shader discovery now finds the resource bundle beside the test bundle, so these tests run normally without a manual shader link; missing shaders fail when a Metal device is available.

The focused suites and strict-concurrency build pass. Recent upstream [CI](https://github.com/migueldeicaza/SwiftTerm/actions/runs/33348635235) already fails on unrelated Linux PTY typing and Unicode segmentation.

## Related

[The refused-frame retry proposal](https://github.com/migueldeicaza/SwiftTerm/pull/642) addresses a different stage. This patch handles transient glyph failures after frame construction begins, not semaphore/drawable refusal polling.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
