### PR TITLE
Make TerminalView.pasteText public

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleKittyClipboard.swift
+++ b/Sources/SwiftTerm/Apple/AppleKittyClipboard.swift
@@ -123,10 +123,16 @@ extension TerminalView {
         return !result.needsTextFallback
     }
 
-    /// Sends `text` as a text paste. A paste that the safety policy rejected
-    /// is sent again with the policy relaxed.
+    /// Sends `text` as a text paste, using the same path as a clipboard paste.
+    ///
+    /// The text is bracketed when the running application enabled bracketed
+    /// paste mode, and sanitized the same way clipboard text is, so a host
+    /// can feed the terminal content that did not come from the pasteboard -
+    /// a dropped file's path, for instance - without it being seen as typed
+    /// input. A paste that the safety policy rejected is sent again with the
+    /// policy relaxed.
     @MainActor
-    func pasteText(_ text: String) {
+    public func pasteText(_ text: String) {
         ensureCaretIsVisible()
         let request = TerminalPasteRequest(text: text)
         var result = withTerminal { $0.paste(request) }


### PR DESCRIPTION
Hosts that need to feed the terminal text which did not come from the pasteboard, a dropped file's path, for instance, had no way to reach the paste path: `pasteText(_:)` was internal and the public paste action reads the system clipboard. Their only option was `insertText`, which the running application sees as typed input rather than a paste.

Widen the existing method to public so a host can send text through `Terminal.paste`, getting the `ESC[200~/ESC[201~` framing when the application enabled bracketed paste mode (`DECSET 2004`) and the same control-byte sanitization a clipboard paste gets. No behavior change for the macOS and iOS views, which already call it for `Cmd-V`.

_LLM Disclosure: This was written with Claude Code and Opus 5._