### PR TITLE
Add TerminalView.observeOscEvents

### DIFF
--- a/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1622,6 +1622,22 @@ extension TerminalView {
         renderOwner.bufferData(kind: kind, encoding: encoding)
     }
 
+    /// Observes copied OSC sequences as the view's terminal encounters them,
+    /// without changing how the view handles them.
+    ///
+    /// This forwards to ``Terminal/observeOscEvents(_:)`` on the terminal the
+    /// view owns, so a host can react to sequences the view does not surface
+    /// itself — desktop notifications sent with OSC 9, 99 or 777, for
+    /// instance — without access to the mutable terminal. Events are delivered
+    /// asynchronously on a private serial queue in encounter order. Retain the
+    /// returned token for as long as events are needed.
+    @MainActor
+    public func observeOscEvents(
+        _ handler: @escaping @Sendable (TerminalOscEvent) -> Void
+    ) -> TerminalOscObservation {
+        terminal.observeOscEvents(handler)
+    }
+
     /// Records the light/dark preference represented by the current palette and optionally
     /// notifies an application that subscribed with `CSI ? 2031 h`.
     ///

--- a/Sources/SwiftTerm/Documentation.docc/MigratingFrom1To2.md
+++ b/Sources/SwiftTerm/Documentation.docc/MigratingFrom1To2.md
@@ -89,6 +89,8 @@ Use terminal snapshots and command entry points instead:
 - ``TerminalView/send(data:)`` / ``TerminalView/feed(byteArray:)`` /
   ``TerminalView/feed(text:)`` for parser-safe input
 - ``TerminalView/softReset()`` and ``TerminalView/resetToInitialState()``
+- ``TerminalView/observeOscEvents(_:)`` for copied OSC sequences, such as
+  desktop notifications (OSC 9, 99 and 777) that the view does not display
 
 If you need terminal-level behavior inside UI callbacks, use the ``Terminal``
 instance passed to ``TerminalViewDelegate`` methods such as

--- a/Tests/SwiftTermTests/TerminalViewOscObservationTests.swift
+++ b/Tests/SwiftTermTests/TerminalViewOscObservationTests.swift
@@ -1,0 +1,29 @@
+#if os(macOS)
+import Dispatch
+import Foundation
+import Testing
+@testable import SwiftTerm
+
+@Suite("TerminalView OSC observation")
+struct TerminalViewOscObservationTests {
+    @MainActor
+    @Test func viewForwardsCopiedOscEventsToObservers() {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 640, height: 320)))
+        let received = Locked<[TerminalOscEvent]>([])
+        let delivered = DispatchSemaphore(value: 0)
+
+        let observation = view.observeOscEvents { event in
+            received.withLock { $0.append(event) }
+            delivered.signal()
+        }
+
+        view.feed(text: "\u{1b}]777;notify;Title;Body\u{7}")
+
+        #expect(delivered.wait(timeout: .now() + 2) == .success)
+        #expect(received.withLock { $0 } == [
+            TerminalOscEvent(code: 777, payload: Array("notify;Title;Body".utf8))
+        ])
+        withExtendedLifetime(observation) {}
+    }
+}
+#endif


### PR DESCRIPTION
## Why

SwiftTerm 2.0 removed `TerminalView.getTerminal()` and keeps the view's `Terminal` internal, steering hosts toward copied, `Sendable` entry points instead. `Terminal.observeOscEvents(_:)` is exactly that kind of entry point, but it is only declared on `Terminal`, so a host that embeds `TerminalView` has no way to reach it.

That leaves no supported way to see OSC sequences the view does not surface itself. Desktop notifications are the common case: agents such as Claude Code announce "waiting for your input" with OSC 9 (iTerm2), OSC 99 (kitty) or OSC 777 (Ghostty). `TerminalView.notify(source:title:body:)` is `public` but not `open`, and its body is empty, so it cannot be overridden either. Today the only workaround is reflecting into the internal `terminal` property.

## Change

- `TerminalView.observeOscEvents(_:)`: a `@MainActor` forwarder to `Terminal.observeOscEvents(_:)` on the terminal the view owns. It observes only; how the view handles every sequence is unchanged, including OSC 9;4 progress.
- `MigratingFrom1To2.md`: listed alongside the other replacements for `getTerminal()`.
- `TerminalViewOscObservationTests`: a macOS test that feeds a real `TerminalView` an OSC 777 and checks that the observer receives the copied event.

The view creates its `Terminal` once in `setupOptions` and reuses it, so an observation stays valid for the view's lifetime.

## Testing

- `swift test --filter "TerminalViewOscObservationTests|ParserEventBoundaryTests"` — 3 tests pass.
- `xcodebuild build -scheme SwiftTerm -destination 'generic/platform=iOS'` — builds, since the method lives in the shared Apple view code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyPLoFPD9cEjCoyvAbvfo6
