### PR TITLE
find SwiftPM shaders beside XCTest bundles

### DIFF
--- a/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -4092,10 +4092,8 @@ final class MetalTerminalRenderer {
 
     /// Whether a shader library can be built here at all.
     ///
-    /// Exposed for tests: under `swift test` the SwiftTerm resource bundle is
-    /// not next to the test binary, so Metal cannot be enabled and any test
-    /// that needs it must skip rather than fail. Cheap and cached — building
-    /// the library once is the only honest way to answer this.
+    /// Exposed for tests that optionally exercise Metal. Cheap and cached —
+    /// building the library once is the only honest way to answer this.
     static let shaderLibraryIsAvailable: Bool = {
         guard let device = MTLCreateSystemDefaultDevice() else { return false }
         return (try? makeLibrary(device: device)) != nil
@@ -4206,6 +4204,16 @@ final class MetalTerminalRenderer {
         if let url = Bundle.main.bundleURL.appendingPathComponent(bundleName) as URL?,
            let resourceBundle = Bundle(url: url) {
             bundles.append(resourceBundle)
+        }
+        // SwiftPM puts resources beside the .xctest bundle, which may be
+        // loaded by a separate runner. Never search arbitrary app siblings.
+        for bundle in [Bundle.main, Bundle(for: MetalTerminalRenderer.self)]
+            where bundle.bundleURL.pathExtension == "xctest" {
+            let url = bundle.bundleURL.deletingLastPathComponent()
+                .appendingPathComponent(bundleName)
+            if let resourceBundle = Bundle(url: url) {
+                bundles.append(resourceBundle)
+            }
         }
         #endif
         bundles.append(Bundle(for: MetalTerminalRenderer.self))

--- a/Tests/SwiftTermTests/MetalSurfaceParityTests.swift
+++ b/Tests/SwiftTermTests/MetalSurfaceParityTests.swift
@@ -31,10 +31,8 @@ struct MetalSurfaceParityTests {
     /// Renders `content` through `target` and returns the drawable's pixels.
     private func renderPixels(into target: any MetalRenderTarget,
                               terminalView: TerminalView) -> [UInt8]? {
-        // The renderer loads its shaders from the SwiftTerm resource bundle,
-        // which is not present next to the SwiftPM test binary. When that is
-        // the case there is nothing to compare, so skip rather than fail — the
-        // app-side harness runs this same comparison where the bundle exists.
+        // Rendering requires a usable device, shader library, and drawable.
+        // Return nil when one is unavailable so callers can skip the comparison.
         target.renderContentsScale = 1
         target.renderDrawableSize = CGSize(width: Self.width, height: Self.height)
         guard let renderer = try? MetalTerminalRenderer(target: target) else {

--- a/Tests/SwiftTermTests/MetalToggleTests.swift
+++ b/Tests/SwiftTermTests/MetalToggleTests.swift
@@ -27,11 +27,8 @@ struct MetalToggleTests {
         return view
     }
 
-    /// A device is not enough: the renderer loads its shaders from the SwiftTerm
-    /// resource bundle, which is not next to the SwiftPM test binary, so
-    /// `swift test` cannot enable Metal at all. These skip there — reported as
-    /// skipped, not quietly passing — and run from Xcode. The version that
-    /// always runs is the `metaltoggle` scenario in the app harness.
+    /// A device is not enough: the renderer also needs a usable shader library.
+    /// These tests skip when either is unavailable, including on GPU-less CI.
     nonisolated static var metalIsUsable: Bool {
         MetalTerminalRenderer.shaderLibraryIsAvailable
     }


### PR DESCRIPTION
SwiftPM can load an XCTest bundle from a separate runner, leaving the shader resources beside the bundle rather than the runner. Search that sibling location only for XCTest bundles, so Metal tests can execute without broadening application resource discovery.

Update stale test comments; legitimate device or shader unavailability remains handled as before.

## Tests

Exercises Metal concurrency, render targets, surface parity, and toggles. Local GPU coverage includes texture readback and pixel comparison, not merely an early-return path.

## Related

Separated from [the embedding proposal](https://github.com/migueldeicaza/SwiftTerm/pull/673) for independent review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
