### PR TITLE
add ordered local process output consumers

### DIFF
--- a/Sources/SwiftTerm/Documentation.docc/Embedding.md
+++ b/Sources/SwiftTerm/Documentation.docc/Embedding.md
@@ -96,6 +96,38 @@ thread yourself. Reading terminal state inside such a callback is fine — you
 already hold the lock — but calling back into SwiftTerm APIs that take it is
 not.
 
+## Taking ownership of local process output
+
+On macOS, configure `LocalProcessTerminalView.setProcessOutputConsumer` before
+starting a process to receive owned output batches instead of automatic parsing.
+Changing the consumer while the process is running or draining throws
+`ProcessOutputConsumerError.processActive`. Passing `nil` restores the existing
+borrowed-byte parser path without an extra copy.
+
+The consumer runs synchronously on the main actor, without terminal or process
+locks held. The parse worker waits for each callback to return, preserving FIFO
+order and backpressure. Feed each batch or put it in bounded storage before
+returning; never synchronously wait for more process output or termination.
+Direct calls to `feed` bypass the consumer. Buffering raw bytes does not start
+the parser's synchronized-output watchdog; feeding them uses the normal feed
+transaction and watchdog behavior.
+
+The view's process adapter retains the consumer. Capture `[weak view]` when
+feeding it, not `unowned`: the adapter can outlive the view.
+
+```swift
+try view.setProcessOutputConsumer { [weak view] bytes in
+    view?.feed(byteArray: bytes[...])
+}
+```
+
+Process termination is also handed off synchronously on the main actor, after
+earlier output callbacks return and before a callback-driven relaunch. This
+observable ordering keeps the previous process's output and termination ahead
+of the next process's output, even when main-actor delivery delays draining.
+`setProcessOutputHandler` runs after the consumer returns, which means the batch
+was handled, not necessarily parsed if the consumer buffered it.
+
 ## Topics
 
 ### Related

--- a/Sources/SwiftTerm/Documentation.docc/Embedding.md
+++ b/Sources/SwiftTerm/Documentation.docc/Embedding.md
@@ -125,8 +125,9 @@ Process termination is also handed off synchronously on the main actor, after
 earlier output callbacks return and before a callback-driven relaunch. This
 observable ordering keeps the previous process's output and termination ahead
 of the next process's output, even when main-actor delivery delays draining.
-`setProcessOutputHandler` runs after the consumer returns, which means the batch
-was handled, not necessarily parsed if the consumer buffered it.
+`setProcessOutputHandler` runs on the process parse thread after the consumer
+returns, which means the batch was handled, not necessarily parsed if the
+consumer buffered it.
 
 ## Topics
 

--- a/Sources/SwiftTerm/Locked.swift
+++ b/Sources/SwiftTerm/Locked.swift
@@ -17,6 +17,10 @@ import Synchronization
 /// Callers must not expose mutable value storage from `withLock`. They can copy
 /// a stable reference when that reference has separate synchronization and
 /// does not escape the owning API.
+///
+/// Do not use a function type as `Value`: generic inout access can accumulate
+/// reabstraction wrappers on each read, growing invocation and teardown stacks.
+/// Keep callbacks in concrete fields on stable reference objects instead.
 final class Locked<Value>: @unchecked Sendable {
     private let lock = NSLock()
     private var value: Value

--- a/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -13,6 +13,26 @@ private struct WeakLocalProcessInputReference {
     weak var value: LocalProcess?
 }
 
+/// Receives an owned process-output batch instead of automatic parsing.
+public typealias ProcessOutputConsumer = @MainActor @Sendable ([UInt8]) -> Void
+
+public enum ProcessOutputConsumerError: Error {
+    /// Output ownership cannot change while a process is running or draining.
+    case processActive
+}
+
+/// LocalProcess calls its adapter either on its parse worker or its explicitly
+/// configured main queue. Do not hold terminal, render, or process locks here.
+private func deliverProcessCallbackOnMain(
+    _ body: @MainActor @Sendable () -> Void
+) {
+    if Thread.isMainThread {
+        MainActor.assumeIsolated { body() }
+    } else {
+        DispatchQueue.main.sync { body() }
+    }
+}
+
 /// Delegate for the ``LocalProcessTerminalView`` class that is used to
 /// notify the user of process-related changes.
 @MainActor
@@ -52,10 +72,24 @@ public protocol LocalProcessTerminalViewDelegate: AnyObject {
 private final class LocalProcessTerminalViewProcessAdapter:
     LocalProcessDelegate, LocalProcessBorrowedDataDelegate, Sendable
 {
+    private final class OutputConsumerBox: Sendable {
+        private let body: ProcessOutputConsumer
+
+        init(_ body: @escaping ProcessOutputConsumer) {
+            self.body = body
+        }
+
+        @MainActor
+        func invoke(_ bytes: [UInt8]) {
+            body(bytes)
+        }
+    }
+
     private let renderOwner: TerminalRenderOwner
     private let frameSignal: FrameDriverSignal
     private let diagnosticsState: Locked<TerminalView.Diagnostics>
     private let outputHandler: LockedVoidCallback
+    private let outputConsumer = Locked<OutputConsumerBox?>(nil)
     private let windowSize = Locked(winsize())
     private let inputProcess = Locked(WeakLocalProcessInputReference())
     private let terminationHandler: @MainActor @Sendable (Int32?) -> Void
@@ -86,14 +120,24 @@ private final class LocalProcessTerminalViewProcessAdapter:
         }
     }
 
+    @MainActor
+    func setOutputConsumer(_ consumer: ProcessOutputConsumer?) {
+        let next = consumer.map(OutputConsumerBox.init)
+        outputConsumer.withLock { $0 = next }
+    }
+
     func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
         let handler = terminationHandler
-        Task { @MainActor in
-            handler(exitCode)
-        }
+        deliverProcessCallbackOnMain { handler(exitCode) }
     }
 
     func dataReceived(slice: ArraySlice<UInt8>) {
+        if let consumer = outputConsumer.withLock({ $0 }) {
+            let bytes = Array(slice)
+            deliverProcessCallbackOnMain { consumer.invoke(bytes) }
+            outputHandler.call()
+            return
+        }
         frameSignal.markDirty()
         let parse = Profiling.begin(.ioParse, "bytes=%d", slice.count)
         _ = renderOwner.feed(bytes: slice)
@@ -107,6 +151,12 @@ private final class LocalProcessTerminalViewProcessAdapter:
     }
 
     func dataReceivedBorrowed(_ bytes: Span<UInt8>) {
+        if let consumer = outputConsumer.withLock({ $0 }) {
+            let copy = bytes.copiedBytes()
+            deliverProcessCallbackOnMain { consumer.invoke(copy) }
+            outputHandler.call()
+            return
+        }
         frameSignal.markDirty()
         let parse = Profiling.begin(.ioParse, "bytes=%d", bytes.count)
         _ = renderOwner.feed(borrowedBytes: bytes)
@@ -200,10 +250,27 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate {
     }
 
     /// Installs a notification that runs on the process parse thread after an
-    /// output batch is applied. The handler receives no mutable terminal state
-    /// and must return quickly.
+    /// output batch is handled. With an output consumer, this means the consumer
+    /// has returned, not necessarily that the bytes have been parsed. The handler
+    /// receives no mutable terminal state and must return quickly.
     public func setProcessOutputHandler(_ handler: (@Sendable () -> Void)?) {
         processOutputHandler.replace(with: handler)
+    }
+
+    /// Takes ownership of process output before parsing, or restores automatic
+    /// background parsing with nil. Configure this before starting a process.
+    ///
+    /// A consumer receives one copied batch synchronously on the main actor.
+    /// It must feed the bytes or place them in its own bounded storage before
+    /// returning. The parse worker waits, preserving FIFO and backpressure;
+    /// consumers must not synchronously wait for process output or termination.
+    /// Direct calls to feed do not invoke the consumer. With nil, the existing
+    /// borrowed-byte parser path remains unchanged and makes no extra copy.
+    public func setProcessOutputConsumer(_ consumer: ProcessOutputConsumer?) throws {
+        guard !process.running, !process.windingDown else {
+            throw ProcessOutputConsumerError.processActive
+        }
+        processAdapter.setOutputConsumer(consumer)
     }
     
     /**

--- a/Tests/SwiftTermTests/ProcessOutputConsumerTeardownTests.swift
+++ b/Tests/SwiftTermTests/ProcessOutputConsumerTeardownTests.swift
@@ -1,0 +1,192 @@
+#if os(macOS)
+import AppKit
+import Darwin
+import MachO
+import XCTest
+
+@testable import SwiftTerm
+
+@MainActor
+final class ProcessOutputConsumerTeardownTests: XCTestCase {
+    private static let childModeKey = "SWIFTTERM_CONSUMER_TEARDOWN_CHILD"
+    nonisolated private static let batchCount = 20_000
+
+    private final class Capture {
+        var view: LocalProcessTerminalView?
+        weak var weakView: LocalProcessTerminalView?
+        weak var weakAdapter: LocalProcessDelegate?
+        var batches = 0
+        var firstAddress: UInt = 0
+        var lastAddress: UInt = 0
+    }
+
+    func testBorrowedConsumerInvocationStackDoesNotGrow() throws {
+        try checkInvocationStack(borrowed: true)
+    }
+
+    func testSliceConsumerInvocationStackDoesNotGrow() throws {
+        try checkInvocationStack(borrowed: false)
+    }
+
+    private func checkInvocationStack(borrowed: Bool) throws {
+        let capture = Capture()
+        let adapter = try prepareAdapter(capture, batches: 1_000)
+        Self.deliverAndRelease(adapter, borrowed: borrowed, batches: 1_000)
+        XCTAssertEqual(capture.batches, 1_000)
+        let growth = max(capture.firstAddress, capture.lastAddress) - min(capture.firstAddress, capture.lastAddress)
+        FileHandle.standardError.write(Data("INVOCATION STACK \(borrowed ? "borrowed" : "slice"): \(growth) bytes\n".utf8))
+        XCTAssertLessThan(growth, 4_096, "consumer invocation stack grew by \(growth) bytes")
+    }
+
+    func testBorrowedConsumerTeardownAfterManyBatches() async throws {
+        try await runChild(mode: "borrowed")
+    }
+
+    func testSliceConsumerTeardownAfterManyBatches() async throws {
+        try await runChild(mode: "slice")
+    }
+
+    private func runChild(mode: String) async throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent(".build/consumer-teardown-tests/\(UUID().uuidString)")
+        let fileManager = FileManager.default
+        for name in ["home", "runtime"] {
+            try fileManager.createDirectory(at: root.appendingPathComponent(name), withIntermediateDirectories: true)
+        }
+        defer { try? fileManager.removeItem(at: root) }
+        let logURL = root.appendingPathComponent("child.log")
+        XCTAssertTrue(fileManager.createFile(atPath: logURL.path, contents: nil))
+        let log = try FileHandle(forWritingTo: logURL)
+        defer { try? log.close() }
+        let child = Process()
+        // Reuse the XCTest runner directly: xcrun strips sanitizer preload variables.
+        child.executableURL = try XCTUnwrap(Bundle.main.executableURL)
+        child.arguments = [
+            "-XCTest",
+            "SwiftTermTests.ProcessOutputConsumerTeardownTests/testConsumerTeardownChild",
+            Bundle(for: Self.self).bundleURL.path
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment[Self.childModeKey] = mode
+        environment["HOME"] = root.appendingPathComponent("home").path
+        environment["CFFIXED_USER_HOME"] = environment["HOME"]
+        environment["TMPDIR"] = root.appendingPathComponent("runtime").path
+        environment["SHELL"] = "/bin/sh"
+        // XCTest loads the test bundle dynamically. Preload ThreadSanitizer
+        // in children too, even when the parent consumed its DYLD environment.
+        let sanitizer = (0..<_dyld_image_count()).compactMap { index in
+            _dyld_get_image_name(index).map { String(cString: $0) }
+        }.first { $0.contains("/libclang_rt.tsan_") }
+        if let sanitizer {
+            environment["DYLD_INSERT_LIBRARIES"] = [sanitizer, environment["DYLD_INSERT_LIBRARIES"]]
+                .compactMap { $0 }.joined(separator: ":")
+        }
+        child.environment = environment
+        child.standardOutput = log
+        child.standardError = log
+        try child.run()
+        defer {
+            if child.isRunning {
+                kill(child.processIdentifier, SIGKILL)
+                child.waitUntilExit()
+            }
+        }
+        let deadline = ContinuousClock.now + .seconds(30)
+        while child.isRunning, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        if child.isRunning {
+            child.terminate()
+            let terminationDeadline = ContinuousClock.now + .seconds(2)
+            while child.isRunning, ContinuousClock.now < terminationDeadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            if child.isRunning { kill(child.processIdentifier, SIGKILL) }
+            XCTFail("\(mode) consumer teardown child timed out")
+        }
+        child.waitUntilExit()
+        let output = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertEqual(child.terminationReason, .exit, output)
+        XCTAssertEqual(child.terminationStatus, 0, output)
+        XCTAssertTrue(output.contains("TEARDOWN COMPLETE \(mode)"), output)
+    }
+
+    func testConsumerTeardownChild() async throws {
+        guard let mode = ProcessInfo.processInfo.environment[Self.childModeKey] else {
+            throw XCTSkip("Runs only in the isolated teardown subprocess")
+        }
+        let capture = Capture()
+        let adapter = try prepareAdapter(capture)
+        let completed = Locked(false)
+        let worker = Thread {
+            Self.deliverAndRelease(adapter, borrowed: mode == "borrowed")
+            FileHandle.standardError.write(Data("TEARDOWN COMPLETE \(mode)\n".utf8))
+            completed.withLock { $0 = true }
+        }
+        worker.name = "swiftterm-output-consumer-teardown"
+        worker.stackSize = 512 * 1024
+        worker.start()
+        let deadline = ContinuousClock.now + .seconds(20)
+        while !completed.withLock({ $0 }), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTAssertTrue(completed.withLock { $0 })
+        XCTAssertEqual(capture.batches, Self.batchCount)
+        XCTAssertNil(capture.weakView)
+        XCTAssertNil(capture.weakAdapter)
+        // AppKit autorelease can delay final destruction until main; retain
+        // the drift assertion so a delayed release cannot mask stack growth.
+        let growth = max(capture.firstAddress, capture.lastAddress) - min(capture.firstAddress, capture.lastAddress)
+        XCTAssertLessThan(growth, 4_096, "consumer invocation stack grew by \(growth) bytes")
+    }
+
+    private func prepareAdapter(_ capture: Capture, batches: Int = batchCount) throws -> Locked<LocalProcessDelegate?> {
+        let view = LocalProcessTerminalView(frame: .zero)
+        capture.view = view
+        capture.weakView = view
+        try view.setProcessOutputConsumer { bytes in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(bytes, [UInt8(truncatingIfNeeded: capture.batches)])
+            var marker = 0
+            let address = withUnsafePointer(to: &marker) { UInt(bitPattern: $0) }
+            if capture.batches == 0 { capture.firstAddress = address }
+            capture.lastAddress = address
+            capture.batches += 1
+            if capture.batches == batches {
+                FileHandle.standardError.write(Data("DELIVERED \(capture.batches); dropping view on main\n".utf8))
+                capture.view = nil
+            }
+        }
+        // Keep the production adapter private: this probe only borrows the
+        // delegate installed by the real view, without changing library API.
+        let value = Mirror(reflecting: view).children.first { $0.label == "processAdapter" }?.value
+        let adapter = try XCTUnwrap(value as? LocalProcessDelegate)
+        capture.weakAdapter = adapter
+        return Locked(adapter)
+    }
+
+    @inline(never)
+    nonisolated private static func deliverAndRelease(
+        _ pending: Locked<LocalProcessDelegate?>, borrowed: Bool, batches: Int = batchCount
+    ) {
+        let adapter = pending.withLock { value in
+            let current = value
+            value = nil
+            return current
+        }!
+        for index in 0..<batches {
+            let bytes = [UInt8(truncatingIfNeeded: index)]
+            let slice = bytes[...]
+            if borrowed {
+                (adapter as! LocalProcessBorrowedDataDelegate).dataReceivedBorrowed(slice.span)
+            } else {
+                adapter.dataReceived(slice: slice)
+            }
+        }
+        // Returning drops the last adapter reference on the same-sized worker
+        // stack used by LocalProcess, after main has released the owning view.
+        withExtendedLifetime(adapter) {}
+    }
+}
+#endif

--- a/Tests/SwiftTermTests/ProcessOutputConsumerTests.swift
+++ b/Tests/SwiftTermTests/ProcessOutputConsumerTests.swift
@@ -1,0 +1,162 @@
+#if os(macOS)
+import AppKit
+import Testing
+
+@testable import SwiftTerm
+
+@MainActor
+@Suite(.serialized)
+struct ProcessOutputConsumerTests {
+    private final class Delegate: LocalProcessTerminalViewDelegate {
+        var exits = 0
+        var onExit: (() -> Void)?
+        func processTerminated(source: TerminalView, exitCode: Int32?) {
+            #expect(Thread.isMainThread)
+            #expect(exitCode == 0)
+            exits += 1
+            onExit?()
+        }
+        func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
+        func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+    }
+
+    private final class Capture {
+        var bytes: [UInt8] = []
+        var batches = 0
+        var events: [String] = []
+    }
+
+    private func waitForExit(_ delegate: Delegate, count: Int = 1) async {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while delegate.exits < count, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(delegate.exits == count)
+    }
+
+    @Test func actualPTYOutputIsConsumedExactlyOnceWithoutAutomaticFeed() async throws {
+        let view = LocalProcessTerminalView(frame: .zero)
+        let delegate = Delegate()
+        view.processDelegate = delegate
+        let capture = Capture()
+        let handled = Locked(0)
+        view.setProcessOutputHandler { handled.withLock { $0 += 1 } }
+        try view.setProcessOutputConsumer { bytes in
+            #expect(Thread.isMainThread)
+            #expect(bytes.count <= 65_536)
+            capture.bytes += bytes
+            capture.batches += 1
+        }
+        view.startProcess(executable: "/bin/sh", args: ["-c", "printf consumer-output"], environment: [])
+        await waitForExit(delegate)
+        #expect(capture.bytes == Array("consumer-output".utf8))
+        #expect(capture.batches > 0)
+        #expect(handled.withLock { $0 } == capture.batches)
+        #expect(view.withTerminal { terminal in
+            (0..<terminal.rows).allSatisfy { row in
+                terminal.getLine(row: row)?.translateToString(
+                    trimRight: true, skipNullCellsFollowingWide: false).isEmpty == true
+            }
+        })
+        view.feed(byteArray: capture.bytes[...])
+        #expect(view.withTerminal {
+            $0.getLine(row: 0)?.translateToString(trimRight: true, skipNullCellsFollowingWide: false)
+        } == "consumer-output")
+        #expect(capture.bytes == Array("consumer-output".utf8), "Replay must bypass the consumer")
+        #expect(view.diagnostics.bytesFed == capture.bytes.count)
+    }
+
+    @Test func consumerCanFeedWithoutLockRecursionAndRejectsActiveChanges() async throws {
+        let view = LocalProcessTerminalView(frame: .zero)
+        let delegate = Delegate()
+        view.processDelegate = delegate
+        let capture = Capture()
+        try view.setProcessOutputConsumer { [weak view] bytes in
+            capture.bytes += bytes
+            view?.feed(byteArray: bytes[...])
+        }
+        view.startProcess(executable: "/bin/sh", args: ["-c", "read line; printf fed-once"], environment: [])
+        #expect(throws: ProcessOutputConsumerError.self) {
+            try view.setProcessOutputConsumer(nil)
+        }
+        view.send([0x0d])
+        await waitForExit(delegate)
+        #expect(String(decoding: capture.bytes, as: UTF8.self).contains("fed-once"))
+        #expect(view.diagnostics.bytesFed == capture.bytes.count)
+        try view.setProcessOutputConsumer(nil)
+    }
+
+    @Test func blockedMainTimeoutKeepsOutputBeforeTerminationAndRelaunch() async throws {
+        let view = LocalProcessTerminalView(frame: .zero)
+        let delegate = Delegate()
+        view.processDelegate = delegate
+        view.process.drainTimeout = 0.2
+        let capture = Capture()
+        try view.setProcessOutputConsumer { bytes in
+            capture.bytes += bytes
+            capture.events.append(String(decoding: bytes, as: UTF8.self))
+        }
+        delegate.onExit = { [weak view, weak delegate] in
+            capture.events.append("exit")
+            if delegate?.exits == 1 {
+                view?.startProcess(executable: "/bin/sh", args: ["-c", "printf second"], environment: [])
+            }
+        }
+        let releaseHandled = DispatchSemaphore(value: 0)
+        let handled = Locked(0)
+        view.setProcessOutputHandler {
+            let first = handled.withLock { count in
+                count += 1
+                return count == 1
+            }
+            if first { _ = releaseHandled.wait(timeout: .now() + 3) }
+        }
+        defer { releaseHandled.signal() }
+        view.startProcess(executable: "/bin/sh", args: ["-c", "printf first"], environment: [])
+        // Hold the parse worker after its first consumer returns. Let the
+        // main-queue exit monitor start the drain, then block main so its
+        // termination callback remains queued when the drain times out.
+        let exitDeadline = ContinuousClock.now + .seconds(2)
+        while (view.process.shellPid != 0 || handled.withLock { $0 } == 0),
+              ContinuousClock.now < exitDeadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(view.process.shellPid == 0)
+        blockMainUntilWindingDown(view.process)
+        #expect(view.process.windingDown)
+        #expect(capture.bytes == Array("first".utf8))
+        #expect(delegate.exits == 0)
+        #expect(throws: ProcessOutputConsumerError.self) {
+            try view.setProcessOutputConsumer(nil)
+        }
+        releaseHandled.signal()
+        await waitForExit(delegate, count: 2)
+        #expect(capture.bytes == Array("firstsecond".utf8))
+        #expect(capture.events == ["first", "exit", "second", "exit"])
+        #expect(view.process.shellPid == 0)
+        #expect(!view.process.running)
+        #expect(!view.process.windingDown)
+    }
+
+    private func blockMainUntilWindingDown(_ process: LocalProcess) {
+        let deadline = Date().addingTimeInterval(2)
+        while !process.windingDown, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+    }
+
+    @Test func nilConsumerRetainsAutomaticBackgroundParsing() async throws {
+        let view = LocalProcessTerminalView(frame: .zero)
+        let delegate = Delegate()
+        view.processDelegate = delegate
+        try view.setProcessOutputConsumer(nil)
+        view.startProcess(executable: "/bin/sh", args: ["-c", "printf automatic"], environment: [])
+        await waitForExit(delegate)
+        #expect(view.withTerminal {
+            $0.getLine(row: 0)?.translateToString(trimRight: true, skipNullCellsFollowingWide: false)
+        } == "automatic")
+        #expect(view.diagnostics.bytesFed == "automatic".utf8.count)
+    }
+}
+#endif


### PR DESCRIPTION
Hosts that capture or buffer local PTY output need an interception point before parsing. Add an opt-in owned-output consumer with synchronous main-actor delivery and parse-worker backpressure; the default borrowed-byte parsing path remains unchanged.

Termination also moves from an unstructured task to the same main-queue handoff, preserving output-before-termination and callback-driven relaunch across drain timeouts. The consumer uses immutable callback storage to avoid accumulating reabstraction wrappers. The guide documents bounded buffering and weak view captures.

## Tests

Covers real PTY delivery, replay without recapture, active-process configuration guards, drain-timeout ordering, and bounded invocation/teardown stacks. Tests use existing inspection APIs, so this proposal is independent of copied snapshots.

## Related

Separated from the [original embedding proposal](https://github.com/migueldeicaza/SwiftTerm/pull/673) for independent review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
