### PR TITLE
fix Linux PTY build and lifecycle-test portability

### DIFF
--- a/Sources/SwiftTerm/Pty.swift
+++ b/Sources/SwiftTerm/Pty.swift
@@ -155,7 +155,7 @@ public class PseudoTerminalHelpers {
         indices += [VDISCARD, VEOL2, VLNEXT, VREPRINT, VSWTC, VWERASE]
 #endif
 
-        let disabledValue = fpathconf(masterPtyDescriptor, _PC_VDISABLE)
+        let disabledValue = fpathconf(masterPtyDescriptor, Int32(_PC_VDISABLE))
         let disabledByte: UInt8? = disabledValue >= 0 && disabledValue <= 0xff
             ? UInt8(disabledValue)
             : nil

--- a/Tests/SwiftTermTests/LocalProcessLifecycleTests.swift
+++ b/Tests/SwiftTermTests/LocalProcessLifecycleTests.swift
@@ -321,7 +321,7 @@ final class LocalProcessLifecycleTests: XCTestCase {
         weak var releasedProcess: LocalProcess?
         var pid: pid_t = 0
 
-        autoreleasepool {
+        func startAndReleaseProcess() {
             let process = LocalProcess(
                 delegate: delegate,
                 dispatchQueue: DispatchQueue(label: "SwiftTerm.LocalProcessLifecycle.deinit"))
@@ -333,6 +333,11 @@ final class LocalProcessLifecycleTests: XCTestCase {
             pid = process.shellPid
             releasedProcess = process
         }
+#if canImport(ObjectiveC)
+        autoreleasepool(invoking: startAndReleaseProcess)
+#else
+        startAndReleaseProcess()
+#endif
 
         XCTAssertNil(releasedProcess)
         XCTAssertTrue(waitUntil(timeout: 5, interval: 0.01) {


### PR DESCRIPTION
Linux compilation stops at the `fpathconf` selector type and an Objective-C-only autorelease pool in the lifecycle tests. Correct the selector type and keep the same scoped lifetime assertions on both platforms, without changing Darwin behavior.

## Tests

Covers PTY control characters and child-process lifetime. Targeted macOS coverage and strict-concurrency builds pass; Linux validation is left to CI.

## Related

Separated from [the embedding proposal](https://github.com/migueldeicaza/SwiftTerm/pull/673) for independent review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
