### PR TITLE
recover failed Metal renderers without waiting for GPU completion

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalError.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalError.swift
@@ -1,12 +1,8 @@
 #if os(macOS) || os(iOS) || os(visionOS)
 import Foundation
 
-/// Errors thrown when initializing or configuring the Metal rendering pipeline.
-///
-/// These errors are thrown by ``TerminalView/setUseMetal(_:)`` when the GPU
-/// renderer cannot be created — typically because the device does not support
-/// Metal or a required shader resource is missing.
-public enum MetalError: Error, CustomStringConvertible {
+/// Initialization, configuration, and runtime failures of the Metal renderer.
+public enum MetalError: Error, CustomStringConvertible, Sendable {
     case metalKitUnavailable
     case deviceUnavailable
     case commandQueueUnavailable
@@ -19,6 +15,11 @@ public enum MetalError: Error, CustomStringConvertible {
     case pipelineCreationFailed(String)
     case samplerUnavailable
     case rendererBusy
+    case commandBufferUnavailable
+    case renderEncoderUnavailable
+    case commandFailed(String)
+    case commandTimedOut
+    case inFlightLimitReached
 
     public var description: String {
         switch self {
@@ -46,6 +47,16 @@ public enum MetalError: Error, CustomStringConvertible {
             return "Failed to create Metal sampler state."
         case .rendererBusy:
             return "The Metal renderer did not become idle before teardown."
+        case .commandBufferUnavailable:
+            return "Failed to create a Metal command buffer."
+        case .renderEncoderUnavailable:
+            return "Failed to create a Metal render encoder."
+        case .commandFailed(let reason):
+            return "Metal command failed: \(reason)"
+        case .commandTimedOut:
+            return "A submitted Metal command did not finish within five seconds."
+        case .inFlightLimitReached:
+            return "Metal rendering cannot resume until an outstanding frame completes."
         }
     }
 }

--- a/Sources/SwiftTerm/Apple/Metal/MetalRendererHealth.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalRendererHealth.swift
@@ -1,0 +1,246 @@
+#if os(macOS) || os(iOS) || os(visionOS)
+import Foundation
+import Metal
+import QuartzCore
+
+/// Shared by every renderer generation of a view, including explicit toggles.
+/// A stalled GPU may retain at most two submitted frames for that view. Time
+/// windows and surface changes never reset this budget; only completion does.
+final class MetalFrameBudget: Sendable {
+    private let count = Locked(0)
+
+    var hasCapacity: Bool { outstandingCount < 2 }
+    var outstandingCount: Int { count.withLock { $0 } }
+
+    func acquire() -> Bool {
+        count.withLock {
+            guard $0 < 2 else { return false }
+            $0 += 1
+            return true
+        }
+    }
+
+    func release() {
+        count.withLock {
+            precondition($0 > 0)
+            $0 -= 1
+        }
+    }
+}
+
+/// The only additional resource lifetime captured by a submitted command.
+/// Metal's retained-reference command buffer owns encoded buffers/textures;
+/// this capsule keeps the actual presented drawable alive, not its view or
+/// renderer. Retirement must NOT release its permit or recycle its resources.
+final class MetalSubmittedFrame: Sendable {
+    private let drawable: Locked<(any CAMetalDrawable)?>
+    private let permit: DispatchSemaphore
+    private let budget: MetalFrameBudget
+
+    init(drawable: any CAMetalDrawable, permit: DispatchSemaphore,
+         budget: MetalFrameBudget) {
+        self.drawable = Locked(drawable)
+        self.permit = permit
+        self.budget = budget
+    }
+
+    func complete() {
+        let completed = drawable.withLock {
+            guard $0 != nil else { return false }
+            $0 = nil
+            return true
+        }
+        guard completed else { return }
+        budget.release()
+        permit.signal()
+    }
+}
+
+/// One coalesced monitor and at most one queued main-actor delivery per
+/// renderer. Neither a missing drawable nor a refused frame permit starts the
+/// watchdog: it observes only submitted commands that remain nonterminal.
+final class MetalRendererHealth: Sendable {
+    typealias FailureHandler = @MainActor @Sendable (MetalError) -> Void
+    typealias PresentationHandler = @MainActor @Sendable () -> Void
+    static let timeout: TimeInterval = 5
+
+    private struct State {
+        var active = true
+        var failed = false
+        var command: (any MTLCommandBuffer)?
+        var submittedAt: TimeInterval = 0
+        var pendingFailure: MetalError?
+        var pendingPresentation = false
+        var deliveryScheduled = false
+        var failureHandler: FailureHandler?
+        var presentationHandler: PresentationHandler?
+#if DEBUG
+        var simulatedStatus: MTLCommandBufferStatus?
+#endif
+    }
+
+    private let state = Locked(State())
+    private let timer: DispatchSourceTimer
+    private let redrawState: MetalRedrawState
+
+    init(redrawState: MetalRedrawState) {
+        self.redrawState = redrawState
+        timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        timer.setEventHandler { [weak self] in self?.checkForTimeout() }
+        timer.resume()
+    }
+
+    deinit { timer.cancel() }
+
+    var canRender: Bool { state.withLock { $0.active && !$0.failed } }
+
+    @MainActor
+    func configure(failure: FailureHandler?, presentation: PresentationHandler?) {
+        state.withLock {
+            $0.failureHandler = failure
+            $0.presentationHandler = presentation
+        }
+    }
+
+    func submitted(_ command: any MTLCommandBuffer) {
+        state.withLock {
+            guard $0.active, !$0.failed, $0.failureHandler != nil else { return }
+            $0.command = command
+            $0.submittedAt = ProcessInfo.processInfo.systemUptime
+            timer.schedule(deadline: .now() + Self.timeout)
+        }
+    }
+
+    func completed(error: MetalError?, frame: MetalSubmittedFrame) {
+        let deliver = state.withLock { state in
+            state.command = nil
+            timer.schedule(deadline: .distantFuture)
+            guard state.active, !state.failed else { return false }
+            if let error, state.failureHandler != nil {
+                state.failed = true
+                state.pendingFailure = error
+            } else if error == nil {
+                state.pendingPresentation = true
+            }
+            return scheduleDelivery(&state)
+        }
+        // Clear the old monitor before returning its permit: another frame
+        // may start immediately, and must not have its command cleared by us.
+        frame.complete()
+        if deliver { enqueueDelivery() }
+    }
+
+    func fail(_ error: MetalError) {
+        let deliver = state.withLock { state in
+            guard state.active, !state.failed, state.failureHandler != nil else { return false }
+            state.failed = true
+            state.pendingFailure = error
+            timer.schedule(deadline: .distantFuture)
+            return scheduleDelivery(&state)
+        }
+        if deliver { enqueueDelivery() }
+    }
+
+    func checkForTimeout(now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
+        let deliver = state.withLock { state in
+            guard state.active, !state.failed, let command = state.command,
+                  now - state.submittedAt >= Self.timeout else { return false }
+            var status = command.status
+#if DEBUG
+            status = state.simulatedStatus ?? status
+#endif
+            switch status {
+            case .completed: return false
+            case .error:
+                state.pendingFailure = .commandFailed(command.error?.localizedDescription ?? "Unknown GPU error")
+            default: state.pendingFailure = .commandTimedOut
+            }
+            state.failed = true
+            return scheduleDelivery(&state)
+        }
+        if deliver { enqueueDelivery() }
+    }
+
+    /// Called only after CPU rendering is quiescent. A Metal completion may
+    /// still run, but can now only release its own frame/recycler resources.
+    func retire() {
+        state.withLock {
+            $0.active = false
+            $0.command = nil
+            $0.pendingFailure = nil
+            $0.pendingPresentation = false
+            $0.failureHandler = nil
+            $0.presentationHandler = nil
+            timer.schedule(deadline: .distantFuture)
+        }
+        redrawState.invalidate()
+    }
+
+    private func scheduleDelivery(_ state: inout State) -> Bool {
+        guard !state.deliveryScheduled else { return false }
+        state.deliveryScheduled = true
+        return true
+    }
+
+    private func enqueueDelivery() {
+        Task { @MainActor [self] in
+            let delivery = state.withLock { state -> (MetalError?, FailureHandler?, PresentationHandler?)? in
+                state.deliveryScheduled = false
+                guard state.active else { return nil }
+                let result = (state.pendingFailure, state.failureHandler,
+                              state.pendingPresentation && !state.failed ? state.presentationHandler : nil)
+                state.pendingFailure = nil
+                state.pendingPresentation = false
+                return result
+            }
+            guard let delivery else { return }
+            if let error = delivery.0 {
+                delivery.1?(error)
+            } else if canRender {
+                delivery.2?()
+                if redrawState.consumePendingRedraw() { redrawState.requestRedraw() }
+            }
+        }
+    }
+
+#if DEBUG
+    func simulateCommandStatus(_ status: MTLCommandBufferStatus) {
+        state.withLock { $0.simulatedStatus = status }
+    }
+#endif
+}
+
+#if DEBUG
+/// Withholds a completion notification, never GPU execution. Tests release it
+/// explicitly; no blocked shared event, infinite kernel, or driver wait.
+final class MetalCompletionGate: Sendable {
+    private struct State {
+        var pending: (@Sendable (MetalError?) -> Void)?
+        var released = false
+    }
+    private let state = Locked(State())
+
+    var isHoldingCompletion: Bool { state.withLock { $0.pending != nil } }
+
+    func hold(_ completion: @escaping @Sendable (MetalError?) -> Void) {
+        let held = state.withLock {
+            guard !$0.released else { return false }
+            precondition($0.pending == nil)
+            $0.pending = completion
+            return true
+        }
+        if !held { completion(nil) }
+    }
+
+    func release(error: MetalError? = nil) {
+        let completion = state.withLock {
+            $0.released = true
+            let completion = $0.pending
+            $0.pending = nil
+            return completion
+        }
+        completion?(error)
+    }
+}
+#endif
+#endif

--- a/Sources/SwiftTerm/Apple/Metal/MetalRendererHealth.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalRendererHealth.swift
@@ -7,24 +7,47 @@ import QuartzCore
 /// A stalled GPU may retain at most two submitted frames for that view. Time
 /// windows and surface changes never reset this budget; only completion does.
 final class MetalFrameBudget: Sendable {
-    private let count = Locked(0)
+    private struct State {
+        var count = 0
+        var capacityRetry: (@Sendable () -> Void)?
+    }
+    private let state = Locked(State())
 
     var hasCapacity: Bool { outstandingCount < 2 }
-    var outstandingCount: Int { count.withLock { $0 } }
+    var outstandingCount: Int { state.withLock { $0.count } }
 
     func acquire() -> Bool {
-        count.withLock {
-            guard $0 < 2 else { return false }
-            $0 += 1
+        state.withLock {
+            guard $0.count < 2 else { return false }
+            $0.count += 1
             return true
         }
     }
 
-    func release() {
-        count.withLock {
-            precondition($0 > 0)
-            $0 -= 1
+    /// One deferred structural change, not a per-frame scheduler. Checking
+    /// capacity and registering under the same lock avoids a lost release.
+    func retryWhenAvailable(_ retry: @escaping @Sendable () -> Void) {
+        let ready = state.withLock {
+            guard $0.count >= 2 else { return true }
+            $0.capacityRetry = retry
+            return false
         }
+        if ready { retry() }
+    }
+
+    func cancelRetry() {
+        state.withLock { $0.capacityRetry = nil }
+    }
+
+    func release() {
+        let retry = state.withLock {
+            precondition($0.count > 0)
+            $0.count -= 1
+            let retry = $0.capacityRetry
+            $0.capacityRetry = nil
+            return retry
+        }
+        retry?()
     }
 }
 
@@ -56,12 +79,11 @@ final class MetalSubmittedFrame: Sendable {
     }
 }
 
-/// One coalesced monitor and at most one queued main-actor delivery per
-/// renderer. Neither a missing drawable nor a refused frame permit starts the
-/// watchdog: it observes only submitted commands that remain nonterminal.
+/// One submitted-frame monitor and at most one main-actor failure delivery
+/// per renderer. Healthy completion stays on the completion thread. Neither
+/// a missing drawable nor a refused frame permit starts the watchdog.
 final class MetalRendererHealth: Sendable {
     typealias FailureHandler = @MainActor @Sendable (MetalError) -> Void
-    typealias PresentationHandler = @MainActor @Sendable () -> Void
     static let timeout: TimeInterval = 5
 
     private struct State {
@@ -69,11 +91,7 @@ final class MetalRendererHealth: Sendable {
         var failed = false
         var command: (any MTLCommandBuffer)?
         var submittedAt: TimeInterval = 0
-        var pendingFailure: MetalError?
-        var pendingPresentation = false
-        var deliveryScheduled = false
         var failureHandler: FailureHandler?
-        var presentationHandler: PresentationHandler?
 #if DEBUG
         var simulatedStatus: MTLCommandBufferStatus?
 #endif
@@ -95,11 +113,8 @@ final class MetalRendererHealth: Sendable {
     var canRender: Bool { state.withLock { $0.active && !$0.failed } }
 
     @MainActor
-    func configure(failure: FailureHandler?, presentation: PresentationHandler?) {
-        state.withLock {
-            $0.failureHandler = failure
-            $0.presentationHandler = presentation
-        }
+    func configure(failure: FailureHandler?) {
+        state.withLock { $0.failureHandler = failure }
     }
 
     func submitted(_ command: any MTLCommandBuffer) {
@@ -112,53 +127,51 @@ final class MetalRendererHealth: Sendable {
     }
 
     func completed(error: MetalError?, frame: MetalSubmittedFrame) {
-        let deliver = state.withLock { state in
+        let deliverFailure = state.withLock { state in
             state.command = nil
             timer.schedule(deadline: .distantFuture)
-            guard state.active, !state.failed else { return false }
-            if let error, state.failureHandler != nil {
-                state.failed = true
-                state.pendingFailure = error
-            } else if error == nil {
-                state.pendingPresentation = true
-            }
-            return scheduleDelivery(&state)
+            guard state.active, !state.failed, error != nil,
+                  state.failureHandler != nil else { return false }
+            state.failed = true
+            return true
         }
         // Clear the old monitor before returning its permit: another frame
         // may start immediately, and must not have its command cleared by us.
         frame.complete()
-        if deliver { enqueueDelivery() }
+        if deliverFailure, let error { enqueueFailure(error) }
+        guard canRender else { return }
+        // Preserve the ordinary completion-thread fast path, including when
+        // no health handler or presentation observer has been installed.
+        if error == nil { TerminalView.onFramePresented?() }
+        if redrawState.consumePendingRedraw() { redrawState.requestRedraw() }
     }
 
     func fail(_ error: MetalError) {
         let deliver = state.withLock { state in
             guard state.active, !state.failed, state.failureHandler != nil else { return false }
             state.failed = true
-            state.pendingFailure = error
             timer.schedule(deadline: .distantFuture)
-            return scheduleDelivery(&state)
+            return true
         }
-        if deliver { enqueueDelivery() }
+        if deliver { enqueueFailure(error) }
     }
 
     func checkForTimeout(now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
-        let deliver = state.withLock { state in
+        let error: MetalError? = state.withLock { state in
             guard state.active, !state.failed, let command = state.command,
-                  now - state.submittedAt >= Self.timeout else { return false }
+                  now - state.submittedAt >= Self.timeout else { return nil }
             var status = command.status
 #if DEBUG
             status = state.simulatedStatus ?? status
 #endif
-            switch status {
-            case .completed: return false
-            case .error:
-                state.pendingFailure = .commandFailed(command.error?.localizedDescription ?? "Unknown GPU error")
-            default: state.pendingFailure = .commandTimedOut
-            }
+            guard status != .completed else { return nil }
             state.failed = true
-            return scheduleDelivery(&state)
+            if status == .error {
+                return .commandFailed(command.error?.localizedDescription ?? "Unknown GPU error")
+            }
+            return .commandTimedOut
         }
-        if deliver { enqueueDelivery() }
+        if let error { enqueueFailure(error) }
     }
 
     /// Called only after CPU rendering is quiescent. A Metal completion may
@@ -167,39 +180,18 @@ final class MetalRendererHealth: Sendable {
         state.withLock {
             $0.active = false
             $0.command = nil
-            $0.pendingFailure = nil
-            $0.pendingPresentation = false
             $0.failureHandler = nil
-            $0.presentationHandler = nil
             timer.schedule(deadline: .distantFuture)
         }
         redrawState.invalidate()
     }
 
-    private func scheduleDelivery(_ state: inout State) -> Bool {
-        guard !state.deliveryScheduled else { return false }
-        state.deliveryScheduled = true
-        return true
-    }
-
-    private func enqueueDelivery() {
+    /// `failed` admits exactly one recovery delivery per renderer lifetime.
+    /// Healthy completion, presentation and redraw never enqueue actor work.
+    private func enqueueFailure(_ error: MetalError) {
         Task { @MainActor [self] in
-            let delivery = state.withLock { state -> (MetalError?, FailureHandler?, PresentationHandler?)? in
-                state.deliveryScheduled = false
-                guard state.active else { return nil }
-                let result = (state.pendingFailure, state.failureHandler,
-                              state.pendingPresentation && !state.failed ? state.presentationHandler : nil)
-                state.pendingFailure = nil
-                state.pendingPresentation = false
-                return result
-            }
-            guard let delivery else { return }
-            if let error = delivery.0 {
-                delivery.1?(error)
-            } else if canRender {
-                delivery.2?()
-                if redrawState.consumePendingRedraw() { redrawState.requestRedraw() }
-            }
+            let handler = state.withLock { $0.active ? $0.failureHandler : nil }
+            handler?(error)
         }
     }
 

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -709,6 +709,7 @@ final class MetalRedrawState: Sendable {
     typealias RedrawCallback = @Sendable () -> Void
 
     private struct State: Sendable {
+        var active = true
         var pendingRedraw = false
         var cursorBlinkOn = true
         var cursorBlinkWanted = false
@@ -727,6 +728,26 @@ final class MetalRedrawState: Sendable {
         }
     }
 
+    /// Coalesces render-thread requests before the host's generation check.
+    /// A blocked main thread can retain only one pending delivery, not one
+    /// Task for every transient row failure or refused frame permit.
+    func configureOnMain(callback: @escaping @MainActor @Sendable () -> Void) {
+        let queued = Locked(false)
+        configure { [weak self] in
+            let enqueue = queued.withLock {
+                guard !$0 else { return false }
+                $0 = true
+                return true
+            }
+            guard enqueue else { return }
+            Task { @MainActor [weak self] in
+                queued.withLock { $0 = false }
+                guard self?.state.withLock({ $0.active }) == true else { return }
+                callback()
+            }
+        }
+    }
+
     var callback: RedrawCallback? {
         state.withLock { $0.callback }
     }
@@ -736,8 +757,17 @@ final class MetalRedrawState: Sendable {
         callback?()
     }
 
+    func invalidate() {
+        state.withLock {
+            $0.active = false
+            $0.callback = nil
+            $0.pendingRedraw = false
+            $0.cursorBlinkWanted = false
+        }
+    }
+
     func markPendingRedraw() {
-        state.withLock { $0.pendingRedraw = true }
+        state.withLock { if $0.active { $0.pendingRedraw = true } }
     }
 
     func consumePendingRedraw() -> Bool {
@@ -759,6 +789,7 @@ final class MetalRedrawState: Sendable {
     /// Returns true when the main-actor timer must change.
     func setCursorBlinkWanted(_ wanted: Bool) -> Bool {
         state.withLock { state in
+            guard state.active else { return false }
             let changed = state.cursorBlinkWanted != wanted
             state.cursorBlinkWanted = wanted
             if changed && !wanted {
@@ -887,6 +918,12 @@ final class MetalTerminalRenderer {
     private let redrawState: MetalRedrawState
     private let cursorBlinkController: MetalCursorBlinkController
     private let frameSemaphore = DispatchSemaphore(value: 1)
+    private let frameBudget: MetalFrameBudget
+    let health: MetalRendererHealth
+#if DEBUG
+    var completionGate: MetalCompletionGate?
+    var creationFailure: MetalError?
+#endif
     private let redrawLock = NSLock()
     private var activeProfileCounters = MetalProfileCounters()
     private var totalProfileCounters = MetalProfileCounters()
@@ -967,6 +1004,10 @@ final class MetalTerminalRenderer {
         }
     }
 
+    func configureRedrawOnMain(_ callback: @escaping @MainActor @Sendable () -> Void) {
+        redrawState.configureOnMain(callback: callback)
+    }
+
     /// The renderer's own text builder. Owning it, rather than calling into
     /// the view, is what frees this path from the main thread (io-gaps.md G1).
     /// It also means this cache is never shared with the Core Graphics path.
@@ -987,12 +1028,15 @@ final class MetalTerminalRenderer {
 #endif
 
     @MainActor
-    init(target: any MetalRenderTarget) throws {
+    init(target: any MetalRenderTarget, frameBudget: MetalFrameBudget = MetalFrameBudget()) throws {
         guard let device = target.renderDevice ?? MTLCreateSystemDefaultDevice() else {
             throw MetalError.deviceUnavailable
         }
         let redrawState = MetalRedrawState()
         self.redrawState = redrawState
+        self.frameBudget = frameBudget
+        health = MetalRendererHealth(redrawState: redrawState)
+        health.configure(failure: nil, presentation: { TerminalView.onFramePresented?() })
         cursorBlinkController = MetalCursorBlinkController(redrawState: redrawState)
         self.device = device
         target.renderDevice = device
@@ -1093,6 +1137,7 @@ final class MetalTerminalRenderer {
     /// acquires one from `renderSurface`. In both cases snapshot preparation,
     /// including terminal-lock work, finishes before drawable acquisition.
     func render(frame suppliedFrame: MetalDrawableFrame? = nil) {
+        guard health.canRender else { return }
         // Same event as the Core Graphics draw: only one renderer is active at
         // a time, and the report names which. Needed to compare the two paths
         // and to grade io-gaps.md G1.
@@ -1206,27 +1251,58 @@ final class MetalTerminalRenderer {
             os_signpost(.begin, log: MetalTerminalRenderer.profileLog, name: "Metal.Encode", signpostID: encodeID)
         }
 #endif
-        guard let commandBuffer = commandQueue.makeCommandBuffer(),
-              let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: passDescriptor) else {
+        // Retained references are essential to asynchronous retirement. The
+        // default makeCommandBuffer() retains every encoded resource until
+        // GPU completion; never use makeCommandBufferWithUnretainedReferences.
+        // The small completion capsule additionally owns the presented drawable.
+        var submitted = false
+        defer {
+            if !submitted {
+                frameSemaphore.signal()
 #if canImport(os)
-            if MetalTerminalRenderer.profileEnabled {
-                os_signpost(.end, log: MetalTerminalRenderer.profileLog, name: "Metal.Encode", signpostID: encodeID)
-            }
+                if MetalTerminalRenderer.profileEnabled {
+                    os_signpost(.end, log: MetalTerminalRenderer.profileLog, name: "Metal.Encode", signpostID: encodeID)
+                }
 #endif
-            frameSemaphore.signal()
+            }
+        }
+#if DEBUG
+        if let creationFailure {
+            health.fail(creationFailure)
             return
         }
-        let frameSemaphore = self.frameSemaphore
-        let redrawState = redrawState
-        commandBuffer.addCompletedHandler { _ in
-            frameSemaphore.signal()
-            // Fires on a Metal thread the moment the frame is done, which is
-            // the closest thing to "the glyph is on screen" available without
-            // a display-link correlation.
-            TerminalView.onFramePresented?()
-            if redrawState.consumePendingRedraw() {
-                redrawState.requestRedraw()
+#endif
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else {
+            health.fail(.commandBufferUnavailable)
+            return
+        }
+        guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: passDescriptor) else {
+            health.fail(.renderEncoderUnavailable)
+            return
+        }
+        guard frameBudget.acquire() else {
+            encoder.endEncoding()
+            health.fail(.inFlightLimitReached)
+            return
+        }
+        let lifetime = MetalSubmittedFrame(drawable: drawable, permit: frameSemaphore,
+                                           budget: frameBudget)
+        let health = health
+#if DEBUG
+        let completionGate = completionGate
+#endif
+        commandBuffer.addCompletedHandler { command in
+            let error: MetalError? = command.status == .error
+                ? .commandFailed(command.error?.localizedDescription ?? "Unknown GPU error") : nil
+#if DEBUG
+            if let completionGate {
+                completionGate.hold { injectedError in
+                    health.completed(error: injectedError ?? error, frame: lifetime)
+                }
+                return
             }
+#endif
+            health.completed(error: error, frame: lifetime)
         }
         bufferPool.beginFrame()
         let viewport = SIMD2<Float>(Float(drawableSize.width), Float(drawableSize.height))
@@ -1351,6 +1427,8 @@ final class MetalTerminalRenderer {
         }
         commandBuffer.present(drawable)
         bufferPool.commit(commandBuffer: commandBuffer)
+        health.submitted(commandBuffer)
+        submitted = true
         commandBuffer.commit()
         if waitForCompletionAfterCommit {
             // Testing only: makes the drawable texture readable right after
@@ -1370,11 +1448,18 @@ final class MetalTerminalRenderer {
         redrawState.markPendingRedraw()
     }
 
-    /// Waits for the last committed frame before a host removes or rebinds
-    /// its surface. Never call while holding the terminal lock.
-    ///
-    /// The timeout bounds teardown on a failed GPU. A successful wait returns
-    /// the permit immediately so future frames can continue.
+    /// Quiesce the CPU render executor before calling. Committed commands
+    /// retain their resources and release only their own permit on completion;
+    /// neither the renderer nor its surface needs to wait for the GPU.
+    @MainActor
+    func retire() {
+        health.retire()
+        cursorBlinkController.shutdown()
+        preparedSnapshot = nil
+    }
+
+    /// Diagnostics/test synchronization only, never surface teardown.
+    /// A successful wait returns the permit so future frames can continue.
     func waitForIdle(timeout: TimeInterval = 5) -> Bool {
         precondition(timeout >= 0)
         let result = frameSemaphore.wait(timeout: .now() + timeout)

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -4161,10 +4161,8 @@ final class MetalTerminalRenderer {
 
     /// Whether a shader library can be built here at all.
     ///
-    /// Exposed for tests: under `swift test` the SwiftTerm resource bundle is
-    /// not next to the test binary, so Metal cannot be enabled and any test
-    /// that needs it must skip rather than fail. Cheap and cached — building
-    /// the library once is the only honest way to answer this.
+    /// Exposed for tests that optionally exercise Metal. Cheap and cached —
+    /// building the library once is the only honest way to answer this.
     static let shaderLibraryIsAvailable: Bool = {
         guard let device = MTLCreateSystemDefaultDevice() else { return false }
         return (try? makeLibrary(device: device)) != nil
@@ -4275,6 +4273,16 @@ final class MetalTerminalRenderer {
         if let url = Bundle.main.bundleURL.appendingPathComponent(bundleName) as URL?,
            let resourceBundle = Bundle(url: url) {
             bundles.append(resourceBundle)
+        }
+        // SwiftPM puts resources beside the .xctest bundle, which may be
+        // loaded by a separate runner. Never search arbitrary app siblings.
+        for bundle in [Bundle.main, Bundle(for: MetalTerminalRenderer.self)]
+            where bundle.bundleURL.pathExtension == "xctest" {
+            let url = bundle.bundleURL.deletingLastPathComponent()
+                .appendingPathComponent(bundleName)
+            if let resourceBundle = Bundle(url: url) {
+                bundles.append(resourceBundle)
+            }
         }
         #endif
         bundles.append(Bundle(for: MetalTerminalRenderer.self))

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -728,26 +728,6 @@ final class MetalRedrawState: Sendable {
         }
     }
 
-    /// Coalesces render-thread requests before the host's generation check.
-    /// A blocked main thread can retain only one pending delivery, not one
-    /// Task for every transient row failure or refused frame permit.
-    func configureOnMain(callback: @escaping @MainActor @Sendable () -> Void) {
-        let queued = Locked(false)
-        configure { [weak self] in
-            let enqueue = queued.withLock {
-                guard !$0 else { return false }
-                $0 = true
-                return true
-            }
-            guard enqueue else { return }
-            Task { @MainActor [weak self] in
-                queued.withLock { $0 = false }
-                guard self?.state.withLock({ $0.active }) == true else { return }
-                callback()
-            }
-        }
-    }
-
     var callback: RedrawCallback? {
         state.withLock { $0.callback }
     }
@@ -1004,10 +984,6 @@ final class MetalTerminalRenderer {
         }
     }
 
-    func configureRedrawOnMain(_ callback: @escaping @MainActor @Sendable () -> Void) {
-        redrawState.configureOnMain(callback: callback)
-    }
-
     /// The renderer's own text builder. Owning it, rather than calling into
     /// the view, is what frees this path from the main thread (io-gaps.md G1).
     /// It also means this cache is never shared with the Core Graphics path.
@@ -1036,7 +1012,6 @@ final class MetalTerminalRenderer {
         self.redrawState = redrawState
         self.frameBudget = frameBudget
         health = MetalRendererHealth(redrawState: redrawState)
-        health.configure(failure: nil, presentation: { TerminalView.onFramePresented?() })
         cursorBlinkController = MetalCursorBlinkController(redrawState: redrawState)
         self.device = device
         target.renderDevice = device

--- a/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
+++ b/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
@@ -126,6 +126,7 @@ private struct TerminalRenderState {
 #if canImport(MetalKit)
     var renderer: MetalTerminalRenderer?
     var needsExternalDraw = false
+    var metalRenderingSuspended = false
 #endif
 }
 
@@ -710,6 +711,7 @@ final class TerminalRenderOwner: Sendable {
                          "Install a Metal renderer only after removing the old renderer")
             state.renderer = renderer
             state.needsExternalDraw = needsExternalDraw
+            state.metalRenderingSuspended = false
         }
     }
 
@@ -717,14 +719,14 @@ final class TerminalRenderOwner: Sendable {
     /// first. Submitted GPU work retains only its own resources, not this owner.
     @MainActor
     func replaceMetalRenderer (_ renderer: MetalTerminalRenderer,
-                               needsExternalDraw: Bool) -> Bool {
+                               needsExternalDraw: Bool) {
         precondition(currentSession()?.terminal.terminalLock.isLockedByCurrentThread != true,
                      "Metal replacement cannot enter the render domain under the terminal lock")
-        return withRenderState { state in
+        withRenderState { state in
             state.renderer?.retire()
             state.renderer = renderer
             state.needsExternalDraw = needsExternalDraw
-            return true
+            state.metalRenderingSuspended = false
         }
     }
 
@@ -799,7 +801,17 @@ final class TerminalRenderOwner: Sendable {
     }
 
     func renderMetal (frame: MetalDrawableFrame? = nil) {
-        withRenderState { $0.renderer?.render(frame: frame) }
+        withRenderState {
+            guard !$0.metalRenderingSuspended else { return }
+            $0.renderer?.render(frame: frame)
+        }
+    }
+
+    /// A surface awaiting window rebind must not submit more work while its
+    /// replacement waits for capacity, including through the main draw path.
+    @MainActor
+    func setMetalRenderingSuspended(_ suspended: Bool) {
+        withRenderState { $0.metalRenderingSuspended = suspended }
     }
 
     func discardPreparedMetalSnapshot () {
@@ -813,14 +825,14 @@ final class TerminalRenderOwner: Sendable {
 
     /// Like replacement, removal retires CPU ownership without a GPU wait.
     @MainActor
-    func removeMetalRenderer () -> Bool {
+    func removeMetalRenderer () {
         precondition(currentSession()?.terminal.terminalLock.isLockedByCurrentThread != true,
                      "Metal teardown cannot enter the render domain under the terminal lock")
-        return withRenderState { state in
+        withRenderState { state in
             state.renderer?.retire()
             state.renderer = nil
             state.needsExternalDraw = false
-            return true
+            state.metalRenderingSuspended = false
         }
     }
 
@@ -829,7 +841,6 @@ final class TerminalRenderOwner: Sendable {
         withRenderState { $0.renderer?.health }
     }
 
-    @MainActor
     func configureMetalFaultForTesting(creationFailure: MetalError? = nil,
                                        completionGate: MetalCompletionGate? = nil) {
         withRenderState {

--- a/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
+++ b/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
@@ -713,13 +713,15 @@ final class TerminalRenderOwner: Sendable {
         }
     }
 
+    /// The host stops/suspends its CPU render loop and unbinds the old surface
+    /// first. Submitted GPU work retains only its own resources, not this owner.
     @MainActor
     func replaceMetalRenderer (_ renderer: MetalTerminalRenderer,
                                needsExternalDraw: Bool) -> Bool {
         precondition(currentSession()?.terminal.terminalLock.isLockedByCurrentThread != true,
-                     "Metal replacement cannot wait while the terminal lock is held")
+                     "Metal replacement cannot enter the render domain under the terminal lock")
         return withRenderState { state in
-            guard state.renderer?.waitForIdle() != false else { return false }
+            state.renderer?.retire()
             state.renderer = renderer
             state.needsExternalDraw = needsExternalDraw
             return true
@@ -809,17 +811,33 @@ final class TerminalRenderOwner: Sendable {
         withRenderState { $0.renderer?.waitForIdle() ?? true }
     }
 
+    /// Like replacement, removal retires CPU ownership without a GPU wait.
     @MainActor
     func removeMetalRenderer () -> Bool {
         precondition(currentSession()?.terminal.terminalLock.isLockedByCurrentThread != true,
-                     "Metal teardown cannot wait while the terminal lock is held")
+                     "Metal teardown cannot enter the render domain under the terminal lock")
         return withRenderState { state in
-            guard state.renderer?.waitForIdle() != false else { return false }
+            state.renderer?.retire()
             state.renderer = nil
             state.needsExternalDraw = false
             return true
         }
     }
+
+#if DEBUG
+    func metalHealthForTesting() -> MetalRendererHealth? {
+        withRenderState { $0.renderer?.health }
+    }
+
+    @MainActor
+    func configureMetalFaultForTesting(creationFailure: MetalError? = nil,
+                                       completionGate: MetalCompletionGate? = nil) {
+        withRenderState {
+            $0.renderer?.creationFailure = creationFailure
+            $0.renderer?.completionGate = completionGate
+        }
+    }
+#endif
 
     var completedMetalRenders: Int {
         withRenderState { $0.renderer?.completedRenders ?? 0 }

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -994,14 +994,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         metalView = newView
         metalDrawDelegate = newDrawDelegate
         metalBoundWindow = window
-        if refreshSnapshotForMetal() {
-            if newView.needsExternalDrawCall {
-                renderOwner.renderMetal()
-            } else if let frame = newView.acquireDrawableFrame() {
-                renderOwner.renderMetal(frame: frame)
-            }
-            renderOwner.discardPreparedMetalSnapshot()
-        }
+        drawMetalFrameNow()
 #if DEBUG
         metalReplacementBeforeRemovalForTesting = (
             renderOwner.completedMetalRenders, oldView.superview === self)

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -344,6 +344,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private var useMetalRenderer = false
     private let metalFrameBudget = MetalFrameBudget()
     private var metalRendererGeneration: UInt64 = 0
+    // Also fences a retry already dequeued from the budget but not run on main.
     private var pendingMetalRebindGeneration: UInt64?
     private var lastMetalRecovery: TimeInterval?
 
@@ -356,6 +357,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     var metalRecoveryTestTime: TimeInterval?
     var metalGenerationForTesting: UInt64 { metalRendererGeneration }
     var metalBoundWindowForTesting: NSWindow? { metalBoundWindow }
+    private(set) var metalReplacementBeforeRemovalForTesting: (submittedFrames: Int, oldSurfaceAttached: Bool)?
     var metalOutstandingFramesForTesting: Int { metalFrameBudget.outstandingCount }
 
     func deliverMetalFailureForTesting(_ error: MetalError, generation: UInt64) {
@@ -901,10 +903,11 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     ///
     /// To avoid the visible CoreGraphics-fallback flash that a naive
     /// disable/enable toggle produces, the new view is built and inserted
-    /// before the old one is removed. The frame driver then draws the fresh
-    /// surface without waiting for the old generation's GPU work. At the
-    /// in-flight limit, a completion retries the rebind asynchronously while
-    /// the old surface stays paused; ordinary backpressure is not a failure.
+    /// before the old one is removed. An immediate draw attempt submits the
+    /// first frame without waiting for GPU completion; the frame driver retries
+    /// when no drawable is available yet. At the in-flight limit, a completion
+    /// retries the rebind asynchronously while the old surface stays paused;
+    /// ordinary backpressure is not a failure.
     ///
     /// On failure (renderer init throws), we fall back to CoreGraphics
     /// rendering rather than leaving a frozen Metal view in place — a
@@ -991,6 +994,18 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         metalView = newView
         metalDrawDelegate = newDrawDelegate
         metalBoundWindow = window
+        if refreshSnapshotForMetal() {
+            if newView.needsExternalDrawCall {
+                renderOwner.renderMetal()
+            } else if let frame = newView.acquireDrawableFrame() {
+                renderOwner.renderMetal(frame: frame)
+            }
+            renderOwner.discardPreparedMetalSnapshot()
+        }
+#if DEBUG
+        metalReplacementBeforeRemovalForTesting = (
+            renderOwner.completedMetalRenders, oldView.superview === self)
+#endif
         oldView.removeFromSuperview()
         newView.requestDisplay()
         frameDriver.markDirty()

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -342,6 +342,26 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// Experimental GPU path: CoreText glyph atlas + Metal quads.
     /// Limitations: image caching is basic; GPU path is still evolving.
     private var useMetalRenderer = false
+    private let metalFrameBudget = MetalFrameBudget()
+    private var metalRendererGeneration: UInt64 = 0
+    private var lastMetalRecovery: TimeInterval?
+
+    /// Called only after automatic recovery has finally fallen back to Core
+    /// Graphics. The terminal, selection, scrollback and input session survive.
+    /// Delivered synchronously on main, outside renderer/owner locks, with
+    /// `isUsingMetalRenderer == false` and the Core Graphics path active.
+    public final var metalRendererFallbackHandler: (@MainActor @Sendable (MetalError) -> Void)?
+#if DEBUG
+    var metalRecoveryTestTime: TimeInterval?
+    var metalGenerationForTesting: UInt64 { metalRendererGeneration }
+    var metalOutstandingFramesForTesting: Int { metalFrameBudget.outstandingCount }
+
+    func deliverMetalFailureForTesting(_ error: MetalError, generation: UInt64) {
+        handleMetalFailure(error, generation: generation)
+    }
+
+    func rebindMetalForTesting() { rebindMetalRendererToWindow() }
+#endif
     /// The NSWindow that the current `metalView`'s CAMetalLayer is bound to.
     /// CAMetalLayer's binding to a window's WindowServer surface doesn't
     /// survive being reparented across NSWindow instances — `present(_:)`
@@ -427,7 +447,8 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     }
 
     func startRenderLoopIfNeeded () {
-        guard usesMetalLayerSurfaceSetting, metalView?.needsExternalDrawCall == true else {
+        guard activeRenderLoop() == nil,
+              usesMetalLayerSurfaceSetting, metalView?.needsExternalDrawCall == true else {
             return
         }
         let owner = renderOwner
@@ -618,6 +639,11 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// ```
     ///
     /// You can switch back to CoreGraphics at any time by passing `false`.
+    /// Runtime failures automatically rebuild Metal once; a second failure
+    /// within 30 seconds falls back to CoreGraphics. At most two outstanding
+    /// frames may span retired generations. If neither completes, Metal stays
+    /// unavailable until one completes, including across explicit toggles.
+    /// The terminal and its input session are never recreated for recovery.
     ///
     /// - Parameter enabled: Pass `true` to activate Metal rendering, or
     ///   `false` to revert to CoreGraphics.
@@ -641,13 +667,14 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
             if metalView != nil {
                 return
             }
+            guard metalFrameBudget.hasCapacity else { throw MetalError.inFlightLimitReached }
             guard let device = MTLCreateSystemDefaultDevice() else {
                 throw MetalError.deviceUnavailable
             }
             let surface = makeMetalView(frame: bounds, device: device)
-            let renderer = try MetalTerminalRenderer(target: surface)
-            let frameSignal = frameDriver.signal
-            renderer.requestRedraw = { frameSignal.markDirty() }
+            let renderer = try MetalTerminalRenderer(target: surface, frameBudget: metalFrameBudget)
+            metalRendererGeneration &+= 1
+            configureMetalRenderer(renderer)
             renderOwner.installMetalRenderer(
                 renderer,
                 needsExternalDraw: surface.needsExternalDrawCall)
@@ -662,13 +689,17 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
             needsDisplay = false
             surface.requestDisplay()
         } else {
-            stopRenderLoop()
-            guard renderOwner.removeMetalRenderer() else {
-                startRenderLoopIfNeeded()
-                throw MetalError.rendererBusy
-            }
-            detachMetalRendererUI()
+            disableMetalRenderer()
         }
+    }
+
+    private func disableMetalRenderer() {
+        stopRenderLoop()
+        unbindSurface(metalView)
+        metalRendererGeneration &+= 1
+        _ = renderOwner.removeMetalRenderer()
+        detachMetalRendererUI()
+        useMetalRenderer = false
     }
 
     /// Detaches the Metal surface after the render owner has released it.
@@ -724,8 +755,12 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         usesMetalLayerSurfaceSetting = enabled
         // Not running Metal: the choice applies the next time it starts.
         guard useMetalRenderer else { return }
-        try updateMetalRenderer(enabled: false)
-        try updateMetalRenderer(enabled: true)
+        do {
+            try replaceMetalRendererSurface()
+        } catch {
+            disableMetalRenderer()
+            throw error
+        }
     }
 
     private var usesMetalLayerSurfaceSetting =
@@ -813,8 +848,8 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// cursor), with the scroller and the progress bar above it. When there
     /// is no caret view and `replacing` is non-nil, the new view takes the
     /// old one's z-position instead. Actually removing the old view is the
-    /// caller's responsibility — the rebind path defers removal until after
-    /// the new view has drawn its first frame so the hierarchy is never empty.
+    /// caller's responsibility — replacement inserts the new surface first
+    /// so the hierarchy is never empty, even when no drawable is available.
     private func insertMetalView(_ newView: NSView, replacing oldView: NSView?) {
         if let caretView = caretView {
             addSubview(newView, positioned: .below, relativeTo: caretView)
@@ -847,109 +882,92 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     ///
     /// To avoid the visible CoreGraphics-fallback flash that a naive
     /// disable/enable toggle produces, the new view is built and inserted
-    /// before the old one is removed, and we force a synchronous draw plus a
-    /// belt-and-braces `setNeedsDisplay` so the new layer has content the
-    /// moment it is in the hierarchy.
+    /// before the old one is removed. The frame driver then draws the fresh
+    /// surface without waiting for the old generation's GPU work.
     ///
     /// On failure (renderer init throws), we fall back to CoreGraphics
     /// rendering rather than leaving a frozen Metal view in place — a
     /// degraded but responsive terminal beats a dead one.
-    private func rebindMetalRendererToWindow(_ targetWindow: NSWindow) {
-        // Swapping the surface out from under an in-flight frame would have the
-        // render loop present into a layer that is already off screen.
-        withRenderLoopSuspended {
-            rebindMetalRendererToWindowLocked(targetWindow)
-        }
-        // Outside the suspension on purpose: stopping the loop waits on the
-        // same lock, so doing it from the failure path inside would deadlock.
-        if metalView == nil {
-            stopRenderLoop()
+    private func rebindMetalRendererToWindow() {
+        do {
+            try replaceMetalRendererSurface()
+        } catch {
+            finishAutomaticMetalFallback(error as? MetalError ?? .deviceUnavailable)
         }
     }
 
-    private func rebindMetalRendererToWindowLocked(_ targetWindow: NSWindow) {
-        guard useMetalRenderer, let oldView = metalView else { return }
-        // Reuse the old view's MTLDevice when possible so we don't churn
-        // GPUs unnecessarily on multi-GPU or eGPU setups.
-        guard let device = oldView.renderDevice ?? MTLCreateSystemDefaultDevice() else {
-            disableMetalRendererAfterRebindFailure(error: MetalError.deviceUnavailable)
-            return
+    private func configureMetalRenderer(_ renderer: MetalTerminalRenderer) {
+        let generation = metalRendererGeneration
+        let frameSignal = frameDriver.signal
+        renderer.configureRedrawOnMain { [weak self] in
+            guard let self, self.uiShutdownState == .active,
+                  self.useMetalRenderer, self.metalRendererGeneration == generation else { return }
+            frameSignal.markDirty()
         }
+        renderer.health.configure(failure: { [weak self] error in
+            self?.handleMetalFailure(error, generation: generation)
+        }, presentation: { [weak self] in
+            guard let self, self.uiShutdownState == .active,
+                  self.useMetalRenderer, self.metalRendererGeneration == generation else { return }
+            TerminalView.onFramePresented?()
+        })
+    }
 
-        let newView = makeMetalView(frame: oldView.frame, device: device)
-
-        let newRenderer: MetalTerminalRenderer
-        do {
-            newRenderer = try MetalTerminalRenderer(target: newView)
-            let frameSignal = frameDriver.signal
-            newRenderer.requestRedraw = { frameSignal.markDirty() }
-        } catch {
-            disableMetalRendererAfterRebindFailure(error: error)
-            return
-        }
-        guard renderOwner.replaceMetalRenderer(
-            newRenderer,
-            needsExternalDraw: newView.needsExternalDrawCall)
-        else {
-#if canImport(os)
-            os_log("SwiftTerm: kept the current Metal surface because its renderer is busy",
-                   type: .error)
+    private func handleMetalFailure(_ error: MetalError, generation: UInt64) {
+        guard uiShutdownState == .active, useMetalRenderer,
+              generation == metalRendererGeneration else { return }
+#if DEBUG
+        let now = metalRecoveryTestTime ?? ProcessInfo.processInfo.systemUptime
+#else
+        let now = ProcessInfo.processInfo.systemUptime
 #endif
+        if let lastMetalRecovery, now - lastMetalRecovery < 30 {
+            finishAutomaticMetalFallback(error)
             return
         }
+        lastMetalRecovery = now
+        do {
+            try replaceMetalRendererSurface()
+        } catch {
+            finishAutomaticMetalFallback(error as? MetalError ?? .deviceUnavailable)
+        }
+    }
+
+    private func finishAutomaticMetalFallback(_ error: MetalError) {
+        // Nonthrowing CPU retirement cannot leave a frozen Metal surface
+        // active while reporting Core Graphics fallback to the host.
+        disableMetalRenderer()
+        metalRendererFallbackHandler?(error)
+    }
+
+    private func replaceMetalRendererSurface() throws {
+        stopRenderLoop() // drains frameLock, not a GPU semaphore
+        guard useMetalRenderer, let oldView = metalView else { return }
+        guard metalFrameBudget.hasCapacity else { throw MetalError.inFlightLimitReached }
+        guard let device = oldView.renderDevice ?? MTLCreateSystemDefaultDevice() else {
+            throw MetalError.deviceUnavailable
+        }
+        let newView = makeMetalView(frame: oldView.frame, device: device)
+        let newRenderer = try MetalTerminalRenderer(target: newView, frameBudget: metalFrameBudget)
+        unbindSurface(oldView)
+        metalRendererGeneration &+= 1
+        configureMetalRenderer(newRenderer)
+        _ = renderOwner.replaceMetalRenderer(
+            newRenderer, needsExternalDraw: newView.needsExternalDrawCall)
         let newDrawDelegate = bindSurface(newView)
 
-        // Critical sequence: the new layer must have visible content before
-        // the old view is removed. Force a synchronous draw, plus a
-        // `setNeedsDisplay` belt-and-braces in case the synchronous draw bails
-        // out (e.g. the new layer hasn't acquired its first drawable yet).
+        // Keep a surface attached throughout replacement. A missing first
+        // drawable is ordinary backpressure, not another health failure.
         insertMetalView(newView, replacing: oldView)
-        if refreshSnapshotForMetal() {
-            if newView.needsExternalDrawCall {
-                renderOwner.renderMetal()
-            } else if let frame = newView.acquireDrawableFrame() {
-                renderOwner.renderMetal(frame: frame)
-            }
-            renderOwner.discardPreparedMetalSnapshot()
-        }
-        newView.requestDisplay()
-
-        unbindSurface(oldView)
-        oldView.removeFromSuperview()
-
         metalView = newView
         metalDrawDelegate = newDrawDelegate
-        metalBoundWindow = targetWindow
+        metalBoundWindow = window
+        oldView.removeFromSuperview()
+        newView.requestDisplay()
+        frameDriver.markDirty()
+        if window != nil { startRenderLoopIfNeeded() }
     }
 
-    /// Tears down the Metal renderer and reverts to CoreGraphics rendering
-    /// after an unrecoverable rebind failure. Keeps the terminal usable when
-    /// the GPU path can't be restored.
-    private func disableMetalRendererAfterRebindFailure(error: Error) {
-        guard renderOwner.removeMetalRenderer() else {
-#if canImport(os)
-            os_log("SwiftTerm: could not replace or remove the busy Metal renderer: %{public}@",
-                   type: .error, String(describing: error))
-#endif
-            return
-        }
-#if canImport(os)
-        os_log("SwiftTerm: Metal renderer rebind failed; falling back to CoreGraphics: %{public}@",
-               type: .error, String(describing: error))
-#endif
-        unbindSurface(metalView)
-        metalView?.removeFromSuperview()
-        metalView = nil
-        metalDrawDelegate = nil
-        metalBoundWindow = nil
-        useMetalRenderer = false
-        if let caretView = caretView {
-            caretView.isHidden = false
-            caretView.updateCursorStyle()
-        }
-        needsDisplay = true
-        invalidateTerminalContents()
-    }
 #endif
 
     open override func viewDidMoveToWindow() {
@@ -975,7 +993,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
 #if canImport(MetalKit)
         guard useMetalRenderer, let currentWindow = window else { return }
         if currentWindow !== metalBoundWindow {
-            rebindMetalRendererToWindow(currentWindow)
+            rebindMetalRendererToWindow()
         }
         startRenderLoopIfNeeded()
 #endif
@@ -1089,8 +1107,8 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// An owner must call this method when it permanently releases the view.
     /// A temporary `window == nil` transition is not permanent teardown.
     ///
-    /// Returns `false` when committed GPU work is still active. In that case,
-    /// the complete Metal graph stays attached and the owner must retry.
+    /// Committed GPU work retires asynchronously. No GPU wait is needed and
+    /// a stalled command does not prevent permanent UI shutdown.
     @MainActor
     @discardableResult
     public func updateUiClosed() -> Bool {
@@ -1100,9 +1118,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
 #if canImport(MetalKit)
         stopRenderLoop()
         if useMetalRenderer {
-            guard renderOwner.removeMetalRenderer() else { return false }
-            detachMetalRendererUI()
-            useMetalRenderer = false
+            disableMetalRenderer()
         }
 #endif
         stopSelectionAutoScrollTimer()

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -344,6 +344,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private var useMetalRenderer = false
     private let metalFrameBudget = MetalFrameBudget()
     private var metalRendererGeneration: UInt64 = 0
+    private var pendingMetalRebindGeneration: UInt64?
     private var lastMetalRecovery: TimeInterval?
 
     /// Called only after automatic recovery has finally fallen back to Core
@@ -354,6 +355,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
 #if DEBUG
     var metalRecoveryTestTime: TimeInterval?
     var metalGenerationForTesting: UInt64 { metalRendererGeneration }
+    var metalBoundWindowForTesting: NSWindow? { metalBoundWindow }
     var metalOutstandingFramesForTesting: Int { metalFrameBudget.outstandingCount }
 
     func deliverMetalFailureForTesting(_ error: MetalError, generation: UInt64) {
@@ -447,7 +449,8 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     }
 
     func startRenderLoopIfNeeded () {
-        guard activeRenderLoop() == nil,
+        guard activeRenderLoop() == nil, pendingMetalRebindGeneration == nil,
+              metalBoundWindow === window,
               usesMetalLayerSurfaceSetting, metalView?.needsExternalDrawCall == true else {
             return
         }
@@ -673,7 +676,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
             }
             let surface = makeMetalView(frame: bounds, device: device)
             let renderer = try MetalTerminalRenderer(target: surface, frameBudget: metalFrameBudget)
-            metalRendererGeneration &+= 1
+            advanceMetalRendererGeneration()
             configureMetalRenderer(renderer)
             renderOwner.installMetalRenderer(
                 renderer,
@@ -693,11 +696,21 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         }
     }
 
+    private func cancelPendingMetalRebind() {
+        pendingMetalRebindGeneration = nil
+        metalFrameBudget.cancelRetry()
+    }
+
+    private func advanceMetalRendererGeneration() {
+        cancelPendingMetalRebind()
+        metalRendererGeneration &+= 1
+    }
+
     private func disableMetalRenderer() {
         stopRenderLoop()
         unbindSurface(metalView)
-        metalRendererGeneration &+= 1
-        _ = renderOwner.removeMetalRenderer()
+        advanceMetalRendererGeneration()
+        renderOwner.removeMetalRenderer()
         detachMetalRendererUI()
         useMetalRenderer = false
     }
@@ -748,17 +761,23 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// Selects the Metal surface, rebuilding it if Metal is already running.
     ///
     /// Throws for the same reasons ``setUseMetal(_:)`` does — the rebuild can
-    /// fail to create a device, renderer or shader library — in which case the
-    /// view falls back to Core Graphics rather than keeping a dead surface.
+    /// fail to create a device, renderer or shader library. A failed explicit
+    /// change keeps the previous renderer and surface choice intact.
     public func setUsesMetalLayerSurface(_ enabled: Bool) throws {
         guard usesMetalLayerSurfaceSetting != enabled else { return }
+        let previousSetting = usesMetalLayerSurfaceSetting
+        let wasRendering = isUsingRenderLoop
         usesMetalLayerSurfaceSetting = enabled
         // Not running Metal: the choice applies the next time it starts.
         guard useMetalRenderer else { return }
         do {
             try replaceMetalRendererSurface()
         } catch {
-            disableMetalRenderer()
+            usesMetalLayerSurfaceSetting = previousSetting
+            if metalBoundWindow === window, pendingMetalRebindGeneration == nil {
+                renderOwner.setMetalRenderingSuspended(false)
+                if wasRendering { startRenderLoopIfNeeded() }
+            }
             throw error
         }
     }
@@ -883,7 +902,9 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     /// To avoid the visible CoreGraphics-fallback flash that a naive
     /// disable/enable toggle produces, the new view is built and inserted
     /// before the old one is removed. The frame driver then draws the fresh
-    /// surface without waiting for the old generation's GPU work.
+    /// surface without waiting for the old generation's GPU work. At the
+    /// in-flight limit, a completion retries the rebind asynchronously while
+    /// the old surface stays paused; ordinary backpressure is not a failure.
     ///
     /// On failure (renderer init throws), we fall back to CoreGraphics
     /// rendering rather than leaving a frozen Metal view in place — a
@@ -891,6 +912,21 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private func rebindMetalRendererToWindow() {
         do {
             try replaceMetalRendererSurface()
+        } catch MetalError.inFlightLimitReached {
+            // Ordinary reparenting is not a health failure. Keep the current
+            // generation paused until one of its outstanding frames releases.
+            guard pendingMetalRebindGeneration == nil else { return }
+            let generation = metalRendererGeneration
+            pendingMetalRebindGeneration = generation
+            metalFrameBudget.retryWhenAvailable { [weak self] in
+                Task { @MainActor in
+                    guard let self, self.uiShutdownState == .active,
+                          self.useMetalRenderer, self.metalRendererGeneration == generation,
+                          self.pendingMetalRebindGeneration == generation else { return }
+                    self.pendingMetalRebindGeneration = nil
+                    self.rebindMetalRendererToWindow()
+                }
+            }
         } catch {
             finishAutomaticMetalFallback(error as? MetalError ?? .deviceUnavailable)
         }
@@ -899,17 +935,9 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     private func configureMetalRenderer(_ renderer: MetalTerminalRenderer) {
         let generation = metalRendererGeneration
         let frameSignal = frameDriver.signal
-        renderer.configureRedrawOnMain { [weak self] in
-            guard let self, self.uiShutdownState == .active,
-                  self.useMetalRenderer, self.metalRendererGeneration == generation else { return }
-            frameSignal.markDirty()
-        }
+        renderer.requestRedraw = { frameSignal.markDirty() }
         renderer.health.configure(failure: { [weak self] error in
             self?.handleMetalFailure(error, generation: generation)
-        }, presentation: { [weak self] in
-            guard let self, self.uiShutdownState == .active,
-                  self.useMetalRenderer, self.metalRendererGeneration == generation else { return }
-            TerminalView.onFramePresented?()
         })
     }
 
@@ -941,8 +969,9 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
     }
 
     private func replaceMetalRendererSurface() throws {
-        stopRenderLoop() // drains frameLock, not a GPU semaphore
         guard useMetalRenderer, let oldView = metalView else { return }
+        stopRenderLoop() // drains frameLock, not a GPU semaphore
+        renderOwner.setMetalRenderingSuspended(true)
         guard metalFrameBudget.hasCapacity else { throw MetalError.inFlightLimitReached }
         guard let device = oldView.renderDevice ?? MTLCreateSystemDefaultDevice() else {
             throw MetalError.deviceUnavailable
@@ -950,9 +979,9 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         let newView = makeMetalView(frame: oldView.frame, device: device)
         let newRenderer = try MetalTerminalRenderer(target: newView, frameBudget: metalFrameBudget)
         unbindSurface(oldView)
-        metalRendererGeneration &+= 1
+        advanceMetalRendererGeneration()
         configureMetalRenderer(newRenderer)
-        _ = renderOwner.replaceMetalRenderer(
+        renderOwner.replaceMetalRenderer(
             newRenderer, needsExternalDraw: newView.needsExternalDrawCall)
         let newDrawDelegate = bindSurface(newView)
 
@@ -978,6 +1007,7 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         frameDriver.markDirty()
         if window == nil {
 #if canImport(MetalKit)
+            cancelPendingMetalRebind()
             stopRenderLoop()
 #endif
             stopWindowMouseMovedFallback()
@@ -994,6 +1024,9 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         guard useMetalRenderer, let currentWindow = window else { return }
         if currentWindow !== metalBoundWindow {
             rebindMetalRendererToWindow()
+        } else {
+            cancelPendingMetalRebind()
+            renderOwner.setMetalRenderingSuspended(false)
         }
         startRenderLoopIfNeeded()
 #endif

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -247,6 +247,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var metalView: MTKView?
     private var metalDrawDelegate: MetalMainActorDrawDelegate?
     private var useMetalRenderer = false
+    private let metalFrameBudget = MetalFrameBudget()
 
     /// Whether the terminal view is currently using the Metal GPU renderer.
     ///
@@ -481,7 +482,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
                 // Composite through the layer when the background is translucent
                 metalLayer.isOpaque = backgroundOpacity >= 1.0
             }
-            let renderer = try MetalTerminalRenderer(target: mtkView)
+            guard metalFrameBudget.hasCapacity else { throw MetalError.inFlightLimitReached }
+            let renderer = try MetalTerminalRenderer(target: mtkView, frameBudget: metalFrameBudget)
             let frameSignal = frameDriver.signal
             renderer.requestRedraw = { frameSignal.markDirty() }
             renderOwner.installMetalRenderer(renderer, needsExternalDraw: false)
@@ -501,10 +503,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             mtkView.setNeedsDisplay(mtkView.bounds)
         } else {
             precondition(terminal == nil || !terminal.terminalLock.isLockedByCurrentThread,
-                         "Metal teardown cannot wait while the terminal lock is held")
-            guard renderOwner.removeMetalRenderer() else {
-                throw MetalError.rendererBusy
-            }
+                         "Metal teardown cannot enter the render domain under the terminal lock")
+            metalView?.delegate = nil
+            _ = renderOwner.removeMetalRenderer()
             detachMetalRendererUI()
         }
     }
@@ -572,8 +573,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     /// An owner must call this method when it permanently releases the view.
     /// A temporary `window == nil` transition is not permanent teardown.
     ///
-    /// Returns `false` when committed GPU work is still active. In that case,
-    /// the complete Metal graph stays attached and the owner must retry.
+    /// Committed GPU work retires asynchronously; a stalled command does not
+    /// prevent permanent UI shutdown.
     @MainActor
     @discardableResult
     public func updateUiClosed() -> Bool {
@@ -582,7 +583,8 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         frameDriver.shutdown()
 #if canImport(MetalKit)
         if useMetalRenderer {
-            guard renderOwner.removeMetalRenderer() else { return false }
+            metalView?.delegate = nil
+            _ = renderOwner.removeMetalRenderer()
             detachMetalRendererUI()
             useMetalRenderer = false
         }

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -505,7 +505,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             precondition(terminal == nil || !terminal.terminalLock.isLockedByCurrentThread,
                          "Metal teardown cannot enter the render domain under the terminal lock")
             metalView?.delegate = nil
-            _ = renderOwner.removeMetalRenderer()
+            renderOwner.removeMetalRenderer()
             detachMetalRendererUI()
         }
     }
@@ -584,7 +584,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 #if canImport(MetalKit)
         if useMetalRenderer {
             metalView?.delegate = nil
-            _ = renderOwner.removeMetalRenderer()
+            renderOwner.removeMetalRenderer()
             detachMetalRendererUI()
             useMetalRenderer = false
         }

--- a/Tests/SwiftTermTests/MetalRecoveryTests.swift
+++ b/Tests/SwiftTermTests/MetalRecoveryTests.swift
@@ -5,14 +5,11 @@ import QuartzCore
 import Testing
 @testable import SwiftTerm
 
-// Opt in with SWIFTTERM_TEST_METAL_RECOVERY=1 on a Metal host. SwiftPM's
-// XCTest host needs Shaders.metal staged from SwiftTerm_SwiftTerm.bundle into
-// SwiftTermPackageTests.xctest/Contents/Resources. Once enabled, missing
-// shaders, failed device creation, or missing drawables FAIL these tests.
+// Gate only hardware availability: missing shaders, renderer initialization
+// failures, or missing drawables must fail rather than silently skip coverage.
 @MainActor
 @Suite("Metal recovery", .serialized,
-       .enabled(if: ProcessInfo.processInfo.environment["SWIFTTERM_TEST_METAL_RECOVERY"] == "1"
-                && MTLCreateSystemDefaultDevice() != nil))
+       .enabled(if: MTLCreateSystemDefaultDevice() != nil))
 struct MetalRecoveryTests {
     private func makeView(size: CGSize = CGSize(width: 320, height: 120)) throws -> TerminalView {
         let view = TerminalView(frame: CGRect(origin: .zero, size: size), font: nil,

--- a/Tests/SwiftTermTests/MetalRecoveryTests.swift
+++ b/Tests/SwiftTermTests/MetalRecoveryTests.swift
@@ -29,12 +29,12 @@ struct MetalRecoveryTests {
         try #require(condition())
     }
 
-    private func heldSubmission(_ view: TerminalView) async throws -> MetalCompletionGate {
+    private func heldSubmission(_ view: TerminalView, simulateHang: Bool = true) async throws -> MetalCompletionGate {
         view.stopRenderLoop()
         let gate = MetalCompletionGate()
         let health = try #require(view.renderOwner.metalHealthForTesting())
         view.renderOwner.configureMetalFaultForTesting(completionGate: gate)
-        health.simulateCommandStatus(.committed)
+        if simulateHang { health.simulateCommandStatus(.committed) }
         view.drawMetalFrameNow()
         do {
             try await eventually { gate.isHoldingCompletion }
@@ -64,6 +64,98 @@ struct MetalRecoveryTests {
                   selectedText: view.selection.getSelectedText(),
                   searchResult: view.search.lastResult)
         }
+    }
+
+    nonisolated private static func waitForCompletion(_ gate: MetalCompletionGate) -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + 2
+        while !gate.isHoldingCompletion, ProcessInfo.processInfo.systemUptime < deadline {
+            Thread.sleep(forTimeInterval: 0.001)
+        }
+        return gate.isHoldingCompletion
+    }
+
+    private func releaseOffMain(_ gate: MetalCompletionGate) throws {
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            gate.release()
+            done.signal()
+        }
+        try #require(done.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test(arguments: [true, false])
+    func healthyCompletionAndRedrawDoNotWaitForMain(observePresentation: Bool) throws {
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        try view.setUseMetal(false)
+        let target = TerminalMetalLayerView(frame: CGRect(x: 0, y: 0, width: 80, height: 40))
+        let renderer = try MetalTerminalRenderer(target: target)
+        let redraws = Locked(0)
+        let presentations = Locked(0)
+        let callbacksOnMain = Locked(0)
+        renderer.requestRedraw = {
+            redraws.withLock { $0 += 1 }
+            if Thread.isMainThread { callbacksOnMain.withLock { $0 += 1 } }
+        }
+        let previous = TerminalView.onFramePresented
+        if observePresentation {
+            TerminalView.onFramePresented = {
+                presentations.withLock { $0 += 1 }
+                if Thread.isMainThread { callbacksOnMain.withLock { $0 += 1 } }
+            }
+        } else {
+            TerminalView.onFramePresented = nil
+        }
+        defer { TerminalView.onFramePresented = previous }
+        let owner = view.renderOwner
+        owner.installMetalRenderer(renderer, needsExternalDraw: true)
+        defer { owner.removeMetalRenderer() }
+        let viewState = try #require(view.captureFrameViewState())
+        let gates = [MetalCompletionGate(), MetalCompletionGate()]
+        defer { gates.forEach { $0.release() } }
+        let failures = Locked<[String]>([])
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            defer { done.signal() }
+            for gate in gates {
+                owner.configureMetalFaultForTesting(completionGate: gate)
+                guard owner.refreshMetalSnapshot(viewState: viewState) else {
+                    failures.withLock { $0.append("Snapshot preparation failed") }
+                    return
+                }
+                owner.renderMetal()
+                guard Self.waitForCompletion(gate) else {
+                    failures.withLock { $0.append("GPU notification did not arrive") }
+                    return
+                }
+                // The refused permit records a pending redraw before releasing
+                // the real, already-finished GPU command's notification.
+                _ = owner.refreshMetalSnapshot(viewState: viewState)
+                owner.renderMetal()
+                gate.release()
+            }
+        }
+        // Intentionally block only the TEST main actor, never the GPU. Both
+        // frames' callbacks must have run before this wait lets main proceed.
+        try #require(done.wait(timeout: .now() + 6) == .success)
+        #expect(failures.withLock { $0 }.isEmpty)
+        #expect(redraws.withLock { $0 } == 2)
+        #expect(presentations.withLock { $0 } == (observePresentation ? 2 : 0))
+        #expect(callbacksOnMain.withLock { $0 } == 0)
+        #expect(owner.completedMetalRenders == 2)
+
+        let late = MetalCompletionGate()
+        defer { late.release() }
+        owner.configureMetalFaultForTesting(completionGate: late)
+        #expect(owner.refreshMetalSnapshot(viewState: viewState))
+        owner.renderMetal()
+        try #require(Self.waitForCompletion(late))
+        _ = owner.refreshMetalSnapshot(viewState: viewState)
+        owner.renderMetal()
+        owner.removeMetalRenderer()
+        try releaseOffMain(late)
+        #expect(redraws.withLock { $0 } == 2)
+        #expect(presentations.withLock { $0 } == (observePresentation ? 2 : 0))
     }
 
     @Test func firstFailureReplacesSecondFallsBackWithoutLosingModelOrInput() async throws {
@@ -263,6 +355,119 @@ struct MetalRecoveryTests {
         #expect(ProcessInfo.processInfo.systemUptime - started < 2)
     }
 
+    @Test func healthyCapacityDefersWindowRebindWithoutFallbackOrOldSurfaceDraws() async throws {
+        let view = try makeView()
+        let windows = (0..<3).map { _ in
+            let window = NSWindow(contentRect: view.frame, styleMask: .borderless,
+                                  backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            return window
+        }
+        let input = RecoveryInputDelegate()
+        view.terminalDelegate = input
+        defer {
+            view.metalRendererFallbackHandler = nil
+            view.updateUiClosed()
+            for window in windows { window.contentView = nil; window.close() }
+        }
+        windows[0].contentView = view
+        view.feed(text: (0..<40).map { "line \($0)\r\n" }.joined())
+        #expect(view.findNext("line 12", scrollToResult: false))
+        let before = model(view)
+        var fallbacks = 0
+        view.metalRendererFallbackHandler = { _ in fallbacks += 1 }
+        let first = try await heldSubmission(view, simulateHang: false)
+        defer { first.release() }
+        windows[1].contentView = view
+        #expect(view.metalBoundWindowForTesting === windows[1])
+        let second = try await heldSubmission(view, simulateHang: false)
+        defer { second.release() }
+        #expect(view.metalOutstandingFramesForTesting == 2)
+        let generation = view.metalGenerationForTesting
+        let surface = try #require(view.metalView)
+        windows[2].contentView = view
+        #expect(view.window === windows[2])
+        #expect(view.metalBoundWindowForTesting === windows[1])
+        #expect(view.metalView === surface)
+        #expect(view.metalGenerationForTesting == generation)
+        #expect(view.isUsingMetalRenderer)
+        #expect(!view.isUsingRenderLoop)
+        #expect(fallbacks == 0)
+
+        // Free the CURRENT renderer's permit, not just a retired one's. Until
+        // main runs the queued rebind, no entry point may spend that capacity
+        // submitting into the surface still bound to the previous window.
+        try releaseOffMain(second)
+        view.startRenderLoopIfNeeded()
+        view.drawMetalFrameNow()
+        #expect(!view.isUsingRenderLoop)
+        #expect(view.renderOwner.completedMetalRenders == 1)
+        #expect(view.metalOutstandingFramesForTesting == 1)
+        #expect(view.metalGenerationForTesting == generation)
+        try await eventually { view.metalGenerationForTesting != generation }
+        #expect(view.metalGenerationForTesting == generation + 1)
+        #expect(view.metalBoundWindowForTesting === windows[2])
+        #expect(view.metalView !== surface)
+        #expect(surface.superview == nil)
+        #expect(model(view) == before)
+        #expect(fallbacks == 0)
+        view.send(txt: "after rebind")
+        try await eventually { String(decoding: input.bytes, as: UTF8.self) == "after rebind" }
+    }
+
+    @Test(arguments: [false, true])
+    func pendingCapacityRetryIsInvalidatedByGenerationOrShutdown(shutdown: Bool) async throws {
+        let view = try makeView()
+        defer { view.metalRendererFallbackHandler = nil; view.updateUiClosed() }
+        var fallbacks = 0
+        view.metalRendererFallbackHandler = { _ in fallbacks += 1 }
+        let first = try await heldSubmission(view, simulateHang: false)
+        defer { first.release() }
+        view.rebindMetalForTesting()
+        let second = try await heldSubmission(view, simulateHang: false)
+        defer { second.release() }
+        view.rebindMetalForTesting()
+        view.rebindMetalForTesting() // still only one pending structural retry
+        let oldGeneration = view.metalGenerationForTesting
+        try releaseOffMain(second) // retry is queued, but cannot run on main yet
+        if shutdown {
+            view.updateUiClosed()
+        } else {
+            try view.setUseMetal(false)
+            try view.setUseMetal(true)
+        }
+        let newGeneration = view.metalGenerationForTesting
+        #expect(newGeneration != oldGeneration)
+        try await Task.sleep(nanoseconds: 40_000_000)
+        #expect(view.metalGenerationForTesting == newGeneration)
+        #expect(view.isUsingMetalRenderer == !shutdown)
+        #expect(fallbacks == 0)
+    }
+
+    @Test func failedExplicitSurfaceChangePreservesTheValidOldRenderLoop() async throws {
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        let first = try await heldSubmission(view, simulateHang: false)
+        defer { first.release() }
+        view.rebindMetalForTesting()
+        let second = try await heldSubmission(view, simulateHang: false)
+        defer { second.release() }
+        let surface = try #require(view.metalView)
+        let generation = view.metalGenerationForTesting
+        view.startRenderLoopIfNeeded()
+        #expect(view.isUsingRenderLoop)
+        #expect(throws: MetalError.self) { try view.setUsesMetalLayerSurface(false) }
+        #expect(view.isUsingMetalRenderer)
+        #expect(view.usesMetalLayerSurface)
+        #expect(view.isUsingRenderLoop)
+        #expect(view.metalView === surface)
+        #expect(view.metalGenerationForTesting == generation)
+        second.release()
+        view.drawMetalFrameNow()
+        #expect(view.renderOwner.completedMetalRenders == 2)
+        try await eventually { view.metalOutstandingFramesForTesting == 1 }
+    }
+
     @Test func retirementQuiescesCPUWithoutWaitingForHeldGPUCompletion() async throws {
         let view = try makeView()
         defer { view.updateUiClosed() }
@@ -325,7 +530,8 @@ struct MetalRecoveryTests {
         try await eventually { gate.isHoldingCompletion }
         #expect(renderer?.waitForIdle(timeout: 0) == false)
         renderer = nil
-        #expect(view.renderOwner.removeMetalRenderer())
+        view.renderOwner.removeMetalRenderer()
+        #expect(!view.renderOwner.hasMetalRenderer)
         #expect(weakRenderer == nil)
         #expect(budget.outstandingCount == 1)
         gate.release()

--- a/Tests/SwiftTermTests/MetalRecoveryTests.swift
+++ b/Tests/SwiftTermTests/MetalRecoveryTests.swift
@@ -11,10 +11,10 @@ import Testing
 @Suite("Metal recovery", .serialized,
        .enabled(if: MTLCreateSystemDefaultDevice() != nil))
 struct MetalRecoveryTests {
-    private func makeView(size: CGSize = CGSize(width: 320, height: 120)) throws -> TerminalView {
+    private func makeView(size: CGSize = CGSize(width: 320, height: 120), usesLayer: Bool = true) throws -> TerminalView {
         let view = TerminalView(frame: CGRect(origin: .zero, size: size), font: nil,
                                 options: TerminalOptions(cols: 30, rows: 6, scrollback: 100))
-        view.usesMetalLayerSurface = true
+        view.usesMetalLayerSurface = usesLayer
         try view.setUseMetal(true)
         view.stopRenderLoop()
         return view
@@ -35,9 +35,14 @@ struct MetalRecoveryTests {
         let health = try #require(view.renderOwner.metalHealthForTesting())
         view.renderOwner.configureMetalFaultForTesting(completionGate: gate)
         if simulateHang { health.simulateCommandStatus(.committed) }
-        view.drawMetalFrameNow()
         do {
-            try await eventually { gate.isHoldingCompletion }
+            // Replacement may already have submitted its first healthy frame.
+            // Retry a refused permit without waiting on GPU execution.
+            try await eventually {
+                if gate.isHoldingCompletion { return true }
+                view.drawMetalFrameNow()
+                return gate.isHoldingCompletion
+            }
             return gate
         } catch {
             gate.release()
@@ -158,6 +163,24 @@ struct MetalRecoveryTests {
         #expect(presentations.withLock { $0 } == (observePresentation ? 2 : 0))
     }
 
+    @Test(arguments: [true, false])
+    func replacementSubmitsBeforeRemovingItsOldSurface(usesLayer: Bool) async throws {
+        let view = try makeView(usesLayer: usesLayer)
+        defer { view.updateUiClosed() }
+        let gate = try await heldSubmission(view, simulateHang: false)
+        defer { gate.release() }
+        let oldSurface = try #require(view.metalView)
+        let start = ProcessInfo.processInfo.systemUptime
+        view.rebindMetalForTesting()
+        let observation = try #require(view.metalReplacementBeforeRemovalForTesting)
+        #expect(observation.submittedFrames > 0)
+        #expect(observation.oldSurfaceAttached)
+        #expect(view.metalView !== oldSurface)
+        #expect(oldSurface.superview == nil)
+        #expect(gate.isHoldingCompletion)
+        #expect(ProcessInfo.processInfo.systemUptime - start < 2)
+    }
+
     @Test func firstFailureReplacesSecondFallsBackWithoutLosingModelOrInput() async throws {
         let view = try makeView()
         let input = RecoveryInputDelegate()
@@ -195,8 +218,10 @@ struct MetalRecoveryTests {
 
         view.stopRenderLoop()
         view.renderOwner.configureMetalFaultForTesting(creationFailure: .renderEncoderUnavailable)
-        view.drawMetalFrameNow()
-        try await eventually { fallbacks == 1 }
+        try await eventually {
+            if fallbacks == 0 { view.drawMetalFrameNow() }
+            return fallbacks == 1
+        }
         #expect(model(view) == before)
         try await eventually { String(decoding: input.bytes, as: UTF8.self) == "after" }
         view.feed(text: "\r\ncontinued")
@@ -212,27 +237,29 @@ struct MetalRecoveryTests {
         defer { gate.release() }
         #expect(view.metalOutstandingFramesForTesting == 1)
 
+        let presentations = Locked(0)
+        let previous = TerminalView.onFramePresented
+        TerminalView.onFramePresented = { presentations.withLock { $0 += 1 } }
+        defer { TerminalView.onFramePresented = previous }
+
         oldHealth.checkForTimeout(now: .greatestFiniteMagnitude)
         try await eventually { view.metalGenerationForTesting != oldGeneration }
         view.stopRenderLoop()
         let replacement = try #require(view.metalView)
         let replacementHealth = try #require(view.renderOwner.metalHealthForTesting())
         let generation = view.metalGenerationForTesting
-        let presentations = Locked(0)
-        let previous = TerminalView.onFramePresented
-        TerminalView.onFramePresented = { presentations.withLock { $0 += 1 } }
-        defer { TerminalView.onFramePresented = previous }
+        try await eventually { presentations.withLock { $0 } == 1 }
 
         gate.release()
         oldHealth.fail(.commandFailed("late old error"))
         view.deliverMetalFailureForTesting(.commandTimedOut, generation: oldGeneration)
         try await Task.sleep(nanoseconds: 40_000_000)
         #expect(view.metalOutstandingFramesForTesting == 0)
-        #expect(presentations.withLock { $0 } == 0)
+        #expect(presentations.withLock { $0 } == 1)
         #expect(view.metalGenerationForTesting == generation)
         #expect(view.metalView === replacement)
         #expect(replacementHealth.canRender)
-        #expect(view.renderOwner.completedMetalRenders == 0)
+        #expect(view.renderOwner.completedMetalRenders == 1)
     }
 
     @Test func hungFramesStayBoundedAcrossTimeWindowsAndExplicitReenable() async throws {
@@ -287,7 +314,7 @@ struct MetalRecoveryTests {
         first.release(error: .commandFailed("controlled completion error"))
         try await eventually { view.metalGenerationForTesting != generation }
         #expect(view.isUsingMetalRenderer)
-        #expect(view.metalOutstandingFramesForTesting == 0)
+        try await eventually { view.metalOutstandingFramesForTesting == 0 }
 
         let second = try await heldSubmission(view)
         defer { second.release() }
@@ -311,6 +338,12 @@ struct MetalRecoveryTests {
         #expect(empty.renderOwner.completedMetalRenders == 0)
         #expect(emptyHealth.canRender)
         #expect(empty.metalGenerationForTesting == generation)
+        empty.rebindMetalForTesting()
+        let emptyReplacement = try #require(empty.metalReplacementBeforeRemovalForTesting)
+        #expect(emptyReplacement.submittedFrames == 0)
+        #expect(emptyReplacement.oldSurfaceAttached)
+        #expect(empty.isUsingMetalRenderer)
+        #expect(empty.renderOwner.metalHealthForTesting()?.canRender == true)
 
         let view = try makeView()
         defer { view.updateUiClosed() }
@@ -351,8 +384,8 @@ struct MetalRecoveryTests {
         #expect(!view.isUsingMetalRenderer)
         #expect(!view.isUsingRenderLoop)
         #expect(view.metalView == nil)
-        #expect(view.metalOutstandingFramesForTesting == 1)
         #expect(ProcessInfo.processInfo.systemUptime - started < 2)
+        try await eventually { view.metalOutstandingFramesForTesting == 1 }
     }
 
     @Test func healthyCapacityDefersWindowRebindWithoutFallbackOrOldSurfaceDraws() async throws {
@@ -384,6 +417,7 @@ struct MetalRecoveryTests {
         defer { second.release() }
         #expect(view.metalOutstandingFramesForTesting == 2)
         let generation = view.metalGenerationForTesting
+        let submittedBeforeRebind = view.renderOwner.completedMetalRenders
         let surface = try #require(view.metalView)
         windows[2].contentView = view
         #expect(view.window === windows[2])
@@ -401,7 +435,7 @@ struct MetalRecoveryTests {
         view.startRenderLoopIfNeeded()
         view.drawMetalFrameNow()
         #expect(!view.isUsingRenderLoop)
-        #expect(view.renderOwner.completedMetalRenders == 1)
+        #expect(view.renderOwner.completedMetalRenders == submittedBeforeRebind)
         #expect(view.metalOutstandingFramesForTesting == 1)
         #expect(view.metalGenerationForTesting == generation)
         try await eventually { view.metalGenerationForTesting != generation }
@@ -454,6 +488,7 @@ struct MetalRecoveryTests {
         defer { second.release() }
         let surface = try #require(view.metalView)
         let generation = view.metalGenerationForTesting
+        let submittedBeforeChange = view.renderOwner.completedMetalRenders
         view.startRenderLoopIfNeeded()
         #expect(view.isUsingRenderLoop)
         #expect(throws: MetalError.self) { try view.setUsesMetalLayerSurface(false) }
@@ -464,7 +499,7 @@ struct MetalRecoveryTests {
         #expect(view.metalGenerationForTesting == generation)
         second.release()
         view.drawMetalFrameNow()
-        #expect(view.renderOwner.completedMetalRenders == 2)
+        #expect(view.renderOwner.completedMetalRenders == submittedBeforeChange + 1)
         try await eventually { view.metalOutstandingFramesForTesting == 1 }
     }
 

--- a/Tests/SwiftTermTests/MetalRecoveryTests.swift
+++ b/Tests/SwiftTermTests/MetalRecoveryTests.swift
@@ -1,0 +1,388 @@
+#if os(macOS) && canImport(MetalKit) && DEBUG
+import AppKit
+import MetalKit
+import QuartzCore
+import Testing
+@testable import SwiftTerm
+
+// Opt in with SWIFTTERM_TEST_METAL_RECOVERY=1 on a Metal host. SwiftPM's
+// XCTest host needs Shaders.metal staged from SwiftTerm_SwiftTerm.bundle into
+// SwiftTermPackageTests.xctest/Contents/Resources. Once enabled, missing
+// shaders, failed device creation, or missing drawables FAIL these tests.
+@MainActor
+@Suite("Metal recovery", .serialized,
+       .enabled(if: ProcessInfo.processInfo.environment["SWIFTTERM_TEST_METAL_RECOVERY"] == "1"
+                && MTLCreateSystemDefaultDevice() != nil))
+struct MetalRecoveryTests {
+    private func makeView(size: CGSize = CGSize(width: 320, height: 120)) throws -> TerminalView {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: size), font: nil,
+                                options: TerminalOptions(cols: 30, rows: 6, scrollback: 100))
+        view.usesMetalLayerSurface = true
+        try view.setUseMetal(true)
+        view.stopRenderLoop()
+        return view
+    }
+
+    private func eventually(timeout: TimeInterval = 2, _ condition: @MainActor () -> Bool) async throws {
+        let deadline = ProcessInfo.processInfo.systemUptime + timeout
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try #require(condition())
+    }
+
+    private func heldSubmission(_ view: TerminalView) async throws -> MetalCompletionGate {
+        view.stopRenderLoop()
+        let gate = MetalCompletionGate()
+        let health = try #require(view.renderOwner.metalHealthForTesting())
+        view.renderOwner.configureMetalFaultForTesting(completionGate: gate)
+        health.simulateCommandStatus(.committed)
+        view.drawMetalFrameNow()
+        do {
+            try await eventually { gate.isHoldingCompletion }
+            return gate
+        } catch {
+            gate.release()
+            throw error
+        }
+    }
+
+    private struct Model: Equatable {
+        let terminal: ObjectIdentifier
+        let selection: ObjectIdentifier
+        let search: ObjectIdentifier
+        let contents: Data
+        let scrollback: Int
+        let selectedText: String
+        let searchResult: SearchResult?
+    }
+
+    private func model(_ view: TerminalView) -> Model {
+        view.withTerminal { terminal in
+            Model(terminal: ObjectIdentifier(terminal),
+                  selection: ObjectIdentifier(view.selection),
+                  search: ObjectIdentifier(view.search),
+                  contents: terminal.getBufferAsData(), scrollback: terminal.buffer.yBase,
+                  selectedText: view.selection.getSelectedText(),
+                  searchResult: view.search.lastResult)
+        }
+    }
+
+    @Test func firstFailureReplacesSecondFallsBackWithoutLosingModelOrInput() async throws {
+        let view = try makeView()
+        let input = RecoveryInputDelegate()
+        view.terminalDelegate = input
+        defer { view.metalRendererFallbackHandler = nil; view.updateUiClosed() }
+        view.feed(text: (0..<40).map { "line \($0)\r\n" }.joined())
+        #expect(view.findNext("line 12", scrollToResult: false))
+        let before = model(view)
+        #expect(before.scrollback > 0)
+        #expect(before.selectedText == "line 12")
+        let firstSurface = try #require(view.metalView)
+        let generation = view.metalGenerationForTesting
+        var fallbacks = 0
+        view.metalRendererFallbackHandler = { error in
+            // Re-entering value/input APIs here would deadlock if delivery
+            // still held the renderer or owner lock.
+            #expect(!view.isUsingMetalRenderer)
+            #expect(view.metalView == nil)
+            #expect(!view.renderOwner.hasMetalRenderer)
+            #expect(model(view) == before)
+            #expect(error.description.contains("encoder"))
+            view.send(txt: "after")
+            fallbacks += 1
+        }
+        #expect(view.metalRendererFallbackHandler != nil)
+        view.renderOwner.configureMetalFaultForTesting(creationFailure: .commandBufferUnavailable)
+        view.drawMetalFrameNow()
+        try await eventually { view.metalGenerationForTesting != generation }
+        #expect(view.isUsingMetalRenderer)
+        #expect(fallbacks == 0)
+        #expect(view.metalView !== firstSurface)
+        #expect(firstSurface.superview == nil)
+        #expect((firstSurface as? TerminalMetalLayerView)?.onNeedsDisplay == nil)
+        #expect(model(view) == before)
+
+        view.stopRenderLoop()
+        view.renderOwner.configureMetalFaultForTesting(creationFailure: .renderEncoderUnavailable)
+        view.drawMetalFrameNow()
+        try await eventually { fallbacks == 1 }
+        #expect(model(view) == before)
+        try await eventually { String(decoding: input.bytes, as: UTF8.self) == "after" }
+        view.feed(text: "\r\ncontinued")
+        #expect(view.getBufferAsData().count >= before.contents.count)
+    }
+
+    @Test func lateCompletionAndStaleFailureCannotTouchReplacement() async throws {
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        let oldGeneration = view.metalGenerationForTesting
+        let oldHealth = try #require(view.renderOwner.metalHealthForTesting())
+        let gate = try await heldSubmission(view)
+        defer { gate.release() }
+        #expect(view.metalOutstandingFramesForTesting == 1)
+
+        oldHealth.checkForTimeout(now: .greatestFiniteMagnitude)
+        try await eventually { view.metalGenerationForTesting != oldGeneration }
+        view.stopRenderLoop()
+        let replacement = try #require(view.metalView)
+        let replacementHealth = try #require(view.renderOwner.metalHealthForTesting())
+        let generation = view.metalGenerationForTesting
+        let presentations = Locked(0)
+        let previous = TerminalView.onFramePresented
+        TerminalView.onFramePresented = { presentations.withLock { $0 += 1 } }
+        defer { TerminalView.onFramePresented = previous }
+
+        gate.release()
+        oldHealth.fail(.commandFailed("late old error"))
+        view.deliverMetalFailureForTesting(.commandTimedOut, generation: oldGeneration)
+        try await Task.sleep(nanoseconds: 40_000_000)
+        #expect(view.metalOutstandingFramesForTesting == 0)
+        #expect(presentations.withLock { $0 } == 0)
+        #expect(view.metalGenerationForTesting == generation)
+        #expect(view.metalView === replacement)
+        #expect(replacementHealth.canRender)
+        #expect(view.renderOwner.completedMetalRenders == 0)
+    }
+
+    @Test func hungFramesStayBoundedAcrossTimeWindowsAndExplicitReenable() async throws {
+        let view = try makeView()
+        defer { view.metalRendererFallbackHandler = nil; view.updateUiClosed() }
+        var fallbacks = 0
+        view.metalRendererFallbackHandler = { _ in fallbacks += 1 }
+        view.metalRecoveryTestTime = 100
+        let first = try await heldSubmission(view)
+        defer { first.release() }
+        let firstHealth = try #require(view.renderOwner.metalHealthForTesting())
+        firstHealth.checkForTimeout(now: .greatestFiniteMagnitude)
+        try await eventually { view.renderOwner.metalHealthForTesting() !== firstHealth }
+        #expect(view.isUsingMetalRenderer)
+
+        // Even outside the retry window, two permanently outstanding frames
+        // must never permit a third retained generation.
+        view.metalRecoveryTestTime = 131
+        let second = try await heldSubmission(view)
+        defer { second.release() }
+        let secondHealth = try #require(view.renderOwner.metalHealthForTesting())
+        secondHealth.checkForTimeout(now: .greatestFiniteMagnitude)
+        try await eventually { fallbacks == 1 }
+        #expect(view.metalOutstandingFramesForTesting == 2)
+        for _ in 0..<4 {
+            #expect(throws: MetalError.self) { try view.setUseMetal(true) }
+            #expect(!view.isUsingMetalRenderer)
+            #expect(view.metalView == nil)
+        }
+        #expect(view.metalOutstandingFramesForTesting == 2)
+        first.release()
+        try view.setUseMetal(true)
+        #expect(view.isUsingMetalRenderer)
+        #expect(view.metalOutstandingFramesForTesting == 1)
+        second.release()
+        #expect(view.metalOutstandingFramesForTesting == 0)
+        #expect(fallbacks == 1)
+    }
+
+    @Test func commandCompletionErrorRecoversAndRealWatchdogFallsBackOnce() async throws {
+        let view = try makeView()
+        defer { view.metalRendererFallbackHandler = nil; view.updateUiClosed() }
+        var fallbacks = 0
+        view.metalRendererFallbackHandler = { error in
+            #expect(!view.isUsingMetalRenderer)
+            #expect(error.description.contains("five seconds"))
+            fallbacks += 1
+        }
+        let generation = view.metalGenerationForTesting
+        let first = try await heldSubmission(view)
+        defer { first.release() }
+        first.release(error: .commandFailed("controlled completion error"))
+        try await eventually { view.metalGenerationForTesting != generation }
+        #expect(view.isUsingMetalRenderer)
+        #expect(view.metalOutstandingFramesForTesting == 0)
+
+        let second = try await heldSubmission(view)
+        defer { second.release() }
+        // Use the real dispatch timer, without polling the renderer or ever
+        // holding GPU execution. Only the completion notification is withheld.
+        try await eventually(timeout: MetalRendererHealth.timeout + 2) { fallbacks == 1 }
+        #expect(view.metalOutstandingFramesForTesting == 1)
+        second.release(error: .commandFailed("late completion"))
+        try await Task.sleep(nanoseconds: 40_000_000)
+        #expect(fallbacks == 1)
+        #expect(view.metalOutstandingFramesForTesting == 0)
+    }
+
+    @Test func missingDrawableAndPermitRefusalAreNotHealthFailures() async throws {
+        let empty = try makeView(size: .zero)
+        defer { empty.updateUiClosed() }
+        let emptyHealth = try #require(empty.renderOwner.metalHealthForTesting())
+        let generation = empty.metalGenerationForTesting
+        empty.drawMetalFrameNow()
+        emptyHealth.checkForTimeout(now: .greatestFiniteMagnitude)
+        #expect(empty.renderOwner.completedMetalRenders == 0)
+        #expect(emptyHealth.canRender)
+        #expect(empty.metalGenerationForTesting == generation)
+
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        let gate = try await heldSubmission(view)
+        defer { gate.release() }
+        let health = try #require(view.renderOwner.metalHealthForTesting())
+        for _ in 0..<5 { view.drawMetalFrameNow() }
+        #expect(health.canRender)
+        #expect(view.renderOwner.completedMetalRenders == 1)
+        #expect(view.metalOutstandingFramesForTesting == 1)
+        // A terminal command whose notification is merely delayed is not a
+        // hung GPU. Only a nonterminal status is eligible for the watchdog.
+        health.simulateCommandStatus(.completed)
+        health.checkForTimeout(now: .greatestFiniteMagnitude)
+        #expect(health.canRender)
+    }
+
+    @Test func parkingRebindingAndShutdownNeverWaitForGPU() async throws {
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        let before = model(view)
+        let oldSurface = try #require(view.metalView)
+        let gate = try await heldSubmission(view)
+        defer { gate.release() }
+        let started = ProcessInfo.processInfo.systemUptime
+        view.startRenderLoopIfNeeded()
+        view.viewDidMoveToWindow() // nil window: a parked, still-live terminal
+        #expect(!view.isUsingRenderLoop)
+        #expect(view.isUsingMetalRenderer)
+        #expect(view.metalView === oldSurface)
+        view.rebindMetalForTesting()
+        #expect(view.isUsingMetalRenderer)
+        #expect(view.metalView !== oldSurface)
+        #expect(oldSurface.superview == nil)
+        #expect(model(view) == before)
+        #expect(view.updateUiClosed())
+        #expect(view.updateUiClosed())
+        #expect(!view.isUsingMetalRenderer)
+        #expect(!view.isUsingRenderLoop)
+        #expect(view.metalView == nil)
+        #expect(view.metalOutstandingFramesForTesting == 1)
+        #expect(ProcessInfo.processInfo.systemUptime - started < 2)
+    }
+
+    @Test func retirementQuiescesCPUWithoutWaitingForHeldGPUCompletion() async throws {
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        let gate = try await heldSubmission(view)
+        defer { gate.release() }
+        try assertCPUDrain(view)
+    }
+
+    private func assertCPUDrain(_ view: TerminalView) throws {
+        view.startRenderLoopIfNeeded()
+        let loop = try #require(view.renderLoop)
+        let entered = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            loop.frameLock.lock()
+            entered.signal()
+            Thread.sleep(forTimeInterval: 0.1)
+            loop.frameLock.unlock()
+        }
+        try #require(entered.wait(timeout: .now() + 2) == .success)
+        let start = ProcessInfo.processInfo.systemUptime
+        try view.setUseMetal(false)
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+        #expect(elapsed >= 0.08 && elapsed < 2)
+        #expect(!loop.isRunning)
+        #expect(view.metalOutstandingFramesForTesting == 1)
+    }
+
+    @Test func queuedFailureIsInvalidatedByExplicitDisableAndShutdown() async throws {
+        let view = try makeView()
+        defer { view.metalRendererFallbackHandler = nil; view.updateUiClosed() }
+        var fallbacks = 0
+        view.metalRendererFallbackHandler = { _ in fallbacks += 1 }
+        let health = try #require(view.renderOwner.metalHealthForTesting())
+        health.fail(.commandFailed("queued before disable"))
+        try view.setUseMetal(false)
+        try view.setUseMetal(true)
+        let current = try #require(view.renderOwner.metalHealthForTesting())
+        current.fail(.commandFailed("queued before shutdown"))
+        view.updateUiClosed()
+        try await Task.sleep(nanoseconds: 40_000_000)
+        #expect(fallbacks == 0)
+        #expect(!view.isUsingMetalRenderer)
+    }
+
+    @Test func retirementReleasesRendererWithoutReleasingSubmittedPermit() async throws {
+        let view = try makeView()
+        defer { view.updateUiClosed() }
+        try view.setUseMetal(false)
+        let target = TerminalMetalLayerView(frame: CGRect(x: 0, y: 0, width: 80, height: 40))
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        target.renderDevice = device
+        let budget = MetalFrameBudget()
+        var renderer: MetalTerminalRenderer? = try MetalTerminalRenderer(target: target, frameBudget: budget)
+        weak var weakRenderer = renderer
+        let gate = MetalCompletionGate()
+        defer { gate.release() }
+        renderer?.completionGate = gate
+        view.renderOwner.installMetalRenderer(try #require(renderer), needsExternalDraw: true)
+        #expect(view.renderSnapshotForMetal(renderer: try #require(renderer), target: target))
+        try await eventually { gate.isHoldingCompletion }
+        #expect(renderer?.waitForIdle(timeout: 0) == false)
+        renderer = nil
+        #expect(view.renderOwner.removeMetalRenderer())
+        #expect(weakRenderer == nil)
+        #expect(budget.outstandingCount == 1)
+        gate.release()
+        #expect(budget.outstandingCount == 0)
+    }
+
+    @Test func submittedCapsuleOwnsDrawableUntilCompletionOnly() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let texture = try #require(device.makeTexture(descriptor:
+            MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm,
+                                                      width: 2, height: 2, mipmapped: false)))
+        let budget = MetalFrameBudget()
+        let permit = DispatchSemaphore(value: 0)
+        #expect(budget.acquire())
+        var drawable: RecoveryDrawable? = RecoveryDrawable(texture: texture)
+        weak var weakDrawable = drawable
+        let frame = MetalSubmittedFrame(drawable: try #require(drawable), permit: permit, budget: budget)
+        drawable = nil
+        #expect(weakDrawable != nil)
+        #expect(permit.wait(timeout: .now()) == .timedOut)
+        frame.complete()
+        #expect(weakDrawable == nil)
+        #expect(permit.wait(timeout: .now()) == .success)
+        frame.complete()
+        #expect(permit.wait(timeout: .now()) == .timedOut)
+        #expect(budget.outstandingCount == 0)
+        // The API default on which encoded-buffer/atlas retirement relies.
+        #expect(MTLCommandBufferDescriptor().retainedReferences)
+        let queue = try #require(device.makeCommandQueue())
+        let command = try #require(queue.makeCommandBuffer())
+        #expect(command.retainedReferences)
+    }
+}
+
+private final class RecoveryDrawable: NSObject, CAMetalDrawable {
+    let texture: any MTLTexture
+    let layer = CAMetalLayer()
+    let drawableID: Int = 1
+    let presentedTime: CFTimeInterval = 0
+    init(texture: any MTLTexture) { self.texture = texture }
+    func present() {}
+    func present(at presentationTime: CFTimeInterval) {}
+    func present(afterMinimumDuration duration: CFTimeInterval) {}
+    func addPresentedHandler(_ block: @escaping MTLDrawablePresentedHandler) {}
+}
+
+@MainActor
+private final class RecoveryInputDelegate: TerminalViewDelegate {
+    var bytes: [UInt8] = []
+    func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+    func setTerminalTitle(source: TerminalView, title: String) {}
+    func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+    func send(source: TerminalView, data: ArraySlice<UInt8>) { bytes.append(contentsOf: data) }
+    func scrolled(source: TerminalView, position: Double) {}
+    func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+}
+#endif

--- a/Tests/SwiftTermTests/MetalRendererConcurrencyTests.swift
+++ b/Tests/SwiftTermTests/MetalRendererConcurrencyTests.swift
@@ -47,19 +47,6 @@ struct MetalRendererConcurrencyTests {
         #expect(redraws.withLock { $0 } == 0)
     }
 
-    @Test @MainActor func mainRedrawDeliveryIsCoalescedAndInvalidated() async throws {
-        var redraws = 0
-        let state = MetalRedrawState()
-        state.configureOnMain { redraws += 1 }
-        for _ in 0..<1_000 { state.requestRedraw() }
-        try await Task.sleep(nanoseconds: 20_000_000)
-        #expect(redraws == 1)
-        state.requestRedraw()
-        state.invalidate()
-        try await Task.sleep(nanoseconds: 20_000_000)
-        #expect(redraws == 1)
-    }
-
     @Test @MainActor func cursorBlinkControllerOwnsTimerOnMainActor() {
         let redraws = Locked(0)
         let state = MetalRedrawState()
@@ -79,6 +66,31 @@ struct MetalRendererConcurrencyTests {
         controller.apply(shouldBlink: false)
         #expect(!controller.isRunning)
         #expect(state.cursorBlinkOn)
+    }
+
+    @Test func frameBudgetCoalescesAndCancelsCapacityRetries() {
+        let budget = MetalFrameBudget()
+        let deliveries = Locked<[Int]>([])
+        #expect(budget.acquire())
+        #expect(budget.acquire())
+        budget.retryWhenAvailable { deliveries.withLock { $0.append(-1) } }
+        budget.retryWhenAvailable {
+            // Reading the budget here also verifies delivery is outside its lock.
+            deliveries.withLock { $0.append(budget.outstandingCount) }
+        }
+        #expect(deliveries.withLock { $0 }.isEmpty)
+        budget.release()
+        budget.release()
+        #expect(deliveries.withLock { $0 } == [1])
+        budget.retryWhenAvailable { deliveries.withLock { $0.append(0) } }
+        #expect(deliveries.withLock { $0 } == [1, 0])
+        #expect(budget.acquire())
+        #expect(budget.acquire())
+        budget.retryWhenAvailable { deliveries.withLock { $0.append(-2) } }
+        budget.cancelRetry()
+        budget.release()
+        budget.release()
+        #expect(deliveries.withLock { $0 } == [1, 0])
     }
 
     @Test func bufferRecyclerRetainsAndReturnsCompletedBuffers() throws {

--- a/Tests/SwiftTermTests/MetalRendererConcurrencyTests.swift
+++ b/Tests/SwiftTermTests/MetalRendererConcurrencyTests.swift
@@ -30,6 +30,36 @@ struct MetalRendererConcurrencyTests {
         #expect(redraws.withLock { $0 } == 1)
     }
 
+    @Test @MainActor func retirementInvalidatesRedrawAndQueuedBlinkStart() {
+        let redraws = Locked(0)
+        let state = MetalRedrawState()
+        state.configure { redraws.withLock { $0 += 1 } }
+        let controller = MetalCursorBlinkController(redrawState: state)
+        #expect(state.setCursorBlinkWanted(true))
+        state.markPendingRedraw()
+        state.invalidate()
+        controller.apply(shouldBlink: true)
+        state.requestRedraw()
+        state.markPendingRedraw()
+        #expect(!state.consumePendingRedraw())
+        #expect(!state.setCursorBlinkWanted(true))
+        #expect(!controller.isRunning)
+        #expect(redraws.withLock { $0 } == 0)
+    }
+
+    @Test @MainActor func mainRedrawDeliveryIsCoalescedAndInvalidated() async throws {
+        var redraws = 0
+        let state = MetalRedrawState()
+        state.configureOnMain { redraws += 1 }
+        for _ in 0..<1_000 { state.requestRedraw() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(redraws == 1)
+        state.requestRedraw()
+        state.invalidate()
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(redraws == 1)
+    }
+
     @Test @MainActor func cursorBlinkControllerOwnsTimerOnMainActor() {
         let redraws = Locked(0)
         let state = MetalRedrawState()


### PR DESCRIPTION
A submitted GPU command that never completes can hold the current renderer's permit indefinitely and block attempts to tear it down. Retire CPU ownership after rendering quiesces while keeping submitted resources alive until their own completion, without replacing the terminal model or input session.

A submitted-command watchdog and explicit GPU failure handling allow one replacement before repeated failure falls back to Core Graphics. A shared two-frame budget bounds outstanding generations; ordinary rebind backpressure waits for capacity rather than reporting a final failure. Healthy presentation and redraw stay on the completion/render threads. Hosts receive only a final fallback notification after Core Graphics is active.

## Validation

Controlled completion-notification gates cover resource lifetime, stale callbacks, terminal/selection preservation, bounded recovery, capacity-limited rebind, and healthy progress while the test main thread is blocked. Tests do not stall real GPU execution. Normal Metal-gated suites, TSan, and strict macOS/iOS builds pass.

Recent upstream [CI](https://github.com/migueldeicaza/SwiftTerm/actions/runs/33348635235) has pre-existing Linux PTY typing and Unicode segmentation failures.

## Coordination

The Copilot Projects 2.0 migration uses the final fallback callback. The shared SwiftPM test-shader discovery fix is also carried by [the glyph-recovery PR](https://github.com/migueldeicaza/SwiftTerm/pull/672).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
