### PR TITLE
feat: blinking cursors pause as you type

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1348,7 +1348,14 @@ extension TerminalView {
     func configureInputSender() {
         let owner = renderOwner
         let notifyUI: @MainActor @Sendable () -> Void = { [weak self] in
-            self?.ensureCaretIsVisible()
+            guard let self else { return }
+            self.ensureCaretIsVisible()
+            if self.cursorBlinkResetsOnInput {
+                self.caretView?.resetBlinkAfterInput()
+#if canImport(MetalKit)
+                owner.resetMetalCursorBlinkAfterInput()
+#endif
+            }
         }
         let deliverOnMain: @MainActor @Sendable ([UInt8]) -> Void = { [weak self] bytes in
             guard let self else { return }

--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -840,6 +840,17 @@ final class MetalCursorBlinkController {
         timer = nil
         redrawState.resetCursorBlink()
     }
+
+    /// Restarts the interval with the cursor visible. If input arrives more
+    /// frequently than the interval, the cursor never reaches its hidden phase.
+    func resetAfterInput() {
+        guard redrawState.cursorBlinkWanted else { return }
+        timer?.invalidate()
+        timer = nil
+        redrawState.resetCursorBlink()
+        redrawState.requestRedraw()
+        apply(shouldBlink: true)
+    }
 }
 
 final class MetalTerminalRenderer {
@@ -4055,6 +4066,11 @@ final class MetalTerminalRenderer {
         Task { @MainActor in
             controller.apply(shouldBlink: shouldBlink)
         }
+    }
+
+    @MainActor
+    func resetCursorBlinkAfterInput() {
+        cursorBlinkController.resetAfterInput()
     }
 
     private func pruneKittyTextureCache(kitty: SnapshotKitty) {

--- a/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
+++ b/Sources/SwiftTerm/Apple/TerminalRenderOwner.swift
@@ -734,6 +734,11 @@ final class TerminalRenderOwner: Sendable {
         withRenderState { $0.renderer != nil && $0.needsExternalDraw }
     }
 
+    @MainActor
+    func resetMetalCursorBlinkAfterInput() {
+        withRenderState { $0.renderer?.resetCursorBlinkAfterInput() }
+    }
+
     var metalHasPreparedSnapshot: Bool {
         withRenderState { $0.renderer?.hasPreparedSnapshot == true }
     }

--- a/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -121,6 +121,30 @@ class CaretView: NSView {
         layer?.removeAllAnimations()
         layer?.opacity = 1
     }
+
+    /// Makes the cursor visible now and delays the next blink cycle. Repeated
+    /// input therefore keeps the cursor visible until typing pauses.
+    func resetBlinkAfterInput () {
+        let canBlink = !tracksFocus || (terminal?.hasFocus ?? true)
+        guard canBlink else { return }
+        switch style {
+        case .blinkUnderline, .blinkBlock, .blinkBar:
+            layer?.removeAllAnimations()
+            layer?.opacity = 1
+            guard let layer else { return }
+            let anim = CABasicAnimation(keyPath: #keyPath(CALayer.opacity))
+            anim.duration = 0.7
+            anim.beginTime = layer.convertTime(CACurrentMediaTime(), from: nil) + 0.7
+            anim.autoreverses = true
+            anim.repeatCount = .infinity
+            anim.fromValue = 1
+            anim.toValue = 0
+            anim.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            layer.add(anim, forKey: #keyPath(CALayer.opacity))
+        case .steadyBar, .steadyBlock, .steadyUnderline:
+            break
+        }
+    }
     
     public var defaultCaretColor = NSColor.selectedControlColor
     

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -265,6 +265,10 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         }
     }
 
+    /// Keeps a blinking cursor visible while input is being sent by restarting
+    /// its blink interval after every input payload. Defaults to `true`.
+    public var cursorBlinkResetsOnInput = true
+
     /// Controls whether rendering pauses while the window is not visible.
     /// The default is `true`. A rendering benchmark can set this to `false`
     /// so window occlusion does not invalidate its measurements.

--- a/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -129,6 +129,25 @@ class CaretView: UIView {
         layer.removeAllAnimations()
         layer.opacity = 1
     }
+
+    /// Makes the cursor visible now and delays the next blink cycle. Repeated
+    /// input therefore keeps the cursor visible until typing pauses.
+    func resetBlinkAfterInput () {
+        let canBlink = !tracksFocus || (superview?.isFirstResponder ?? true)
+        guard canBlink else { return }
+        switch style {
+        case .blinkUnderline, .blinkBlock, .blinkBar:
+            layer.removeAllAnimations()
+            layer.opacity = 1
+            guard window != nil else { return }
+            UIView.animate(withDuration: 0.7, delay: 0.7,
+                           options: [.autoreverse, .repeat, .curveEaseIn]) {
+                self.layer.opacity = 0
+            }
+        case .steadyBar, .steadyBlock, .steadyUnderline:
+            break
+        }
+    }
     
     public var defaultCaretColor = UIColor.gray
     

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -206,6 +206,11 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 #endif
         }
     }
+
+    /// Keeps a blinking cursor visible while input is being sent by restarting
+    /// its blink interval after every input payload. Defaults to `true`.
+    public var cursorBlinkResetsOnInput = true
+
     var accessibility: AccessibilityService = AccessibilityService()
     var search: SearchService!
     var debug: UIView?

--- a/Tests/SwiftTermTests/MetalRendererConcurrencyTests.swift
+++ b/Tests/SwiftTermTests/MetalRendererConcurrencyTests.swift
@@ -45,6 +45,12 @@ struct MetalRendererConcurrencyTests {
         RunLoop.current.run(until: Date().addingTimeInterval(0.04))
         #expect(redraws.withLock { $0 } > 0)
 
+        let redrawCount = redraws.withLock { $0 }
+        controller.resetAfterInput()
+        #expect(state.cursorBlinkOn)
+        #expect(controller.isRunning)
+        #expect(redraws.withLock { $0 } == redrawCount + 1)
+
         #expect(state.setCursorBlinkWanted(false))
         controller.apply(shouldBlink: false)
         #expect(!controller.isRunning)


### PR DESCRIPTION
## Issue

Other terminals—such as Terminal.app, Ghostty, and Rio—pause a blinking cursor while the user is typing. I noticed the difference immediately in [Tecolot](https://github.com/migueldeicaza/tecolot): blinking cursors are useful, but when the cursor continues blinking during input, it can be easy to lose track of its position.

## Solution

This adds a new public `TerminalView` property, `cursorBlinkResetsOnInput`, which defaults to `true`.

When enabled, sending input makes the cursor fully visible and restarts its blink interval. Repeated input therefore keeps the cursor visible while typing, and blinking resumes after typing pauses. Setting the property to false preserves the previous behavior.

The behavior is supported consistently across:
  - macOS
  - iOS and visionOS
  - Core Animation cursor rendering
  - Metal cursor rendering

You can test the behavior in my fork of Tecolot on the [blinking-cursor](https://github.com/freepicheep/tecolot/tree/blinking-cursor) branch.

Here is a preview:
<img width="800" height="584" alt="CleanShot 2026-09-02 at 10 32 23" src="https://github.com/user-attachments/assets/96edd56a-d34c-4833-a847-04fa982a8ded" />

## Testing

  - Added coverage for resetting the Metal cursor blink controller after input.

*LLM Disclosure: Codex wrote this code with Sol 5.6*
