### PR TITLE
prevent bidi cache reuse across line lifetimes

### DIFF
--- a/Sources/SwiftTerm/Apple/TerminalBidi.swift
+++ b/Sources/SwiftTerm/Apple/TerminalBidi.swift
@@ -445,6 +445,26 @@ enum TerminalBidi {
         let cols: Int
         let font: ObjectIdentifier
         let state: BidiPresentationState
+        // Pin line identities, not mutable lines, while the cache or a deferred
+        // job can still refer to them. Allocator address reuse is not a hit.
+        let lineIdentities: [BufferLine.RenderIdentity]
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.buffer == rhs.buffer && lhs.firstRow == rhs.firstRow &&
+            lhs.lastRow == rhs.lastRow && lhs.revision == rhs.revision &&
+            lhs.cols == rhs.cols && lhs.font == rhs.font && lhs.state == rhs.state &&
+            lhs.lineIdentities.elementsEqual(rhs.lineIdentities, by: { $0 === $1 })
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(buffer)
+            hasher.combine(firstRow)
+            hasher.combine(lastRow)
+            hasher.combine(revision)
+            hasher.combine(cols)
+            hasher.combine(font)
+            hasher.combine(state)
+        }
     }
 
     fileprivate struct ParagraphResult {
@@ -584,13 +604,16 @@ enum TerminalBidi {
         return first...last
     }
 
+    private static func hashLineRevision(_ line: BufferLine, into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(line.renderIdentity))
+        hasher.combine(line.generation)
+        hasher.combine(line.isWrapped)
+    }
+
     private static func paragraphRevision(_ bounds: ClosedRange<Int>, buffer: Buffer) -> Int {
         var hasher = Hasher()
         for row in bounds {
-            let line = buffer.lines[row]
-            hasher.combine(ObjectIdentifier(line))
-            hasher.combine(line.generation)
-            hasher.combine(line.isWrapped)
+            hashLineRevision(buffer.lines[row], into: &hasher)
         }
         return hasher.finalize()
     }
@@ -869,14 +892,23 @@ enum TerminalBidi {
             return .ready(nil)
         }
         let state = buffer.lines[bounds.lowerBound].bidiState
-        let revision = paragraphRevision(bounds, buffer: buffer)
+        var lineIdentities: [BufferLine.RenderIdentity] = []
+        lineIdentities.reserveCapacity(bounds.count)
+        var revisionHasher = Hasher()
+        for row in bounds {
+            let line = buffer.lines[row]
+            lineIdentities.append(line.renderIdentity)
+            hashLineRevision(line, into: &revisionHasher)
+        }
+        let revision = revisionHasher.finalize()
         let key = ParagraphKey(buffer: ObjectIdentifier(buffer),
                                firstRow: bounds.lowerBound,
                                lastRow: bounds.upperBound,
                                revision: revision,
                                cols: cols,
                                font: ObjectIdentifier(font),
-                               state: state)
+                               state: state,
+                               lineIdentities: lineIdentities)
         if let cached = cacheState.withLock({ $0.paragraphCache[key] }) {
             return .ready(cached)
         }

--- a/Tests/SwiftTermTests/BidiCacheTests.swift
+++ b/Tests/SwiftTermTests/BidiCacheTests.swift
@@ -60,6 +60,63 @@ final class BidiCacheTests: TerminalDelegate {
         }
     }
 
+    @Test(arguments: ["éééé", "שלום"], [0, 1])
+    func identityCacheRetainsTokensWithoutRetainingLines(text: String, row: Int) {
+        TerminalBidi._testResetCaches()
+        defer { TerminalBidi._testResetCaches() }
+        weak var releasedLine: BufferLine?
+        weak var cachedIdentity: BufferLine.RenderIdentity?
+
+        func populateCache() {
+            let terminal = makeTerminal(cols: 3, feed: text)
+            #expect(terminal.buffer.lines[1].isWrapped)
+            releasedLine = terminal.buffer.lines[row]
+            cachedIdentity = terminal.buffer.lines[row].renderIdentity
+            _ = layout(terminal, cols: 3)
+        }
+        populateCache()
+
+        #expect(releasedLine == nil)
+        #expect(cachedIdentity != nil,
+                "a cached paragraph must keep its line identity from being reused")
+        TerminalBidi._testResetCaches()
+        #expect(cachedIdentity == nil)
+    }
+
+    @Test func shortLivedTerminalsDoNotReuseAnotherParagraph() throws {
+        TerminalBidi._testResetCaches()
+        defer { TerminalBidi._testResetCaches() }
+
+        func cachedLayout(_ text: String) -> BidiRowLayout? {
+            let terminal = makeTerminal(cols: 10, feed: text)
+            return layout(terminal, cols: 10)
+        }
+        for _ in 0..<2_000 {
+            #expect(cachedLayout("éééé") == nil)
+            let rtl = try #require(cachedLayout("שלום"))
+            #expect(rtl.logicalToVisualCol == Array((0..<10).reversed()))
+        }
+    }
+
+    @Test func replacedWrappedLineWithEqualGenerationIsNotServedStale() throws {
+        TerminalBidi._testResetCaches()
+        defer { TerminalBidi._testResetCaches() }
+        let terminal = makeTerminal(cols: 3, feed: "abcd")
+        let replacementSource = makeTerminal(cols: 3, feed: "abcא")
+        let original = BufferLine(from: terminal.buffer.lines[1])
+        let replacement = BufferLine(from: replacementSource.buffer.lines[1])
+        #expect(original.generation == replacement.generation)
+        #expect(original.isWrapped && replacement.isWrapped)
+
+        terminal.buffer.lines[1] = original
+        #expect(layout(terminal, row: 1, cols: 3) == nil)
+        terminal.buffer.lines[1] = replacement
+        let updated = try #require(layout(terminal, row: 1, cols: 3))
+
+        TerminalBidi._testResetCaches()
+        #expect(equalLayouts(updated, layout(terminal, row: 1, cols: 3)))
+    }
+
     /// A layout served from the content cache must be identical to one
     /// computed from scratch for the same content.
     @Test func contentCacheHitMatchesFreshComputation() {


### PR DESCRIPTION
Allocator reuse can give a new RTL paragraph the cached LTR result of a destroyed line. Keep immutable line identities alive while a paragraph-cache entry or deferred job refers to them, without retaining mutable lines or terminal buffers.

This fixes line-lifetime reuse while retaining the existing cache fast path and bounds. Font-key behavior is unchanged.

## Tests

Covers leading and wrapped-line token lifetime, release of mutable lines, equal-generation replacement, and short-lived terminal churn alongside existing bidi and snapshot behavior.

## Related

Separated from [the embedding proposal](https://github.com/migueldeicaza/SwiftTerm/pull/673) for independent review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
