### PR TITLE
Make withTerminal(_:caller:) public

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1594,7 +1594,7 @@ extension TerminalView {
     /// The closure must not call another API that synchronously acquires the
     /// terminal lock. Helpers that assume the lock is held use the `Locked`
     /// suffix and assert that contract in DEBUG builds.
-    func withTerminal<T> (_ body: (Terminal) throws -> T, caller: StaticString = #function) rethrows -> T
+    public func withTerminal<T> (_ body: (Terminal) throws -> T, caller: StaticString = #function) rethrows -> T
     {
         if ProfilingStats.enabled && Thread.isMainThread {
             ProfilingLockCallers.shared.record(caller)


### PR DESCRIPTION
`getTerminal()` was removed in be55ae4 when the strict-concurrency ownership boundaries landed, which is the right call — handing out the `Terminal` without the lock was the unsafe pattern.

The side effect is that embedders now have no supported way to read the terminal model at all, because `withTerminal` — the lock-holding accessor that replaced it — is internal.

Anything hosting a `TerminalView` from outside the module is stuck: checking bracketed-paste mode before pasting, reading the cursor style, pulling a line of the buffer for a prompt scrape, or issuing a reset all need the model. The remaining options are to vendor the source or to reach around the lock, and both are worse than the API.

This makes the safe path the available one. One keyword, no behaviour change. `withTerminal` already documents its contract, already takes the lock, and already records the caller for profiling, and it is used from 155 call sites inside the module, so it reads as the intended accessor rather than an implementation detail.

Happy to add a short doc note about the re-entrancy rule if you would like it spelled out for external callers.