### PR TITLE
Add translucentCellBackgrounds: explicit cell backgrounds follow backgroundOpacity (iTerm2-style)

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1974,15 +1974,15 @@ extension TerminalView {
                 midx = ansi > 7 ? (Int (ansi) - 8) : Int(ansi)
             }
             if let c = colors [midx] {
-                return c
+                return isFg ? c : cellBackground (c)
             }
             let tcolor = terminal.ansiColors [midx]
             let newColor = TTColor.make (color: tcolor)
             colors [midx] = newColor
-            return newColor
+            return isFg ? newColor : cellBackground (newColor)
         case .trueColor(let r, let g, let b):
             if let tc = trueColors [color] {
-                return tc
+                return isFg ? tc : cellBackground (tc)
             }
             let newColor = TTColor.make(red: CGFloat (r) / 255.0,
                                         green: CGFloat (g) / 255.0,
@@ -1994,11 +1994,21 @@ extension TerminalView {
                 trueColors.removeAll(keepingCapacity: true)
             }
             trueColors [color] = newColor
-            return newColor
+            return isFg ? newColor : cellBackground (newColor)
         }
     }
 
 
+    /// An explicit cell background, carrying `backgroundOpacity` when
+    /// `translucentCellBackgrounds` is on (the palette caches stay opaque; the
+    /// alpha is applied on the way out so foreground uses of the same entry
+    /// are untouched).
+    func cellBackground (_ color: TTColor) -> TTColor
+    {
+        guard translucentCellBackgrounds else { return color }
+        let alpha = backgroundOpacity
+        return alpha < 1 ? color.withAlphaComponent (alpha) : color
+    }
 
     // Clears the cached state for colors and triggers a full display
     func colorsChanged ()

--- a/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1242,6 +1242,26 @@ open class TerminalView: NSView, NSUserInterfaceValidations, TerminalDelegate {
         }
     }
 
+
+    /**
+     * Whether cells with an explicit background color (ANSI, 256-color, truecolor)
+     * share the default background's `backgroundOpacity`.
+     *
+     * `false` (the default) keeps them fully opaque, the way Terminal.app draws
+     * them. `true` applies the same alpha to every cell background, the way iTerm2
+     * does by default, so colored rows (diffs, prompts, TUI chrome) read as part
+     * of one translucent surface instead of solid blocks over it. Reverse-video
+     * highlights stay opaque either way, and this has no effect while
+     * `backgroundOpacity` is 1.
+     */
+    public var translucentCellBackgrounds: Bool = false {
+        didSet {
+            if translucentCellBackgrounds != oldValue {
+                colorsChanged ()
+            }
+        }
+    }
+
     /// Controls weather to use high ansi colors, if false terminal will use bold text instead of high ansi colors
     public var useBrightColors: Bool = true
 

--- a/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -3442,6 +3442,25 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         }
     }
 
+    /**
+     * Whether cells with an explicit background color (ANSI, 256-color, truecolor)
+     * share the default background's `backgroundOpacity`.
+     *
+     * `false` (the default) keeps them fully opaque, the way Terminal.app draws
+     * them. `true` applies the same alpha to every cell background, the way iTerm2
+     * does by default, so colored rows (diffs, prompts, TUI chrome) read as part
+     * of one translucent surface instead of solid blocks over it. Reverse-video
+     * highlights stay opaque either way, and this has no effect while
+     * `backgroundOpacity` is 1.
+     */
+    public var translucentCellBackgrounds: Bool = false {
+        didSet {
+            if translucentCellBackgrounds != oldValue {
+                colorsChanged ()
+            }
+        }
+    }
+
     /// Controls how this view responds to the bell character; `.sound`
     /// preserves the historical behavior of invoking the delegate's `bell`
     public var bellStyle: BellStyle = .sound {

--- a/Tests/SwiftTermTests/ProfileSupportTests.swift
+++ b/Tests/SwiftTermTests/ProfileSupportTests.swift
@@ -225,6 +225,41 @@ final class BackgroundOpacityTests {
         #expect (view.backgroundOpacity == 0.0)
     }
 
+    /// iTerm2-style translucency: with `translucentCellBackgrounds` on, explicit
+    /// cell backgrounds take the default background's alpha; text, reverse
+    /// video and the default (opaque) case are untouched.
+    @Test func explicitCellBackgroundsFollowOpacityWhenEnabled () {
+        let view = TerminalView (frame: CGRect (x: 0, y: 0, width: 400, height: 300))
+        view.backgroundOpacity = 0.4
+        let red = Attribute.Color.ansi256 (code: 1)
+        let teal = Attribute.Color.trueColor (red: 10, green: 120, blue: 130)
+        // mapColor reads the palette; it is only reachable under the terminal lock.
+        func alpha (_ color: Attribute.Color, isFg: Bool) -> CGFloat {
+            view.terminal.terminalLock.withLock {
+                view.mapColor (color: color, isFg: isFg, isBold: false).alphaComponent
+            }
+        }
+
+        // Default: Terminal.app behavior — explicit backgrounds stay opaque.
+        #expect (view.translucentCellBackgrounds == false)
+        #expect (alpha (red, isFg: false) == 1)
+        #expect (alpha (teal, isFg: false) == 1)
+
+        view.translucentCellBackgrounds = true
+        #expect (abs (alpha (red, isFg: false) - 0.4) < 0.001)
+        #expect (abs (alpha (teal, isFg: false) - 0.4) < 0.001)
+        // The same palette entry as FOREGROUND stays opaque (shared cache).
+        #expect (alpha (red, isFg: true) == 1)
+        #expect (alpha (teal, isFg: true) == 1)
+        // Reverse-video highlight stays the one opaque block.
+        #expect (alpha (.defaultInvertedColor, isFg: false) == 1)
+
+        // A fully opaque terminal is unchanged by the option.
+        view.backgroundOpacity = 1.0
+        #expect (alpha (red, isFg: false) == 1)
+        #expect (alpha (teal, isFg: false) == 1)
+    }
+
     @Test func alphaBearingBackgroundReadsAsOpacity () {
         let view = TerminalView (frame: CGRect (x: 0, y: 0, width: 400, height: 300))
         view.nativeBackgroundColor = NSColor (srgbRed: 0, green: 0, blue: 0, alpha: 0.85)


### PR DESCRIPTION
## Summary

`backgroundOpacity` (#e4f31b0) renders the **default** background translucently the way Terminal.app does: cells with an explicit ANSI/256/truecolor background stay fully opaque. Over a translucent window that turns every colored row — diff lines, prompt bars, TUI chrome (Claude Code, lazygit, htop…) — into a solid block over an otherwise see-through surface.

iTerm2 applies the window transparency to *all* backgrounds by default (its "Keep background colors opaque" toggle is the inverse). This adds that as an opt-in:

- New public `translucentCellBackgrounds` on the macOS and iOS views, **default `false`** so existing behavior is unchanged.
- When on and `backgroundOpacity < 1`, `mapColor` applies the same alpha to explicit backgrounds on the way out of the palette caches. The cached entries stay opaque, so the same palette entry used as a **foreground** is untouched.
- Reverse-video highlights keep their forced-opaque handling (#61ce40f).
- The CoreText path fills runs with the mapped color and the Metal renderer converts the attributed color with alpha, so both renderers honor it.
- Toggling calls `colorsChanged()` to drop the attribute/CGColor caches.

## Test

`BackgroundOpacityTests.explicitCellBackgroundsFollowOpacityWhenEnabled`: default stays opaque; enabled → ansi256 and truecolor backgrounds carry the opacity; foreground uses of the same entries stay opaque; reverse video stays opaque; opacity 1 is a no-op.

Motivation: [memterm](https://github.com/ril3y/memterm) (a SwiftTerm-based terminal) runs at window opacity 0.37 and its users see Claude Code's prompt rows as solid black bars. Happy to adjust naming or defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012saq7F94hZ4MqMnZLvBXzM